### PR TITLE
Add robots.txt support

### DIFF
--- a/client/src/components/app/recipes/create.tsx
+++ b/client/src/components/app/recipes/create.tsx
@@ -68,6 +68,7 @@ const FormSchema = z.object({
     .url("Catalogue URL must be a valid URL (e.g. https://example.com)."),
   manualConfig: z.boolean().default(false),
   configuration: RecipeConfigurationSchema.optional(),
+  acknowledgedSkipRobotsTxt: z.boolean().default(false),
 });
 
 function RecipeLevel({
@@ -401,6 +402,7 @@ export default function CreateRecipe() {
     defaultValues: {
       url: "",
       manualConfig: false,
+      acknowledgedSkipRobotsTxt: false,
     },
   });
   const { toast } = useToast();
@@ -439,6 +441,7 @@ export default function CreateRecipe() {
         catalogueId: parseInt(catalogueId!),
         url: data.url,
         configuration: data.manualConfig ? data.configuration : undefined,
+        acknowledgedSkipRobotsTxt: data.acknowledgedSkipRobotsTxt,
       });
       if (result.context?.message) {
         toast({
@@ -596,6 +599,27 @@ export default function CreateRecipe() {
                             <FormDescription>
                               Manually configure the recipe instead of
                               auto-detection
+                            </FormDescription>
+                          </div>
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
+                      name="acknowledgedSkipRobotsTxt"
+                      render={({ field }) => (
+                        <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+                          <FormControl>
+                            <Checkbox
+                              checked={field.value}
+                              onCheckedChange={field.onChange}
+                            />
+                          </FormControl>
+                          <div className="space-y-1 leading-none">
+                            <FormLabel>Bypass robots.txt</FormLabel>
+                            <FormDescription>
+                              I confirm we have permission from the website
+                              owners to bypass robots.txt restrictions.
                             </FormDescription>
                           </div>
                         </FormItem>

--- a/client/src/components/app/recipes/edit.tsx
+++ b/client/src/components/app/recipes/edit.tsx
@@ -8,32 +8,39 @@ import { z } from "zod";
 
 import { Button } from "@/components/ui/button";
 import {
-    Card,
-    CardContent,
-    CardDescription,
-    CardHeader,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
 } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogHeader,
-    DialogTitle,
-    DialogTrigger,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
 } from "@/components/ui/dialog";
 import {
-    Form,
-    FormControl,
-    FormDescription,
-    FormField,
-    FormItem,
-    FormLabel,
-    FormMessage,
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { useToast } from "@/components/ui/use-toast";
-import { LoaderIcon, Pickaxe, RotateCcw, Star } from "lucide-react";
+import {
+  AlertTriangle,
+  Check,
+  LoaderIcon,
+  Pickaxe,
+  RotateCcw,
+  Star,
+} from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { Link } from "wouter";
 import { displayRecipeDetails } from "./util";
@@ -191,7 +198,7 @@ export default function EditRecipe() {
                 {recipe.status == RecipeDetectionStatus.SUCCESS ? (
                   <Card>
                     <CardHeader>
-                      <CardDescription>Configuration</CardDescription>
+                      <CardDescription>Crawling Configuration</CardDescription>
                     </CardHeader>
                     <CardContent>
                       <div className="text-xs">
@@ -230,8 +237,8 @@ export default function EditRecipe() {
                     <CardContent className="text-sm">
                       <div>
                         <p className="text-red-800 font-semibold">
-                          CTDL xTRA failed to detect a valid
-                          configuration for this recipe.
+                          CTDL xTRA failed to detect a valid configuration for
+                          this recipe.
                         </p>
                         <p className="mt-4">
                           You can adjust the URL, or try again.
@@ -336,6 +343,125 @@ export default function EditRecipe() {
                 </div>
               ) : null}
             </div>
+
+            <div className="grid gap-2 md:grid-cols-[1fr_250px] lg:grid-cols-2 lg:gap-4">
+              <Card>
+                <CardHeader>
+                  <CardDescription>robots.txt Configuration</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  {recipe.robotsTxt ? (
+                    <div className="space-y-4">
+                      <div>
+                        <p className="text-sm font-medium">Crawling Status</p>
+                        <div className="mt-2 flex items-center">
+                          {recipe.acknowledgedSkipRobotsTxt ? (
+                            <>
+                              <AlertTriangle className="h-4 w-4 text-amber-500 mr-2" />
+                              <p className="text-sm font-medium text-amber-700">
+                                Ignoring robots.txt (acknowledgment provided)
+                              </p>
+                            </>
+                          ) : (
+                            <>
+                              <Check className="h-4 w-4 text-green-500 mr-2" />
+                              <p className="text-sm font-medium text-green-700">
+                                Following robots.txt rules
+                              </p>
+                            </>
+                          )}
+                        </div>
+                      </div>
+                      <div>
+                        <p className="text-sm font-medium">Rules</p>
+                        <div className="mt-2 text-sm">
+                          {recipe.robotsTxt.rules
+                            .sort((a, b) => {
+                              // Sort rules so that user-agent "*" appears first
+                              if (a.userAgent === "*" && b.userAgent !== "*")
+                                return -1;
+                              if (a.userAgent !== "*" && b.userAgent === "*")
+                                return 1;
+                              return 0;
+                            })
+                            .map((rule, i) => (
+                              <div
+                                key={i}
+                                className={`mb-4 rounded-md border p-3 ${
+                                  rule.userAgent === "*"
+                                    ? "bg-blue-50 border-blue-200"
+                                    : "bg-muted/50"
+                                }`}
+                              >
+                                <p className="font-medium text-xs text-muted-foreground mb-1">
+                                  User-Agent:
+                                </p>
+                                <p
+                                  className={`font-mono mb-2 ${rule.userAgent === "*" ? "font-semibold" : ""}`}
+                                >
+                                  {rule.userAgent}
+                                  {rule.userAgent === "*" && (
+                                    <span className="ml-2 text-xs text-blue-600">
+                                      (in effect)
+                                    </span>
+                                  )}
+                                </p>
+                                {rule.disallow.length > 0 && (
+                                  <>
+                                    <p className="font-medium text-xs text-muted-foreground mb-1">
+                                      Disallow:
+                                    </p>
+                                    <p className="font-mono mb-2">
+                                      {rule.disallow.join(", ")}
+                                    </p>
+                                  </>
+                                )}
+                                {rule.allow.length > 0 && (
+                                  <>
+                                    <p className="font-medium text-xs text-muted-foreground mb-1">
+                                      Allow:
+                                    </p>
+                                    <p className="font-mono mb-2">
+                                      {rule.allow.join(", ")}
+                                    </p>
+                                  </>
+                                )}
+                                {rule.crawlDelay !== undefined && (
+                                  <>
+                                    <p className="font-medium text-xs text-muted-foreground mb-1">
+                                      Crawl-Delay:
+                                    </p>
+                                    <p className="font-mono">
+                                      {rule.crawlDelay}
+                                    </p>
+                                  </>
+                                )}
+                              </div>
+                            ))}
+                        </div>
+                      </div>
+                      {recipe.robotsTxt.sitemaps.length > 0 && (
+                        <div>
+                          <p className="text-sm font-medium">Sitemaps:</p>
+                          <div className="rounded-md border p-3 bg-muted/50">
+                            {recipe.robotsTxt.sitemaps.map((sitemap, i) => (
+                              <p key={i} className="font-mono text-sm mb-1">
+                                {sitemap}
+                              </p>
+                            ))}
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  ) : (
+                    <p className="text-sm">
+                      No robots.txt file found for this website.
+                    </p>
+                  )}
+                </CardContent>
+              </Card>
+            </div>
+
             <div className="flex items-center">
               {recipe.status == RecipeDetectionStatus.IN_PROGRESS ? (
                 <Button disabled={true} variant={"outline"}>

--- a/server/migrations/0006_lucky_talkback.sql
+++ b/server/migrations/0006_lucky_talkback.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "recipes" ADD COLUMN "robots_txt" jsonb;--> statement-breakpoint
+ALTER TABLE "recipes" ADD COLUMN "acknowledged_skip_robots_txt" boolean;

--- a/server/migrations/meta/0006_snapshot.json
+++ b/server/migrations/meta/0006_snapshot.json
@@ -1,0 +1,1103 @@
+{
+  "id": "bea09600-46b0-4ed8-801f-b712745843dd",
+  "prevId": "c08c1b2c-08a9-4746-8e75-1dfb2e4c764a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.catalogues": {
+      "name": "catalogues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "catalogue_type": {
+          "name": "catalogue_type",
+          "type": "catalogue_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COURSES'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "catalogues_url_catalogue_type_unique": {
+          "name": "catalogues_url_catalogue_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url",
+            "catalogue_type"
+          ]
+        }
+      }
+    },
+    "public.crawl_pages": {
+      "name": "crawl_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "extraction_id": {
+          "name": "extraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crawl_step_id": {
+          "name": "crawl_step_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step": {
+          "name": "step",
+          "type": "step",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "page_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'WAITING'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshot": {
+          "name": "screenshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetch_failure_reason": {
+          "name": "fetch_failure_reason",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_type": {
+          "name": "page_type",
+          "type": "page_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_extraction_started_at": {
+          "name": "data_extraction_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crawl_pages_extraction_idx": {
+          "name": "crawl_pages_extraction_idx",
+          "columns": [
+            {
+              "expression": "extraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crawl_pages_status_idx": {
+          "name": "crawl_pages_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crawl_pages_data_type_idx": {
+          "name": "crawl_pages_data_type_idx",
+          "columns": [
+            {
+              "expression": "page_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crawl_pages_step_idx": {
+          "name": "crawl_pages_step_idx",
+          "columns": [
+            {
+              "expression": "crawl_step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crawl_pages_extraction_id_extractions_id_fk": {
+          "name": "crawl_pages_extraction_id_extractions_id_fk",
+          "tableFrom": "crawl_pages",
+          "tableTo": "extractions",
+          "columnsFrom": [
+            "extraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crawl_pages_crawl_step_id_crawl_steps_id_fk": {
+          "name": "crawl_pages_crawl_step_id_crawl_steps_id_fk",
+          "tableFrom": "crawl_pages",
+          "tableTo": "crawl_steps",
+          "columnsFrom": [
+            "crawl_step_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "crawl_pages_extraction_id_url_step_unique": {
+          "name": "crawl_pages_extraction_id_url_step_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "extraction_id",
+            "url",
+            "step"
+          ]
+        }
+      }
+    },
+    "public.crawl_steps": {
+      "name": "crawl_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "extraction_id": {
+          "name": "extraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step": {
+          "name": "step",
+          "type": "step",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_step_id": {
+          "name": "parent_step_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crawl_steps_extraction_idx": {
+          "name": "crawl_steps_extraction_idx",
+          "columns": [
+            {
+              "expression": "extraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crawl_steps_parent_step_idx": {
+          "name": "crawl_steps_parent_step_idx",
+          "columns": [
+            {
+              "expression": "parent_step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crawl_steps_extraction_id_extractions_id_fk": {
+          "name": "crawl_steps_extraction_id_extractions_id_fk",
+          "tableFrom": "crawl_steps",
+          "tableTo": "extractions",
+          "columnsFrom": [
+            "extraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crawl_steps_parent_step_id_crawl_steps_id_fk": {
+          "name": "crawl_steps_parent_step_id_crawl_steps_id_fk",
+          "tableFrom": "crawl_steps",
+          "tableTo": "crawl_steps",
+          "columnsFrom": [
+            "parent_step_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.data_items": {
+      "name": "data_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crawl_page_id": {
+          "name": "crawl_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "structured_data": {
+          "name": "structured_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_inclusion": {
+          "name": "text_inclusion",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_items_dataset_idx": {
+          "name": "data_items_dataset_idx",
+          "columns": [
+            {
+              "expression": "dataset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "data_items_crawl_page_idx": {
+          "name": "data_items_crawl_page_idx",
+          "columns": [
+            {
+              "expression": "crawl_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "data_items_dataset_id_datasets_id_fk": {
+          "name": "data_items_dataset_id_datasets_id_fk",
+          "tableFrom": "data_items",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "data_items_crawl_page_id_crawl_pages_id_fk": {
+          "name": "data_items_crawl_page_id_crawl_pages_id_fk",
+          "tableFrom": "data_items",
+          "tableTo": "crawl_pages",
+          "columnsFrom": [
+            "crawl_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.datasets": {
+      "name": "datasets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "catalogue_id": {
+          "name": "catalogue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extraction_id": {
+          "name": "extraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "datasets_catalogue_idx": {
+          "name": "datasets_catalogue_idx",
+          "columns": [
+            {
+              "expression": "catalogue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "datasets_extraction_idx": {
+          "name": "datasets_extraction_idx",
+          "columns": [
+            {
+              "expression": "extraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "datasets_catalogue_id_catalogues_id_fk": {
+          "name": "datasets_catalogue_id_catalogues_id_fk",
+          "tableFrom": "datasets",
+          "tableTo": "catalogues",
+          "columnsFrom": [
+            "catalogue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "datasets_extraction_id_extractions_id_fk": {
+          "name": "datasets_extraction_id_extractions_id_fk",
+          "tableFrom": "datasets",
+          "tableTo": "extractions",
+          "columnsFrom": [
+            "extraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "datasets_catalogue_id_extraction_id_unique": {
+          "name": "datasets_catalogue_id_extraction_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "catalogue_id",
+            "extraction_id"
+          ]
+        }
+      }
+    },
+    "public.extraction_logs": {
+      "name": "extraction_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "extraction_id": {
+          "name": "extraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "log": {
+          "name": "log",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "log_level": {
+          "name": "log_level",
+          "type": "log_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INFO'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "extraction_logs_extraction_idx": {
+          "name": "extraction_logs_extraction_idx",
+          "columns": [
+            {
+              "expression": "extraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "extraction_logs_extraction_id_extractions_id_fk": {
+          "name": "extraction_logs_extraction_id_extractions_id_fk",
+          "tableFrom": "extraction_logs",
+          "tableTo": "extractions",
+          "columnsFrom": [
+            "extraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.extractions": {
+      "name": "extractions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completion_stats": {
+          "name": "completion_stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "extraction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'WAITING'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "extractions_recipe_idx": {
+          "name": "extractions_recipe_idx",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "extractions_recipe_id_recipes_id_fk": {
+          "name": "extractions_recipe_id_recipes_id_fk",
+          "tableFrom": "extractions",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.model_api_calls": {
+      "name": "model_api_calls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "extraction_id": {
+          "name": "extraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "provider_model",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "call_site": {
+          "name": "call_site",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_token_count": {
+          "name": "input_token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_token_count": {
+          "name": "output_token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "model_api_calls_extraction_idx": {
+          "name": "model_api_calls_extraction_idx",
+          "columns": [
+            {
+              "expression": "extraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_api_calls_extraction_id_extractions_id_fk": {
+          "name": "model_api_calls_extraction_id_extractions_id_fk",
+          "tableFrom": "model_api_calls",
+          "tableTo": "extractions",
+          "columnsFrom": [
+            "extraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.recipes": {
+      "name": "recipes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "catalogue_id": {
+          "name": "catalogue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "detection_failure_reason": {
+          "name": "detection_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "recipe_detection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'WAITING'"
+        },
+        "robots_txt": {
+          "name": "robots_txt",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acknowledged_skip_robots_txt": {
+          "name": "acknowledged_skip_robots_txt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recipes_catalogue_idx": {
+          "name": "recipes_catalogue_idx",
+          "columns": [
+            {
+              "expression": "catalogue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipes_catalogue_id_catalogues_id_fk": {
+          "name": "recipes_catalogue_id_catalogues_id_fk",
+          "tableFrom": "recipes",
+          "tableTo": "catalogues",
+          "columnsFrom": [
+            "catalogue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_encrypted": {
+          "name": "is_encrypted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "encrypted_preview": {
+          "name": "encrypted_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "settings_key_unique": {
+          "name": "settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      }
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "public.catalogue_type": {
+      "name": "catalogue_type",
+      "schema": "public",
+      "values": [
+        "COURSES",
+        "LEARNING_PROGRAMS",
+        "COMPETENCIES"
+      ]
+    },
+    "public.extraction_status": {
+      "name": "extraction_status",
+      "schema": "public",
+      "values": [
+        "WAITING",
+        "IN_PROGRESS",
+        "COMPLETE",
+        "STALE",
+        "CANCELLED"
+      ]
+    },
+    "public.log_level": {
+      "name": "log_level",
+      "schema": "public",
+      "values": [
+        "INFO",
+        "ERROR"
+      ]
+    },
+    "public.page_status": {
+      "name": "page_status",
+      "schema": "public",
+      "values": [
+        "WAITING",
+        "IN_PROGRESS",
+        "SUCCESS",
+        "ERROR"
+      ]
+    },
+    "public.page_type": {
+      "name": "page_type",
+      "schema": "public",
+      "values": [
+        "DETAIL",
+        "CATEGORY_LINKS",
+        "DETAIL_LINKS",
+        "API_REQUEST"
+      ]
+    },
+    "public.provider": {
+      "name": "provider",
+      "schema": "public",
+      "values": [
+        "openai"
+      ]
+    },
+    "public.provider_model": {
+      "name": "provider_model",
+      "schema": "public",
+      "values": [
+        "gpt-4o",
+        "o3-mini"
+      ]
+    },
+    "public.recipe_detection_status": {
+      "name": "recipe_detection_status",
+      "schema": "public",
+      "values": [
+        "WAITING",
+        "IN_PROGRESS",
+        "SUCCESS",
+        "ERROR"
+      ]
+    },
+    "public.step": {
+      "name": "step",
+      "schema": "public",
+      "values": [
+        "FETCH_ROOT",
+        "FETCH_PAGINATED",
+        "FETCH_LINKS",
+        "FETCH_VIA_API"
+      ]
+    },
+    "public.url_pattern_type": {
+      "name": "url_pattern_type",
+      "schema": "public",
+      "values": [
+        "page_num",
+        "offset"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/migrations/meta/_journal.json
+++ b/server/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1744069345911,
       "tag": "0005_graceful_amphibian",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1744071342617,
+      "tag": "0006_lucky_talkback",
+      "breakpoints": true
     }
   ]
 }

--- a/server/package.json
+++ b/server/package.json
@@ -42,6 +42,7 @@
     "puppeteer-extra-plugin-stealth": "^2.11.2",
     "rebrowser-puppeteer": "^23.6.101",
     "turndown": "^7.1.3",
+    "uuid": "^11.1.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       turndown:
         specifier: ^7.1.3
         version: 7.1.3
+      uuid:
+        specifier: ^11.1.0
+        version: 11.1.0
       zod:
         specifier: ^3.22.4
         version: 3.22.5
@@ -4533,6 +4536,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
@@ -9074,6 +9081,8 @@ snapshots:
       '@types/react': 18.2.47
 
   util-deprecate@1.0.2: {}
+
+  uuid@11.1.0: {}
 
   uuid@9.0.1: {}
 

--- a/server/src/data/recipes.ts
+++ b/server/src/data/recipes.ts
@@ -8,9 +8,12 @@ import {
   RecipeConfiguration,
   RecipeDetectionStatus,
 } from "../../../common/types";
+import { RobotsTxt } from "../extraction/robotsParser";
 
 export type Recipe = Omit<InferSelectModel<typeof recipes>, "configuration"> & {
   configuration?: RecipeConfiguration;
+  robotsTxt?: RobotsTxt;
+  acknowledgedSkipRobotsTxt?: boolean;
 };
 
 export async function findRecipes() {
@@ -82,7 +85,9 @@ export async function startRecipe(
 export async function createRecipe(
   catalogueId: number,
   url: string,
-  configuration: RecipeConfiguration
+  configuration: RecipeConfiguration,
+  robotsTxt?: RobotsTxt,
+  acknowledgedSkipRobotsTxt?: boolean
 ) {
   const result = await db
     .insert(recipes)
@@ -92,6 +97,8 @@ export async function createRecipe(
       isDefault: false,
       configuration,
       status: RecipeDetectionStatus.SUCCESS,
+      robotsTxt,
+      acknowledgedSkipRobotsTxt,
     })
     .returning({ id: recipes.id });
   return result[0];

--- a/server/src/data/schema.ts
+++ b/server/src/data/schema.ts
@@ -35,6 +35,7 @@ import {
   Step,
   TextInclusion,
 } from "../../../common/types";
+import { RobotsTxt } from "../extraction/robotsParser";
 import { SimplifiedMarkdown } from "../types";
 
 const gzip = promisify(syncGzip);
@@ -244,6 +245,8 @@ const recipes = pgTable(
     status: recipeDetectionStatusEnum("status")
       .notNull()
       .default(RecipeDetectionStatus.WAITING),
+    robotsTxt: jsonb("robots_txt").$type<RobotsTxt>(),
+    acknowledgedSkipRobotsTxt: boolean("acknowledged_skip_robots_txt"),
   },
   (t) => ({
     catalogueIdx: index("recipes_catalogue_idx").on(t.catalogueId),

--- a/server/src/extraction/robotsParser.ts
+++ b/server/src/extraction/robotsParser.ts
@@ -1,0 +1,191 @@
+import { URL } from "url";
+
+export interface RobotsRule {
+  userAgent: string;
+  allow: string[];
+  disallow: string[];
+  crawlDelay?: number;
+  sitemaps: string[];
+}
+
+export interface RobotsTxt {
+  rules: RobotsRule[];
+  sitemaps: string[];
+}
+
+export async function fetchAndParseRobotsTxt(
+  url: string
+): Promise<RobotsTxt | null> {
+  try {
+    const parsedUrl = new URL(url);
+    const robotsUrl = `${parsedUrl.protocol}//${parsedUrl.host}/robots.txt`;
+
+    console.log(`Fetching robots.txt from ${robotsUrl}`);
+
+    const response = await fetch(robotsUrl);
+
+    if (!response.ok) {
+      console.log(`robots.txt not found at ${robotsUrl}`);
+      return null;
+    }
+
+    const content = await response.text();
+    return parseRobotsTxt(content);
+  } catch (error) {
+    console.error(`Error fetching robots.txt: ${error}`);
+    return null;
+  }
+}
+
+export function parseRobotsTxt(content: string): RobotsTxt {
+  const lines = content.split("\n");
+
+  const result: RobotsTxt = {
+    rules: [],
+    sitemaps: [],
+  };
+
+  let currentRule: RobotsRule | null = null;
+
+  for (let line of lines) {
+    // Remove comments and trim
+    const commentIndex = line.indexOf("#");
+    if (commentIndex !== -1) {
+      line = line.substring(0, commentIndex);
+    }
+    line = line.trim();
+
+    if (!line) continue;
+
+    // Split into field and value
+    const colonIndex = line.indexOf(":");
+    if (colonIndex === -1) continue;
+
+    const field = line.substring(0, colonIndex).trim().toLowerCase();
+    const value = line.substring(colonIndex + 1).trim();
+
+    if (!value) continue;
+
+    if (field === "user-agent") {
+      // Start a new rule if we encounter a user agent
+      if (
+        currentRule &&
+        (currentRule.allow.length > 0 ||
+          currentRule.disallow.length > 0 ||
+          currentRule.crawlDelay !== undefined)
+      ) {
+        result.rules.push(currentRule);
+      }
+
+      currentRule = {
+        userAgent: value,
+        allow: [],
+        disallow: [],
+        sitemaps: [],
+      };
+    } else if (field === "allow" && currentRule) {
+      currentRule.allow.push(value);
+    } else if (field === "disallow" && currentRule) {
+      currentRule.disallow.push(value);
+    } else if (field === "crawl-delay" && currentRule) {
+      const delay = parseFloat(value);
+      if (!isNaN(delay)) {
+        currentRule.crawlDelay = delay;
+      }
+    } else if (field === "sitemap") {
+      if (currentRule) {
+        currentRule.sitemaps.push(value);
+      }
+      result.sitemaps.push(value);
+    }
+  }
+
+  // Add the last rule if it exists
+  if (
+    currentRule &&
+    (currentRule.allow.length > 0 ||
+      currentRule.disallow.length > 0 ||
+      currentRule.crawlDelay !== undefined)
+  ) {
+    result.rules.push(currentRule);
+  }
+
+  return result;
+}
+
+export function findRule(
+  robotsTxt: RobotsTxt,
+  userAgent: string = "*"
+): RobotsRule | null {
+  let matchingRule: RobotsRule | null = null;
+  let wildcardRule: RobotsRule | null = null;
+
+  for (const rule of robotsTxt.rules) {
+    if (rule.userAgent === userAgent) {
+      matchingRule = rule;
+      break;
+    }
+
+    if (rule.userAgent === "*") {
+      wildcardRule = rule;
+    }
+  }
+
+  const rule = matchingRule || wildcardRule;
+
+  return rule;
+}
+
+export function isUrlAllowedForRule(rule: RobotsRule, url: string): boolean {
+  if (!rule || rule.disallow.length === 0) {
+    return true;
+  }
+
+  const path = new URL(url).pathname;
+
+  // Check if the URL matches any allow pattern
+  for (const pattern of rule.allow) {
+    if (isPathMatch(path, pattern)) {
+      return true;
+    }
+  }
+
+  // Check if the URL matches any disallow pattern
+  for (const pattern of rule.disallow) {
+    if (isPathMatch(path, pattern)) {
+      return false;
+    }
+  }
+
+  // Default to allowing the URL if no patterns match
+  return true;
+}
+
+export function isUrlAllowed(
+  robotsTxt: RobotsTxt,
+  url: string,
+  userAgent: string = "*"
+): boolean {
+  const rule = findRule(robotsTxt, userAgent);
+  if (!rule) {
+    return true;
+  }
+
+  return isUrlAllowedForRule(rule, url);
+}
+
+function isPathMatch(path: string, pattern: string): boolean {
+  // Convert robots.txt pattern to a regular expression
+  let regexPattern = pattern
+    .replace(/\./g, "\\.")
+    .replace(/\*/g, ".*")
+    .replace(/\$/g, "$");
+
+  // Add start anchor if pattern doesn't start with *
+  if (!pattern.startsWith("*")) {
+    regexPattern = "^" + regexPattern;
+  }
+
+  const regex = new RegExp(regexPattern);
+  return regex.test(path);
+}

--- a/server/src/extraction/services/base.ts
+++ b/server/src/extraction/services/base.ts
@@ -1,9 +1,9 @@
 import { apiExtractorServices } from ".";
 import { CourseStructuredData } from "../../../../common/types";
-import { Recipe } from "../../data/recipes";
+import { recipes } from "../../data/schema";
 
 export function resolveExtractionService(
-  recipe: Recipe
+  recipe: typeof recipes.$inferSelect
 ): VendorExtractionService {
   const provider = recipe.configuration?.apiProvider!;
   const service = apiExtractorServices[provider];
@@ -20,7 +20,7 @@ export function resolveExtractionService(
 
 export class VendorExtractionService {
   public async extractData(
-    recipe: Recipe,
+    recipe: typeof recipes.$inferSelect,
     onResultBatch: (results: CourseStructuredData[]) => Promise<boolean>
   ): Promise<void> {
     throw new Error(

--- a/server/src/extraction/services/coursedog.ts
+++ b/server/src/extraction/services/coursedog.ts
@@ -1,6 +1,6 @@
 import querystring from "node:querystring";
 import { CourseStructuredData } from "../../../../common/types";
-import { Recipe } from "../../data/recipes";
+import { recipes } from "../../data/schema";
 import { exponentialRetry } from "../../utils";
 import { VendorExtractionService } from "./base";
 
@@ -8,7 +8,7 @@ export class CourseDogAPIService extends VendorExtractionService {
   apiBase = "https://app.coursedog.com/api/v1";
 
   public async extractData(
-    recipe: Recipe,
+    recipe: typeof recipes.$inferSelect,
     onResultBatch: (res: CourseStructuredData[]) => Promise<boolean>
   ): Promise<void> {
     // @ts-ignore

--- a/server/src/extraction/startExtraction.ts
+++ b/server/src/extraction/startExtraction.ts
@@ -1,7 +1,6 @@
 import { RecipeDetectionStatus, Step } from "../../../common/types";
 import { findCatalogueById } from "../data/catalogues";
 import { createExtraction, createPage, createStep } from "../data/extractions";
-import { Recipe } from "../data/recipes";
 import { extractions, recipes } from "../data/schema";
 import { Queues, submitJob, submitRepeatableJob } from "../workers";
 
@@ -57,7 +56,7 @@ async function launchLLMExtraction(
 
 async function launchAPIExtraction(
   extraction: typeof extractions.$inferSelect,
-  recipe: Recipe
+  recipe: typeof recipes.$inferSelect
 ) {
   const step = await createStep({
     extractionId: extraction.id,

--- a/server/src/worker.ts
+++ b/server/src/worker.ts
@@ -30,7 +30,7 @@ function processorPath(name: string) {
 
 const processors: [Queue, string, number][] = [
   [Queues.DetectConfiguration, processorPath("detectConfiguration"), 2],
-  [Queues.FetchPage, processorPath("fetchPage"), 3],
+  [Queues.FetchPage, processorPath("fetchPage"), 2],
   [Queues.ExtractData, processorPath("extractData"), 10],
   [Queues.ExtractDataWithAPI, processorPath("extractDataWithApi"), 10],
   [

--- a/server/src/workers/fetchPage.ts
+++ b/server/src/workers/fetchPage.ts
@@ -39,6 +39,8 @@ import { detectPageCount } from "../extraction/llm/detectPageCount";
 import { createUrlExtractor } from "../extraction/llm/detectUrlRegexp";
 import { findRule, isUrlAllowedForRule } from "../extraction/robotsParser";
 
+const redis = getRedisConnection();
+
 const constructPaginatedUrls = (configuration: PaginationConfiguration) => {
   const urls = [];
   if (configuration.urlPatternType == "offset") {
@@ -306,7 +308,6 @@ export default createProcessor<FetchPageJob, FetchPageProgress>(
 
     const domain = new URL(crawlPage.url).hostname;
     const lockKey = `crawl-lock:${domain}`;
-    const redis = getRedisConnection();
 
     // Attempt to acquire the lock atomically
     const lockAcquired = await redis.set(

--- a/server/tests/robotsParser.test.ts
+++ b/server/tests/robotsParser.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { isUrlAllowed, parseRobotsTxt } from "../src/extraction/robotsParser";
+
+// Mock the fetch function for testing
+global.fetch = vi.fn();
+
+describe("Robots.txt Parser", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test("parseRobotsTxt should handle empty content", () => {
+    const result = parseRobotsTxt("");
+    expect(result.rules).toHaveLength(0);
+    expect(result.sitemaps).toHaveLength(0);
+  });
+
+  test("parseRobotsTxt should handle simple robots.txt", () => {
+    const content = `
+      User-agent: *
+      Disallow: /admin/
+      Disallow: /private/
+      Allow: /admin/public/
+      Crawl-delay: 5
+    `;
+
+    const result = parseRobotsTxt(content);
+
+    expect(result.rules).toHaveLength(1);
+    expect(result.rules[0].userAgent).toBe("*");
+    expect(result.rules[0].disallow).toContain("/admin/");
+    expect(result.rules[0].disallow).toContain("/private/");
+    expect(result.rules[0].allow).toContain("/admin/public/");
+    expect(result.rules[0].crawlDelay).toBe(5);
+  });
+
+  test("parseRobotsTxt should handle multiple user agents", () => {
+    const content = `
+      User-agent: GoogleBot
+      Disallow: /google/
+      Crawl-delay: 10
+
+      User-agent: BingBot
+      Disallow: /bing/
+      Crawl-delay: 5
+
+      User-agent: *
+      Disallow: /private/
+    `;
+
+    const result = parseRobotsTxt(content);
+
+    expect(result.rules).toHaveLength(3);
+
+    const googleRule = result.rules.find((r) => r.userAgent === "GoogleBot");
+    expect(googleRule).toBeDefined();
+    expect(googleRule?.disallow).toContain("/google/");
+    expect(googleRule?.crawlDelay).toBe(10);
+
+    const bingRule = result.rules.find((r) => r.userAgent === "BingBot");
+    expect(bingRule).toBeDefined();
+    expect(bingRule?.disallow).toContain("/bing/");
+    expect(bingRule?.crawlDelay).toBe(5);
+
+    const wildcardRule = result.rules.find((r) => r.userAgent === "*");
+    expect(wildcardRule).toBeDefined();
+    expect(wildcardRule?.disallow).toContain("/private/");
+  });
+
+  test("parseRobotsTxt should handle comments", () => {
+    const content = `
+      # This is a comment
+      User-agent: * # This user agent applies to all
+      Disallow: /admin/ # No access to admin
+      Allow: / # Allow everything else
+    `;
+
+    const result = parseRobotsTxt(content);
+
+    expect(result.rules).toHaveLength(1);
+    expect(result.rules[0].userAgent).toBe("*");
+    expect(result.rules[0].disallow).toContain("/admin/");
+    expect(result.rules[0].allow).toContain("/");
+  });
+
+  test("parseRobotsTxt should handle sitemaps", () => {
+    const content = `
+      User-agent: *
+      Disallow: /admin/
+
+      Sitemap: https://example.com/sitemap.xml
+      Sitemap: https://example.com/sitemap-news.xml
+    `;
+
+    const result = parseRobotsTxt(content);
+
+    expect(result.sitemaps).toHaveLength(2);
+    expect(result.sitemaps).toContain("https://example.com/sitemap.xml");
+    expect(result.sitemaps).toContain("https://example.com/sitemap-news.xml");
+  });
+
+  test("isUrlAllowed should properly allow or disallow URLs", () => {
+    const robotsTxt = parseRobotsTxt(`
+      User-agent: *
+      Disallow: /admin/
+      Disallow: /private/
+      Allow: /admin/public/
+    `);
+
+    // These should be allowed
+    expect(isUrlAllowed(robotsTxt, "https://example.com/")).toBe(true);
+    expect(isUrlAllowed(robotsTxt, "https://example.com/public")).toBe(true);
+    expect(isUrlAllowed(robotsTxt, "https://example.com/admin/public/")).toBe(
+      true
+    );
+
+    // These should be disallowed
+    expect(isUrlAllowed(robotsTxt, "https://example.com/admin/")).toBe(false);
+    expect(
+      isUrlAllowed(robotsTxt, "https://example.com/admin/restricted")
+    ).toBe(false);
+    expect(isUrlAllowed(robotsTxt, "https://example.com/private/")).toBe(false);
+  });
+
+  test("isUrlAllowed should respect specific user agents", () => {
+    const robotsTxt = parseRobotsTxt(`
+      User-agent: googlebot
+      Disallow: /googlebot-only/
+
+      User-agent: *
+      Disallow: /private/
+    `);
+
+    // Testing googlebot user-agent
+    expect(
+      isUrlAllowed(
+        robotsTxt,
+        "https://example.com/googlebot-only/",
+        "googlebot"
+      )
+    ).toBe(false);
+    expect(
+      isUrlAllowed(robotsTxt, "https://example.com/private/", "googlebot")
+    ).toBe(true);
+
+    // Testing another user-agent
+    expect(
+      isUrlAllowed(robotsTxt, "https://example.com/googlebot-only/", "otherbot")
+    ).toBe(true);
+    expect(
+      isUrlAllowed(robotsTxt, "https://example.com/private/", "otherbot")
+    ).toBe(false);
+  });
+
+  test("isUrlAllowed should handle pattern wildcards", () => {
+    const robotsTxt = parseRobotsTxt(`
+      User-agent: *
+      Disallow: /*.php$
+      Disallow: /*/admin/
+    `);
+
+    // Should be disallowed
+    expect(isUrlAllowed(robotsTxt, "https://example.com/page.php")).toBe(false);
+    expect(isUrlAllowed(robotsTxt, "https://example.com/section/admin/")).toBe(
+      false
+    );
+
+    // Should be allowed
+    expect(isUrlAllowed(robotsTxt, "https://example.com/page.phps")).toBe(true);
+    expect(isUrlAllowed(robotsTxt, "https://example.com/admin/")).toBe(true);
+  });
+});


### PR DESCRIPTION
Support robots.txt (with crawl delay).

- When configuring a recipe, we fetch `robots.txt` and store its data.
- Users can optionally choose to disregard `robots.txt`.
- The crawler won't fetch pages disallowed by `robots` (unless the user opted out above).
- The crawler will respect `crawl-delay` settings.
- If there's no `robots.txt` for the page, we'll assume a crawl delay of 3000ms. The delay system is more robust now for those configurations. A domain will never be fetched more than once per <default delay>.

The feature relies on redis for setting atomic locks with TTL.
