### PR TITLE
Improve settings backend and proxy configuration

### DIFF
--- a/client/src/components/app/settings/index.tsx
+++ b/client/src/components/app/settings/index.tsx
@@ -1,28 +1,15 @@
-import { trpc } from "@/utils";
 import { OpenAIApiKeyForm } from "./openapi";
 import { ProxySettingsForm } from "./proxy";
 
 export default function Settings() {
-  const listQuery = trpc.settings.list.useQuery();
-
-  const openAIApiKey = listQuery.data?.find(
-    (setting) => setting.key === "OPENAI_API_KEY"
-  );
-
   return (
     <>
       <div className="flex items-center">
         <h1 className="text-lg font-semibold md:text-2xl">Settings</h1>
       </div>
       <div className="flex gap-4 min-h-0 shadow-sm">
-        <OpenAIApiKeyForm
-          currentApiKeyPreview={openAIApiKey?.encryptedPreview}
-          onSuccess={listQuery.refetch}
-        />
-        <ProxySettingsForm
-          settingsQuery={listQuery}
-          onSuccess={listQuery.refetch}
-        />
+        <OpenAIApiKeyForm />
+        <ProxySettingsForm />
       </div>
     </>
   );

--- a/client/src/components/app/settings/openapi.tsx
+++ b/client/src/components/app/settings/openapi.tsx
@@ -13,29 +13,24 @@ import { useToast } from "@/components/ui/use-toast";
 import { trpc } from "@/utils";
 import { useState } from "react";
 
-interface OpenAIApiKeyFormProps {
-  currentApiKeyPreview?: string | null;
-  onSuccess: () => void;
-}
-
-export function OpenAIApiKeyForm({
-  currentApiKeyPreview,
-  onSuccess,
-}: OpenAIApiKeyFormProps) {
+export function OpenAIApiKeyForm() {
+  const settingQuery = trpc.settings.detail.useQuery({
+    key: "OPENAI_API_KEY",
+  });
   const updateMutation = trpc.settings.setOpenAIApiKey.useMutation();
-  const [newApiKey, setNewApiKey] = useState("");
+  const [apiKey, setApiKey] = useState("");
   const { toast } = useToast();
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     try {
-      await updateMutation.mutateAsync({ apiKey: newApiKey });
+      await updateMutation.mutateAsync({ apiKey: apiKey });
       toast({
         title: "API Key Updated",
         description: "The OpenAI API key has been updated.",
       });
-      setNewApiKey("");
-      onSuccess();
+      setApiKey("");
+      settingQuery.refetch();
     } catch (error) {
       toast({
         title: "Error",
@@ -51,10 +46,13 @@ export function OpenAIApiKeyForm({
           <CardTitle>OpenAI API Key</CardTitle>
           <CardDescription>
             The API key that will used for OpenAI requests. <br />
-            {currentApiKeyPreview ? (
+            {settingQuery.data?.encryptedPreview ? (
               <>
                 The key is currently set to{" "}
-                <code className="font-bold">{currentApiKeyPreview}</code>.
+                <code className="font-bold">
+                  {settingQuery.data.encryptedPreview}
+                </code>
+                .
               </>
             ) : null}
           </CardDescription>
@@ -65,8 +63,8 @@ export function OpenAIApiKeyForm({
             <Input
               id="openai_api_key"
               placeholder="sk-..."
-              value={newApiKey}
-              onChange={(e) => setNewApiKey(e.target.value)}
+              value={apiKey}
+              onChange={(e) => setApiKey(e.target.value)}
               type="password"
             />
           </div>
@@ -77,4 +75,4 @@ export function OpenAIApiKeyForm({
       </Card>
     </form>
   );
-};
+}

--- a/common/types.ts
+++ b/common/types.ts
@@ -117,7 +117,7 @@ export interface CompetencyStructuredData {
 }
 
 export type TextInclusion<T> = {
-  [K in keyof T]: { full: boolean, sentences?: boolean };
+  [K in keyof T]: { full: boolean; sentences?: boolean };
 };
 
 export interface StepCompletionStats {
@@ -151,4 +151,8 @@ export interface CompletionStats {
   costs?: CostSummary;
   steps: StepCompletionStats[];
   generatedAt: string;
+}
+
+export interface ProxySettings {
+  url: string;
 }

--- a/server/src/extraction/recursivelyDetectConfiguration.ts
+++ b/server/src/extraction/recursivelyDetectConfiguration.ts
@@ -6,7 +6,7 @@ import {
 } from "../../../common/types";
 import { SimplifiedMarkdown } from "../types";
 import { bestOutOf, exponentialRetry, unique } from "../utils";
-import { fetchPageWithProxy, simplifiedMarkdown } from "./browser";
+import { fetchBrowserPage, simplifiedMarkdown } from "./browser";
 import { detectPageType } from "./llm/detectPageType";
 import { detectPagination } from "./llm/detectPagination";
 import detectUrlRegexp, {
@@ -106,7 +106,7 @@ const detectConfiguration = async (
   catalogueType: CatalogueType,
   pageData?: { content: string; screenshot: string }
 ) => {
-  let { content, screenshot } = pageData || (await fetchPageWithProxy(url));
+  let { content, screenshot } = pageData || (await fetchBrowserPage(url));
   const markdownContent = await simplifiedMarkdown(content);
   console.log(`Detecting page type for ${url}`);
   const pageType = await detectPageTypeWithRetry(
@@ -162,7 +162,7 @@ const recursivelyDetectConfiguration = async (
     throw new Error("Exceeded max category depth");
   }
 
-  let { content: pageContent, screenshot } = await fetchPageWithProxy(url);
+  let { content: pageContent, screenshot } = await fetchBrowserPage(url);
   const apiReceipe = await Probes.detectApiProviderRecipe({
     pageContent,
     pageUrl: url,
@@ -203,7 +203,7 @@ const recursivelyDetectConfiguration = async (
 
     const sampleLinks = await Promise.all(
       sample(urls, 5).map(async (url) => {
-        const { content, screenshot } = await fetchPageWithProxy(url);
+        const { content, screenshot } = await fetchBrowserPage(url);
         const markdownContent = await simplifiedMarkdown(content);
         return { url, content: markdownContent, screenshot };
       })
@@ -273,7 +273,7 @@ const recursivelyDetectConfiguration = async (
     console.log("Detecting configuration for sample child > child pages");
     const sampleSubChildLinks = await Promise.all(
       sample(childUrls, 5).map(async (url) => {
-        const { content, screenshot } = await fetchPageWithProxy(url);
+        const { content, screenshot } = await fetchBrowserPage(url);
         const markdownContent = await simplifiedMarkdown(content);
         return { url, content: markdownContent, screenshot };
       })

--- a/server/src/extraction/submitRecipeDetection.ts
+++ b/server/src/extraction/submitRecipeDetection.ts
@@ -1,18 +1,13 @@
 import { CatalogueType, PageType } from "../../../common/types";
 import { findCatalogueById } from "../data/catalogues";
 import { startRecipe } from "../data/recipes";
-import { findSettingJson } from "../data/settings";
-import { ProxySettings } from "../types";
 import { bestOutOf } from "../utils";
 import { Queues, submitJob } from "../workers";
-import { fetchPageWithProxy, simplifiedMarkdown } from "./browser";
+import { fetchBrowserPage, simplifiedMarkdown } from "./browser";
 import { detectPageType } from "./llm/detectPageType";
 
 export async function submitRecipeDetection(url: string, catalogueId: number) {
-  const proxy = await findSettingJson<ProxySettings>('PROXY');
-  console.log(`Fetching ${url}${proxy?.enabled ? ` using proxy.` : ""}`);
-  
-  const { content, screenshot } = await fetchPageWithProxy(url);
+  const { content, screenshot } = await fetchBrowserPage(url);
   const markdownContent = await simplifiedMarkdown(content);
   console.log(`Downloaded ${url}.`);
   console.log(`Detecting page type`);

--- a/server/src/routers/catalogues.ts
+++ b/server/src/routers/catalogues.ts
@@ -12,8 +12,6 @@ import {
 } from "../data/catalogues";
 import { findDatasets } from "../data/datasets";
 import { fetchPreview } from "../extraction/browser";
-import { findSettingJson } from "../data/settings";
-import { ProxySettings } from "../types";
 
 export const cataloguesRouter = router({
   preview: publicProcedure
@@ -22,10 +20,7 @@ export const cataloguesRouter = router({
         url: z.string().url(),
       })
     )
-    .query(async (opts) => {
-      const proxy = await findSettingJson<ProxySettings>('PROXY');
-      return fetchPreview(opts.input.url, proxy?.enabled ? proxy.url : undefined)
-    }),
+    .query(async (opts) => fetchPreview(opts.input.url)),
   list: publicProcedure
     .input(
       z

--- a/server/src/routers/recipes.ts
+++ b/server/src/routers/recipes.ts
@@ -9,7 +9,7 @@ import {
   setDefault,
   updateRecipe,
 } from "../data/recipes";
-import { fetchPageWithProxy, simplifiedMarkdown } from "../extraction/browser";
+import { fetchBrowserPage, simplifiedMarkdown } from "../extraction/browser";
 import { detectPagination } from "../extraction/llm/detectPagination";
 import detectUrlRegexp, {
   createUrlExtractor,
@@ -132,7 +132,7 @@ export const recipesRouter = router({
       })
     )
     .mutation(async (opts) => {
-      const { content, screenshot } = await fetchPageWithProxy(opts.input.url);
+      const { content, screenshot } = await fetchBrowserPage(opts.input.url);
       const markdownContent = await simplifiedMarkdown(content);
       return detectPagination(
         {
@@ -156,7 +156,7 @@ export const recipesRouter = router({
     .mutation(async (opts) => {
       const pages = await Promise.all(
         opts.input.urls.map(async (url) => {
-          const { content, screenshot } = await fetchPageWithProxy(url);
+          const { content, screenshot } = await fetchBrowserPage(url);
           const markdownContent = await simplifiedMarkdown(content);
           return { url, content: markdownContent, screenshot };
         })

--- a/server/src/routers/settings.ts
+++ b/server/src/routers/settings.ts
@@ -9,17 +9,7 @@ export const settingsRouter = router({
         key: z.enum(["PROXY", "PROXY_ENABLED", "OPENAI_API_KEY"]),
       })
     )
-    .query(async (opts) => {
-      let setting;
-      if (opts.input.key === "PROXY") {
-        setting = await findSetting(opts.input.key);
-      } else if (opts.input.key === "PROXY_ENABLED") {
-        setting = await findSetting<boolean>(opts.input.key);
-      } else if (opts.input.key === "OPENAI_API_KEY") {
-        setting = await findSetting<string>(opts.input.key);
-      }
-      return setting;
-    }),
+    .query(async (opts) => findSetting(opts.input.key)),
   setOpenAIApiKey: publicProcedure
     .input(
       z.object({

--- a/server/src/routers/settings.ts
+++ b/server/src/routers/settings.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import { publicProcedure, router } from ".";
-import { AppError, AppErrors } from "../appErrors";
 import { createOrUpdate, findSetting } from "../data/settings";
 
 export const settingsRouter = router({
@@ -18,8 +17,6 @@ export const settingsRouter = router({
         setting = await findSetting<boolean>(opts.input.key);
       } else if (opts.input.key === "OPENAI_API_KEY") {
         setting = await findSetting<string>(opts.input.key);
-      } else {
-        throw new AppError("Unknown setting", AppErrors.BAD_REQUEST);
       }
       return setting;
     }),

--- a/server/src/types.d.ts
+++ b/server/src/types.d.ts
@@ -31,8 +31,3 @@ type Brand<B> = { [__brand]: B };
 export type Branded<T, B> = T & Brand<B>;
 
 export type SimplifiedMarkdown = Branded<string, "SimplifiedMarkdown">;
-
-export interface ProxySettings {
-  enabled: boolean;
-  url: string;
-}

--- a/server/src/workers/fetchPage.ts
+++ b/server/src/workers/fetchPage.ts
@@ -34,7 +34,7 @@ import {
   storeContent,
   storeScreenshot,
 } from "../data/schema";
-import { fetchPageWithProxy, simplifiedMarkdown } from "../extraction/browser";
+import { fetchBrowserPage, simplifiedMarkdown } from "../extraction/browser";
 import { detectPageCount } from "../extraction/llm/detectPageCount";
 import { createUrlExtractor } from "../extraction/llm/detectUrlRegexp";
 import { findRule, isUrlAllowedForRule } from "../extraction/robotsParser";
@@ -230,7 +230,7 @@ const performJob = async (
     console.log(`Loading ${crawlPage.url}`);
     await updatePage(crawlPage.id, { status: PageStatus.IN_PROGRESS });
 
-    const page = await fetchPageWithProxy(crawlPage.url);
+    const page = await fetchBrowserPage(crawlPage.url);
     if (page.status == 404) {
       await updatePage(crawlPage.id, {
         status: PageStatus.ERROR,


### PR DESCRIPTION
Currently there are some issues with how we're handling settings in the backend that make the app potentially vulnerable.

- Fix issues with encrypted values / previews
- Simplify API for fetching/storing settings
- Make settings handling consistent for all settings (using JSON for all values)
- Simplify proxy usage in the `fetch` methods (assume proxies are always used if enabled, with option to skip)
- Small updates to the proxy settings UI to reflect the changes, plus make the proxy changes UI more assertive