### PR TITLE
Learning program improvements

### DIFF
--- a/common/types.ts
+++ b/common/types.ts
@@ -57,6 +57,7 @@ export enum Provider {
 export enum ProviderModel {
   Gpt4o = "gpt-4o",
   O3Mini = "o3-mini",
+  Gpt41 = "gpt-4.1",
 }
 
 export enum ExtractionStatus {

--- a/server/src/extraction/browser.ts
+++ b/server/src/extraction/browser.ts
@@ -169,7 +169,11 @@ export async function simplifyHtml(html: string) {
       $elm.remove();
       continue;
     }
-    if (["header", "footer"].includes(elm.tagName)) {
+    if (["footer", "form"].includes(elm.tagName)) {
+      $elm.remove();
+      continue;
+    }
+    if (elm.tagName === "iframe" && elm.children.length === 0) {
       $elm.remove();
       continue;
     }

--- a/server/src/extraction/catalogueTypes.ts
+++ b/server/src/extraction/catalogueTypes.ts
@@ -14,23 +14,23 @@ export interface CatalogueTypeDefinition {
    * the desired output. Example values:
    * - 'An array of strings with all the animals mentioned in the page'
    * - 'An array of JSON objects having x, y, z attributes.'
-   * 
+   *
    * If not specified, the LLM will be instructed
    * to give us structured output for the defined
    * data in the `properties` field.
    */
   desiredOutput?: string;
 
-  /** 
+  /**
    * When set to true, we will wrap the page content
    * with a markdown code block in the LLM prompt.
    */
   wrapWithMarkdownBlock?: boolean;
 
   /**
-   * When set to true, we will ask the LLM for additional 
+   * When set to true, we will ask the LLM for additional
    * URLs that could indicate sub pages where we could find
-   * entites when the page extracted does not yield any of 
+   * entites when the page extracted does not yield any of
    * the targeted entities.
    */
   exploreDuringExtraction?: boolean;
@@ -42,7 +42,7 @@ export interface CatalogueTypeDefinition {
    * such as links to social media, external blogs,
    * our outside the catalogue.
    */
-  exploreSameOrigin?: boolean
+  exploreSameOrigin?: boolean;
 
   /**
    * Textual prompt set to the LLM to yield additional URLs
@@ -58,10 +58,10 @@ export interface CatalogueTypeDefinition {
   /**
    * If true, we will not use screenshots for the LLM.
    */
-  skipScreenshot?: boolean
+  skipScreenshot?: boolean;
 
   /**
-   * When defined, we will instruct the LLM to use it for 
+   * When defined, we will instruct the LLM to use it for
    * structured output instead of the default function call
    * instruction.
    */
@@ -109,7 +109,7 @@ export interface CatalogueTypeDefinition {
   examples?: Array<{
     data: string;
     desiredOutcome: string;
-  }>
+  }>;
 }
 
 export const catalogueTypes: Record<CatalogueType, CatalogueTypeDefinition> = {
@@ -219,9 +219,10 @@ export const catalogueTypes: Record<CatalogueType, CatalogueTypeDefinition> = {
         required: true,
       },
       learning_program_description: {
-        description: `the full description of the learning program.
+        description: `the description of the learning program.
            Pages often include other sections aside from the basic description, for example containing program requirements,
            restrictions, etc. We don't want any of that - we only want the program description (directly extracted from the page).
+           You should take only the first few paragraphs of the description.
            If there are links, only extract the text.
           `,
         required: true,
@@ -250,20 +251,20 @@ export const catalogueTypes: Record<CatalogueType, CatalogueTypeDefinition> = {
     verifyFullPhrases: false,
     propertiesRequiredAsPhrases: ["text"],
     wrapWithMarkdownBlock: true,
-    presencePrompt: 
-      'Look at the given markdown page and check if there exists a list of skills in a dedicated section. ' +
-      'We are looking for a list in a dedicated section, do not consider paragraphs or long descriptions. ' +
-      'Do not confuse courses with skills. We are looking for skills attained after taking the course described in the page.',
+    presencePrompt:
+      "Look at the given markdown page and check if there exists a list of skills in a dedicated section. " +
+      "We are looking for a list in a dedicated section, do not consider paragraphs or long descriptions. " +
+      "Do not confuse courses with skills. We are looking for skills attained after taking the course described in the page.",
     desiredOutput:
-      'We are looking for a list of skills that are gained after taking the course described in the page. ' +
-      'If found, take each item exactly as it is in the page and return them. Skip everything else, just the skill list.' +
-      'Do not confuse skills with courses or tools or technologies used. Return the skills that result after the course is completed.' +
-      'Do not return skills required for taking the course. Return only the skills that are gained after taking the course.',
+      "We are looking for a list of skills that are gained after taking the course described in the page. " +
+      "If found, take each item exactly as it is in the page and return them. Skip everything else, just the skill list." +
+      "Do not confuse skills with courses or tools or technologies used. Return the skills that result after the course is completed." +
+      "Do not return skills required for taking the course. Return only the skills that are gained after taking the course.",
     properties: {
       text: {
         description:
           'text of the skill item of the list (for example "Critical Thinking"). ' +
-          'The information should be EXACTLY as in the page AND the FULL PHRASE. DO NOT break phrases. ',
+          "The information should be EXACTLY as in the page AND the FULL PHRASE. DO NOT break phrases. ",
         required: true,
       },
       competency_framework: {
@@ -272,9 +273,9 @@ export const catalogueTypes: Record<CatalogueType, CatalogueTypeDefinition> = {
           "to obtaining the skill or competency or learning outcome. " +
           "Usually this value is the same for the entire list but should be set " +
           "according to the hierarchy structure of the page. This is usually shorter. " +
-          'Sometimes, this might contain descriptive language about the skill - we should only keep the ' +
+          "Sometimes, this might contain descriptive language about the skill - we should only keep the " +
           'name of the skill and trim phrases such as "competency" or "learning outcome".' +
-          'This field should be in title case. If it contains roman numerals, they use use uppercase.',
+          "This field should be in title case. If it contains roman numerals, they use use uppercase.",
         required: false,
       },
       language: {
@@ -296,11 +297,7 @@ export const catalogueTypes: Record<CatalogueType, CatalogueTypeDefinition> = {
               language: { type: "string" },
             },
             additionalProperties: false,
-            required: [
-              "competency_framework",
-              "text",
-              "language",
-            ],
+            required: ["competency_framework", "text", "language"],
           },
         },
       },
@@ -309,7 +306,7 @@ export const catalogueTypes: Record<CatalogueType, CatalogueTypeDefinition> = {
     },
     exploreDuringExtraction: true,
     exploreSameOrigin: true,
-    explorationPrompt: 
+    explorationPrompt:
       "In the page markdown given below, look for all links or URL like information " +
       "that point to pages with information about skills or learning outcomes or competencies obtained. " +
       "The link we are looking for is related to the course presented in the page, general links like navigation should be ignored. " +

--- a/server/src/extraction/splitChunks.ts
+++ b/server/src/extraction/splitChunks.ts
@@ -14,7 +14,9 @@ export async function splitChunks(options: DefaultLlmPageOptions) {
         await detectChunkSplitRegexp(options));
       chunks = options.content.split(regexp);
       if (!chunks) {
-        throw new Error(`Could not find chunks with the regexp: ${regexp}`);
+        const errorMessage = `Could not find any chunks with the regexp: ${regexp}. Expected ${expectedCourseCount} chunks.`;
+        console.error(errorMessage);
+        throw new Error(errorMessage);
       }
 
       chunks = chunks.filter((chunk) => chunk.trim() !== "");
@@ -33,12 +35,17 @@ export async function splitChunks(options: DefaultLlmPageOptions) {
       // LLMs are not good at counting so let's treat the number of courses as a ballpark estimate
       const discrepancy = Math.abs(chunks.length - expectedCourseCount);
       const allowedDiscrepancy =
-        expectedCourseCount > 5 ? Math.floor(expectedCourseCount * 0.3) : 0;
+        expectedCourseCount > 5 ? Math.floor(expectedCourseCount * 0.1) : 0;
       if (discrepancy > allowedDiscrepancy) {
-        throw new Error(
-          `Could not find expected number of chunks: ${chunks.length} !== ${expectedCourseCount}`
-        );
+        const errorMessage =
+          "Could not find expected number of chunks.\n" +
+          `Regexp: ${regexp}.\n` +
+          `Found ${chunks.length} chunks, expected ${expectedCourseCount}`;
+
+        console.error(errorMessage);
+        throw new Error(errorMessage);
       }
+      console.log(`Success - Found ${chunks.length} chunks`);
       return chunks;
     } catch (error) {
       if (error instanceof Error) {

--- a/server/src/openai.ts
+++ b/server/src/openai.ts
@@ -12,12 +12,16 @@ import { exponentialRetry } from "./utils";
 
 export const ModelPrices = {
   [ProviderModel.Gpt4o]: {
-    per1MInput: 5.0,
-    per1MOutput: 15.0,
+    per1MInput: 2.5,
+    per1MOutput: 10.0,
   },
   [ProviderModel.O3Mini]: {
     per1MInput: 1.1,
     per1MOutput: 4.4,
+  },
+  [ProviderModel.Gpt41]: {
+    per1MInput: 2.0,
+    per1MOutput: 8.0,
   },
 };
 

--- a/server/tests/browser.test.ts
+++ b/server/tests/browser.test.ts
@@ -1,0 +1,22 @@
+import { readFile } from "fs/promises";
+import path from "path";
+import { describe, expect, it } from "vitest";
+import { simplifiedMarkdown, simplifyHtml } from "../src/extraction/browser";
+
+describe("simplifiedMarkdown", () => {
+  it("should simplify the html", async () => {
+    // read test/fixtures/doc.html
+    const rawHtml = await readFile(
+      path.join(__dirname, "fixtures", "doc.html"),
+      "utf8"
+    );
+    const markdown = await readFile(
+      path.join(__dirname, "fixtures", "doc_simplified.md"),
+      "utf8"
+    );
+    const simplifiedHtml = await simplifyHtml(rawHtml);
+    console.log(simplifiedHtml);
+    const simplified = await simplifiedMarkdown(rawHtml);
+    expect(simplified).toBe(markdown);
+  });
+});

--- a/server/tests/csv.test.ts
+++ b/server/tests/csv.test.ts
@@ -1,0 +1,390 @@
+import { randomUUID } from "crypto";
+import { Transform } from "stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  CatalogueType,
+  CompetencyStructuredData,
+  CourseStructuredData,
+  LearningProgramStructuredData,
+} from "../../common/types";
+import { buildCsv } from "../src/csv";
+import * as datasetModule from "../src/data/datasets";
+import * as extractionModule from "../src/data/extractions";
+
+vi.mock("../src/data/datasets");
+vi.mock("../src/data/extractions");
+vi.mock("crypto");
+
+describe("buildCsv", () => {
+  let csvStream: Transform;
+  const mockWrite = vi.fn();
+  const mockEnd = vi.fn();
+  const mockEmit = vi.fn();
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    csvStream = {
+      write: mockWrite,
+      end: mockEnd,
+      emit: mockEmit,
+    } as unknown as Transform;
+
+    vi.mocked(randomUUID).mockReturnValue(
+      "12345678-1234-1234-1234-123456789012"
+    );
+
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should handle empty results and end the stream", async () => {
+    vi.mocked(extractionModule.findExtractionById).mockResolvedValue({
+      id: 1,
+      recipe: {
+        catalogue: {
+          catalogueType: CatalogueType.COURSES,
+        },
+      },
+    } as any);
+
+    vi.mocked(datasetModule.findDataItems).mockResolvedValue({ items: [] });
+
+    await buildCsv(csvStream, 1);
+
+    expect(mockEnd).toHaveBeenCalled();
+    expect(mockWrite).not.toHaveBeenCalled();
+  });
+
+  it("should process course data correctly", async () => {
+    vi.mocked(extractionModule.findExtractionById).mockResolvedValue({
+      id: 1,
+      recipe: {
+        catalogue: {
+          catalogueType: CatalogueType.COURSES,
+        },
+      },
+    } as any);
+
+    const mockCourseData = {
+      items: [
+        {
+          id: 1,
+          url: "https://example.com/course1",
+          structuredData: {
+            course_id: "COURSE-001",
+            course_name: "Test Course",
+            course_description: "Course description",
+            course_credits_min: 3,
+            course_credits_max: undefined,
+            course_credits_type: "Credit Hour",
+            course_prerequisites: "None",
+          } as CourseStructuredData,
+          textInclusion: {
+            course_name: { full: true },
+            course_description: { full: true },
+          },
+        },
+      ],
+    };
+
+    vi.mocked(datasetModule.findDataItems)
+      .mockResolvedValueOnce(mockCourseData)
+      .mockResolvedValueOnce({ items: [] });
+
+    await buildCsv(csvStream, 1);
+
+    expect(mockWrite).toHaveBeenCalledTimes(1);
+    expect(mockWrite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "External Identifier": "COURSE-001",
+        "Coded Notation": "COURSE-001",
+        "Learning Type": "Course",
+        "Learning Opportunity Name": "Test Course",
+        Description: "Course description",
+        Language: "English",
+        "Life Cycle Status Type": "Active",
+        "In Catalog": "https://example.com/course1",
+        "Credit Unit Value": 3,
+        "Credit Unit Type": "Credit Hour",
+      })
+    );
+    expect(mockEnd).toHaveBeenCalled();
+  });
+
+  it("should process learning program data correctly", async () => {
+    vi.mocked(extractionModule.findExtractionById).mockResolvedValue({
+      id: 1,
+      recipe: {
+        catalogue: {
+          catalogueType: CatalogueType.LEARNING_PROGRAMS,
+        },
+      },
+    } as any);
+
+    const mockLearningProgramData = {
+      items: [
+        {
+          id: 1,
+          url: "https://example.com/program1",
+          structuredData: {
+            learning_program_id: "PROG-001",
+            learning_program_name: "Test Program",
+            learning_program_description: "Program description",
+          } as LearningProgramStructuredData,
+          textInclusion: {
+            learning_program_name: { full: true },
+            learning_program_description: { full: true },
+          },
+        },
+      ],
+    };
+
+    vi.mocked(datasetModule.findDataItems)
+      .mockResolvedValueOnce(mockLearningProgramData)
+      .mockResolvedValueOnce({ items: [] });
+
+    await buildCsv(csvStream, 1);
+
+    expect(mockWrite).toHaveBeenCalledTimes(1);
+    expect(mockWrite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "External Identifier": "PROG-001",
+        "Learning Type": "Learning Program",
+        "Learning Opportunity Name": "Test Program",
+        Description: "Program description",
+        "Subject Webpage": "https://example.com/program1",
+        Language: "English",
+      })
+    );
+    expect(mockEnd).toHaveBeenCalled();
+  });
+
+  it("should process competency data correctly", async () => {
+    vi.mocked(extractionModule.findExtractionById).mockResolvedValue({
+      id: 1,
+      recipe: {
+        catalogue: {
+          catalogueType: CatalogueType.COMPETENCIES,
+        },
+      },
+    } as any);
+
+    const mockCompetencyData = {
+      items: [
+        {
+          id: 1,
+          url: "https://example.com/competency1",
+          structuredData: {
+            competency_framework: "Test Framework",
+            text: "Competency 1",
+            language: "English",
+          } as CompetencyStructuredData,
+          textInclusion: {
+            text: { full: true },
+          },
+        },
+      ],
+    };
+
+    vi.mocked(datasetModule.findDataItems)
+      .mockResolvedValueOnce(mockCompetencyData)
+      .mockResolvedValueOnce({ items: [] });
+
+    await buildCsv(csvStream, 1);
+
+    // First write is the framework
+    expect(mockWrite).toHaveBeenCalledTimes(2);
+    expect(mockWrite).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        "@type": "ceasn:CompetencyFramework",
+        "@id": "12345678-1234-1234-1234-123456789012",
+        "ceasn:name": "Test Framework",
+        "ceasn:description": expect.any(String),
+        "ceasn:inLanguage": "English",
+      })
+    );
+
+    // Second write is the competency
+    expect(mockWrite).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        "@type": "ceasn:Competency",
+        "@id": "12345678-1234-1234-1234-123456789012",
+        "ceasn:competencyText": "Competency 1",
+        "ceasn:inLanguage": "English",
+        "ceasn:isPartOf": "12345678-1234-1234-1234-123456789012",
+      })
+    );
+
+    expect(mockEnd).toHaveBeenCalled();
+  });
+
+  it("should handle duplicate IDs correctly", async () => {
+    vi.mocked(extractionModule.findExtractionById).mockResolvedValue({
+      id: 1,
+      recipe: {
+        catalogue: {
+          catalogueType: CatalogueType.COURSES,
+        },
+      },
+    } as any);
+
+    const mockDuplicateCourseData = {
+      items: [
+        {
+          id: 1,
+          url: "https://example.com/course1",
+          structuredData: {
+            course_id: "COURSE-001",
+            course_name: "Test Course 1",
+            course_description: "Course description 1",
+          } as CourseStructuredData,
+          textInclusion: {
+            course_name: { full: true },
+          },
+        },
+        {
+          id: 2,
+          url: "https://example.com/course2",
+          structuredData: {
+            course_id: "COURSE-001",
+            course_name: "Test Course 2",
+            course_description: "Course description 2",
+          } as CourseStructuredData,
+          textInclusion: {
+            course_name: { full: true },
+          },
+        },
+      ],
+    };
+
+    vi.mocked(datasetModule.findDataItems)
+      .mockResolvedValueOnce(mockDuplicateCourseData)
+      .mockResolvedValueOnce({ items: [] });
+
+    await buildCsv(csvStream, 1);
+
+    expect(mockWrite).toHaveBeenCalledTimes(2);
+
+    // First item keeps original ID
+    expect(mockWrite).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        "External Identifier": "COURSE-001",
+        "Learning Opportunity Name": "Test Course 1",
+      })
+    );
+
+    // Second item gets a modified ID
+    expect(mockWrite).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        "External Identifier": "COURSE-001-2",
+        "Learning Opportunity Name": "Test Course 2",
+      })
+    );
+
+    expect(mockEnd).toHaveBeenCalled();
+  });
+
+  it("should handle extraction not found error", async () => {
+    vi.mocked(extractionModule.findExtractionById).mockResolvedValue(undefined);
+
+    await buildCsv(csvStream, 1);
+
+    expect(mockEmit).toHaveBeenCalledWith("error", expect.any(Error));
+    expect(mockEnd).toHaveBeenCalled();
+  });
+
+  it("should handle database errors properly", async () => {
+    vi.mocked(extractionModule.findExtractionById).mockRejectedValue(
+      new Error("Database error")
+    );
+
+    await buildCsv(csvStream, 1);
+
+    expect(mockEmit).toHaveBeenCalledWith("error", expect.any(Error));
+    expect(mockEnd).toHaveBeenCalled();
+  });
+
+  it("should paginate through results with multiple batches", async () => {
+    vi.mocked(extractionModule.findExtractionById).mockResolvedValue({
+      id: 1,
+      recipe: {
+        catalogue: {
+          catalogueType: CatalogueType.COURSES,
+        },
+      },
+    } as any);
+
+    // First batch
+    const mockBatch1 = {
+      items: [
+        {
+          id: 1,
+          url: "https://example.com/course1",
+          structuredData: {
+            course_id: "COURSE-001",
+            course_name: "Test Course 1",
+          } as CourseStructuredData,
+          textInclusion: {},
+        },
+      ],
+    };
+
+    // Second batch
+    const mockBatch2 = {
+      items: [
+        {
+          id: 2,
+          url: "https://example.com/course2",
+          structuredData: {
+            course_id: "COURSE-002",
+            course_name: "Test Course 2",
+          } as CourseStructuredData,
+          textInclusion: {},
+        },
+      ],
+    };
+
+    // Empty batch to terminate the loop
+    const emptyBatch = { items: [] };
+
+    vi.mocked(datasetModule.findDataItems)
+      .mockResolvedValueOnce(mockBatch1)
+      .mockResolvedValueOnce(mockBatch2)
+      .mockResolvedValueOnce(emptyBatch);
+
+    await buildCsv(csvStream, 1);
+
+    expect(mockWrite).toHaveBeenCalledTimes(2);
+    expect(datasetModule.findDataItems).toHaveBeenCalledTimes(3);
+    expect(datasetModule.findDataItems).toHaveBeenNthCalledWith(
+      1,
+      1,
+      100,
+      0,
+      true
+    );
+    expect(datasetModule.findDataItems).toHaveBeenNthCalledWith(
+      2,
+      1,
+      100,
+      100,
+      true
+    );
+    expect(datasetModule.findDataItems).toHaveBeenNthCalledWith(
+      3,
+      1,
+      100,
+      200,
+      true
+    );
+    expect(mockEnd).toHaveBeenCalled();
+  });
+});

--- a/server/tests/extractions/learning_programs/acalog.test.ts
+++ b/server/tests/extractions/learning_programs/acalog.test.ts
@@ -1,4 +1,4 @@
-import { describe, test } from "vitest";
+import { describe, expect, test } from "vitest";
 import { assertExtraction, EXTRACTION_TIMEOUT } from "../..";
 import {
   CatalogueType,
@@ -20,6 +20,25 @@ describe("ACALOG", { timeout: EXTRACTION_TIMEOUT }, () => {
         ],
         true,
         CatalogueType.LEARNING_PROGRAMS
+      );
+    });
+
+    test("Description with additional data", async () => {
+      const extractions = await assertExtraction<LearningProgramStructuredData>(
+        "https://www.hccs.edu/programs/areas-of-study/liberal-arts--humanities/interpretingsign-language/",
+        [
+          {
+            learning_program_id: "Interpreting Sign Language",
+            learning_program_name: "Interpreting Sign Language",
+            learning_program_description:
+              "The curriculum for the AAS degree in Interpreting Training/American Sign Language Program is a two-year course of study that prepares students for employment in the interpreting profession.",
+          },
+        ],
+        true,
+        CatalogueType.LEARNING_PROGRAMS
+      );
+      expect(extractions[0].entity.learning_program_description).toEqual(
+        "The curriculum for the AAS degree in Interpreting Training/American Sign Language Program is a two-year course of study that prepares students for employment in the interpreting profession."
       );
     });
   });

--- a/server/tests/fixtures/doc.html
+++ b/server/tests/fixtures/doc.html
@@ -1,0 +1,1526 @@
+<!doctype html>
+<html
+  lang="en"
+  dir="ltr"
+  prefix="content: http://purl.org/rss/1.0/modules/content/ dc: http://purl.org/dc/terms/ foaf: http://xmlns.com/foaf/0.1/ og: http://ogp.me/ns# rdfs: http://www.w3.org/2000/01/rdf-schema# schema: http://schema.org/ sioc: http://rdfs.org/sioc/ns# sioct: http://rdfs.org/sioc/types# skos: http://www.w3.org/2004/02/skos/core# xsd: http://www.w3.org/2001/XMLSchema# "
+  class="js"
+>
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="description"
+      content="This two semester certificate program is designed to provide students with career training for entry-level positions in baking and pastry. The certificate can also be used as a foundation for completing the Baking and Pastry Option in Culinary Arts, A.A.S. degree at the Academy of Culinary Arts. In addition to coursework, students are required to complete 200 hours of documented work experience (Cooperative Education, Internship, Externship or Service-Learning). For additional program information, please contact the Culinary department at (609) 343-4944."
+    />
+    <script
+      async=""
+      defer=""
+      data-domain="catalog.atlanticcape.edu"
+      src="https://plausible.io/js/plausible.js"
+    ></script>
+    <script>
+      window.plausible =
+        window.plausible ||
+        function () {
+          (window.plausible.q = window.plausible.q || []).push(arguments);
+        };
+    </script>
+    <meta name="Generator" content="Drupal 10 (https://www.drupal.org)" />
+    <meta name="MobileOptimized" content="width" />
+    <meta name="HandheldFriendly" content="true" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      rel="icon"
+      href="/themes/custom/atlantic21/images/favicon.png"
+      type="image/vnd.microsoft.icon"
+    />
+    <link
+      rel="canonical"
+      href="https://catalog.atlanticcape.edu/culinary-arts/baking-and-pastry-i"
+    />
+    <link rel="shortlink" href="https://catalog.atlanticcape.edu/node/756" />
+    <title>Baking and Pastry I | Atlantic Cape Community College</title>
+    <link
+      rel="stylesheet"
+      media="all"
+      href="/sites/default/files/css/css_XBaMGnQKjYsQ_kKyz9AhyJamDeGD4ELTk0eVs1C8VvU.css?delta=0&amp;language=en&amp;theme=atlantic21&amp;include=eJxVjEEOwyAMBD9EY6VS34MMuIDqgIXNIb9vOURtbzu7o0VjbFbjfYfMPSDf1E6uLbsYfXxRqtbHA37Bc1XzSyNdlqSnt9454IB_XKsVOgiu4AQH5oFSFNKYgrx9m202meHzXig5PdXogIBKb2OqP7k"
+    />
+    <link
+      rel="stylesheet"
+      media="all"
+      href="https://fonts.googleapis.com/css2?family=Cabin:ital,wght@0,400;0,700;1,400;1,700&amp;display=swap"
+    />
+    <link
+      rel="stylesheet"
+      media="all"
+      href="/sites/default/files/css/css_wy8QrMeMQUdUnKDplTSrrgXZTWU-kMRwVrmyx5HoKwg.css?delta=2&amp;language=en&amp;theme=atlantic21&amp;include=eJxVjEEOwyAMBD9EY6VS34MMuIDqgIXNIb9vOURtbzu7o0VjbFbjfYfMPSDf1E6uLbsYfXxRqtbHA37Bc1XzSyNdlqSnt9454IB_XKsVOgiu4AQH5oFSFNKYgrx9m202meHzXig5PdXogIBKb2OqP7k"
+    />
+  </head>
+  <body class="atlantic-cape-community-college">
+    <a href="#main-content" class="visually-hidden focusable">
+      Skip to main content
+    </a>
+    <div class="dialog-off-canvas-main-canvas" data-off-canvas-main-canvas="">
+      <div class="layout-container outer-course-teaser-table">
+        <div class="content-wrapper">
+          <header role="banner" class="site-header">
+            <div class="header-container">
+              <div class="row">
+                <div class="logo-wrapper">
+                  <a class="logo" href="/">
+                    <img
+                      src="/themes/custom/atlantic21/images/logo.png"
+                      alt="Atlantic Cape Community College catalog"
+                    />
+                  </a>
+                </div>
+                <span class="header-title">College Catalog</span>
+                <div class="site-menu">
+                  <div class="site-menu-wrapper">
+                    <div class="row">
+                      <div class="col-12">
+                        <div class="region region-primary-menu">
+                          <div
+                            class="views-exposed-form block block-views block-views-exposed-filter-blocksearch-api-page-1"
+                            data-drupal-selector="views-exposed-form-search-api-page-1"
+                            id="block-atlantic21-exposedformsearch-apipage-1"
+                          >
+                            <form
+                              action="/search"
+                              method="get"
+                              id="views-exposed-form-search-api-page-1"
+                              accept-charset="UTF-8"
+                            >
+                              <div
+                                class="js-form-item form-item form-type-textfield js-form-type-textfield form-item-search-api-fulltext js-form-item-search-api-fulltext"
+                              >
+                                <label for="edit-search-api-fulltext"
+                                  >Fulltext search</label
+                                >
+                                <input
+                                  data-drupal-selector="edit-search-api-fulltext"
+                                  type="text"
+                                  id="edit-search-api-fulltext"
+                                  name="search_api_fulltext"
+                                  value=""
+                                  size="30"
+                                  maxlength="128"
+                                  placeholder="Search"
+                                  class="form-text"
+                                />
+                              </div>
+                              <div
+                                data-drupal-selector="edit-actions"
+                                class="form-actions js-form-wrapper form-wrapper"
+                                id="edit-actions"
+                              >
+                                <input
+                                  data-drupal-selector="edit-submit-search-api"
+                                  type="submit"
+                                  id="edit-submit-search-api"
+                                  value="Search"
+                                  class="button js-form-submit form-submit"
+                                />
+                              </div>
+                            </form>
+                          </div>
+                          <nav
+                            role="navigation"
+                            aria-labelledby="block-atlantic21-mainnavigation-menu"
+                            id="block-atlantic21-mainnavigation"
+                          >
+                            <h2
+                              class="visually-hidden"
+                              id="block-atlantic21-mainnavigation-menu"
+                            >
+                              Main navigation
+                            </h2>
+                            <ul>
+                              <li>
+                                <a
+                                  href="/"
+                                  data-drupal-link-system-path="&lt;front&gt;"
+                                  >Catalog Home</a
+                                >
+                              </li>
+                              <li>
+                                <a
+                                  href="/degrees"
+                                  data-drupal-link-system-path="degrees"
+                                  >Degrees &amp; Certificates</a
+                                >
+                              </li>
+                              <li>
+                                <a
+                                  href="/classes"
+                                  data-drupal-link-system-path="classes"
+                                  >Courses</a
+                                >
+                              </li>
+                              <li>
+                                <a
+                                  href="/student-handbook"
+                                  data-drupal-link-system-path="node/156"
+                                  >Student Handbook</a
+                                >
+                              </li>
+                              <li>
+                                <a
+                                  href="/#pdf-links"
+                                  data-drupal-link-system-path="&lt;front&gt;"
+                                  >Archived Catalogs</a
+                                >
+                              </li>
+                            </ul>
+                          </nav>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </header>
+          <main role="main" class="site-main">
+            <span id="main-content" tabindex="-1"></span>
+            <div class="layout-content">
+              <div class="region region-content">
+                <div data-drupal-messages-fallback="" class="hidden"></div>
+                <article
+                  about="/culinary-arts/baking-and-pastry-i"
+                  class="node node--type-degree node--view-mode-full"
+                >
+                  <div class="node__content">
+                    <header class="node-header page-header-gray">
+                      <div class="node-header-text">
+                        <nav
+                          class="breadcrumb"
+                          role="navigation"
+                          aria-labelledby="system-breadcrumb"
+                        >
+                          <h2 id="system-breadcrumb" class="visually-hidden">
+                            Breadcrumb
+                          </h2>
+                          <ol>
+                            <li>
+                              <a href="/">Home</a
+                              ><svg
+                                width="17"
+                                height="16"
+                                viewBox="0 0 17 16"
+                                fill="none"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M17 8L16.448 7.36648L10.5598 0.5L9.07755 1.76703L13.5857 7.01907H0L0 8.98093H13.5857L9.07755 14.233L10.5598 15.5L16.448 8.63351L17 8Z"
+                                  fill="#000"
+                                ></path>
+                              </svg>
+                            </li>
+                            <li>
+                              <a href="/culinary-arts">Culinary Arts</a
+                              ><svg
+                                width="17"
+                                height="16"
+                                viewBox="0 0 17 16"
+                                fill="none"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M17 8L16.448 7.36648L10.5598 0.5L9.07755 1.76703L13.5857 7.01907H0L0 8.98093H13.5857L9.07755 14.233L10.5598 15.5L16.448 8.63351L17 8Z"
+                                  fill="#000"
+                                ></path>
+                              </svg>
+                            </li>
+                            <li>Baking and Pastry I</li>
+                          </ol>
+                        </nav>
+                        <div class="degree-class-badge-wrapper">
+                          <span class="degree-class-badge">
+                            <div
+                              class="field field--name-field-degree-type field--type-entity-reference field--label-hidden field__item"
+                            >
+                              Certificate
+                            </div>
+                          </span>
+                        </div>
+                        <h1><span>Baking and Pastry I</span></h1>
+                        <div class="pdf-link">
+                          <a
+                            href="/node/756/download-pdf"
+                            target="_blank"
+                            rel="nofollow"
+                            class="pdf-download-link"
+                          >
+                            <svg
+                              width="18"
+                              height="17"
+                              viewBox="0 0 18 17"
+                              fill="none"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M1 11.4092V15.5001H16.6818V11.4092"
+                                stroke="#000000"
+                                stroke-width="1.2"
+                              ></path>
+                              <path
+                                d="M8.84095 12.0909L9.2729 11.7145L13.9546 7.69988L13.0907 6.68924L9.50977 9.76297V0.5L8.17214 0.5V9.76297L4.5912 6.68924L3.72732 7.69988L8.40901 11.7145L8.84095 12.0909Z"
+                                fill="#000000"
+                              ></path>
+                            </svg>
+                            Download as PDF
+                          </a>
+                        </div>
+                      </div>
+                    </header>
+                    <div class="degree-class-content-wrapper">
+                      <div class="degree-class-overview">
+                        <div
+                          class="field field--name-field-program field--type-entity-reference field--label-above"
+                        >
+                          <div class="field__label">Program</div>
+                          <div class="field__item">
+                            <a href="/culinary-arts" hreflang="en"
+                              >Culinary Arts</a
+                            >
+                          </div>
+                        </div>
+                      </div>
+                      <div class="body-text-wrapper">
+                        <div class="degree-class-details">
+                          <div
+                            class="field field--name-body field--type-text-with-summary field--label-hidden field__item"
+                          >
+                            <p>
+                              This two semester certificate program is designed
+                              to provide students with career training for
+                              entry-level positions in baking and pastry. The
+                              certificate can also be used as a foundation for
+                              completing the Baking and Pastry Option in
+                              Culinary Arts, A.A.S. degree at the Academy of
+                              Culinary Arts.
+                            </p>
+                            <p>
+                              In addition to coursework, students are required
+                              to complete 200 hours of documented work
+                              experience (Cooperative Education, Internship,
+                              Externship or Service-Learning).
+                            </p>
+                            <p>
+                              For additional program information, please contact
+                              the Culinary department at (609) 343-4944.
+                            </p>
+                          </div>
+                          <div
+                            class="field field--name-field-program-outcomes field--type-text-with-summary field--label-above"
+                          >
+                            <div class="field__label">
+                              Upon completion of this program students will be
+                              able to:
+                            </div>
+                            <div class="field__item">
+                              <ul>
+                                <li>
+                                  Demonstrate an understanding of
+                                  professionalism and exceptional work ethics;
+                                </li>
+                                <li>Work effectively in teams;</li>
+                                <li>
+                                  Explain the environmental and conservation
+                                  issues related to the culinary industries;
+                                </li>
+                                <li>
+                                  Demonstrate the knowledge and skills
+                                  appropriate for entry-level positions in the
+                                  baking and pastry culinary field;
+                                </li>
+                                <li>
+                                  Articulate the need and value of life-long
+                                  learning as it relates to career goals;
+                                </li>
+                                <li>
+                                  Compare and contrast traditional and
+                                  non-traditional career opportunities;
+                                </li>
+                                <li>
+                                  Demonstrate industry sanitation standards;
+                                </li>
+                                <li>
+                                  Demonstrate industry equipment safety
+                                  standards;
+                                </li>
+                                <li>
+                                  Demonstrate effective communication and
+                                  computation skills;
+                                </li>
+                                <li>Apply baking theories;</li>
+                                <li>
+                                  Create classic and artisan yeast products,
+                                  quick breads and puff dough;
+                                </li>
+                                <li>
+                                  Create classical and decorative pastries;
+                                </li>
+                                <li>
+                                  Evaluate and interpret menus and recipes in
+                                  terms of human nutrition and apply principles
+                                  in menu planning and food preparation;
+                                </li>
+                                <li>Apply basic culinary cooking methods.</li>
+                              </ul>
+                              <p>(<em>BKPI-Fall&nbsp;</em>2022)</p>
+                            </div>
+                          </div>
+                          <div
+                            class="field field--name-field-degree-section-p field--type-entity-reference-revisions field--label-hidden field__items"
+                          >
+                            <div class="field__item">
+                              <div
+                                class="paragraph paragraph--type--degree-section paragraph--view-mode--default"
+                              >
+                                <h2
+                                  class="field field--name-field-degree-section-title field--type-string field--label-hidden field__item"
+                                >
+                                  General Education Courses
+                                </h2>
+                              </div>
+                            </div>
+                            <div class="field__item">
+                              <div
+                                class="paragraph paragraph--type--degree-section paragraph--view-mode--default"
+                              >
+                                <h2
+                                  class="field field--name-field-degree-section-title field--type-string field--label-hidden field__item"
+                                >
+                                  Communication
+                                </h2>
+                                <div class="row degree-row degree-row-header">
+                                  <div class="col-3">Course #</div>
+                                  <div class="col-7">Title</div>
+                                  <div class="col-2">Credits</div>
+                                </div>
+                                <div
+                                  class="field field--name-field-degree-section-courses field--type-entity-reference field--label-hidden field__items"
+                                >
+                                  <div class="field__item">
+                                    <article
+                                      about="/english/engl101"
+                                      class="node node--type-class node--view-mode-course-table-item row degree-row"
+                                    >
+                                      <div class="col-3">
+                                        <a href="/english/engl101">ENGL101</a>
+                                      </div>
+                                      <div class="col-7">
+                                        <a href="/english/engl101">
+                                          <span
+                                            class="field field--name-field-item field--type-string field--label-hidden field__item"
+                                            >Composition I</span
+                                          >
+                                        </a>
+                                      </div>
+                                      <div class="col-2">
+                                        <span
+                                          class="field field--name-field-credits field--type-decimal field--label-hidden field__item"
+                                          >3</span
+                                        >
+                                      </div>
+                                    </article>
+                                  </div>
+                                </div>
+                                <div class="row degree-row degree-row-subtotal">
+                                  <div class="col-10">Sub-Total Credits</div>
+                                  <div class="col-2">3.00</div>
+                                </div>
+                              </div>
+                            </div>
+                            <div class="field__item">
+                              <div
+                                class="paragraph paragraph--type--degree-section paragraph--view-mode--default"
+                              >
+                                <h2
+                                  class="field field--name-field-degree-section-title field--type-string field--label-hidden field__item"
+                                >
+                                  Mathematics-Science-Technology
+                                </h2>
+                                <div class="row degree-row degree-row-header">
+                                  <div class="col-3">Course #</div>
+                                  <div class="col-7">Title</div>
+                                  <div class="col-2">Credits</div>
+                                </div>
+                                <div
+                                  class="field field--name-field-degree-section-courses field--type-entity-reference field--label-hidden field__items"
+                                >
+                                  <div class="field__item">
+                                    <article
+                                      about="/computer-information-systems/cism125"
+                                      class="node node--type-class node--view-mode-course-table-item row degree-row"
+                                    >
+                                      <div class="col-3">
+                                        <a
+                                          href="/computer-information-systems/cism125"
+                                          >CISM125</a
+                                        >
+                                      </div>
+                                      <div class="col-7">
+                                        <a
+                                          href="/computer-information-systems/cism125"
+                                        >
+                                          <span
+                                            class="field field--name-field-item field--type-string field--label-hidden field__item"
+                                            >Introduction to Computers</span
+                                          >
+                                        </a>
+                                      </div>
+                                      <div class="col-2">
+                                        <span
+                                          class="field field--name-field-credits field--type-decimal field--label-hidden field__item"
+                                          >3</span
+                                        >
+                                      </div>
+                                    </article>
+                                  </div>
+                                </div>
+                                <div class="row degree-row degree-row-subtotal">
+                                  <div class="col-10">Sub-Total Credits</div>
+                                  <div class="col-2">3.00</div>
+                                </div>
+                              </div>
+                            </div>
+                            <div class="field__item">
+                              <div
+                                class="paragraph paragraph--type--degree-section paragraph--view-mode--default"
+                              >
+                                <h2
+                                  class="field field--name-field-degree-section-title field--type-string field--label-hidden field__item"
+                                >
+                                  Program Courses
+                                </h2>
+                                <div
+                                  class="field field--name-field-degree-section-description field--type-text-long field--label-hidden field__item"
+                                >
+                                  <p>
+                                    Note:&nbsp;In addition to coursework,
+                                    students are required to complete 200 hours
+                                    of documented work experience (Cooperative
+                                    Education, Internship, Externship or
+                                    Service-Learning).
+                                  </p>
+                                </div>
+                                <div class="row degree-row degree-row-header">
+                                  <div class="col-3">Course #</div>
+                                  <div class="col-7">Title</div>
+                                  <div class="col-2">Credits</div>
+                                </div>
+                                <div
+                                  class="field field--name-field-degree-section-courses field--type-entity-reference field--label-hidden field__items"
+                                >
+                                  <div class="field__item">
+                                    <article
+                                      about="/hospitality/hosp132"
+                                      class="node node--type-class node--view-mode-course-table-item row degree-row"
+                                    >
+                                      <div class="col-3">
+                                        <a href="/hospitality/hosp132"
+                                          >HOSP132</a
+                                        >
+                                      </div>
+                                      <div class="col-7">
+                                        <a href="/hospitality/hosp132">
+                                          <span
+                                            class="field field--name-field-item field--type-string field--label-hidden field__item"
+                                            >Food Service Sanitation</span
+                                          >
+                                        </a>
+                                      </div>
+                                      <div class="col-2">
+                                        <span
+                                          class="field field--name-field-credits field--type-decimal field--label-hidden field__item"
+                                          >1</span
+                                        >
+                                      </div>
+                                    </article>
+                                  </div>
+                                  <div class="field__item">
+                                    <article
+                                      about="/culinary-arts/cubp101"
+                                      class="node node--type-class node--view-mode-course-table-item row degree-row"
+                                    >
+                                      <div class="col-3">
+                                        <a href="/culinary-arts/cubp101"
+                                          >CUBP101</a
+                                        >
+                                      </div>
+                                      <div class="col-7">
+                                        <a href="/culinary-arts/cubp101">
+                                          <span
+                                            class="field field--name-field-item field--type-string field--label-hidden field__item"
+                                            >The Science Behind the
+                                            Ingredients</span
+                                          >
+                                        </a>
+                                      </div>
+                                      <div class="col-2">
+                                        <span
+                                          class="field field--name-field-credits field--type-decimal field--label-hidden field__item"
+                                          >2</span
+                                        >
+                                      </div>
+                                    </article>
+                                  </div>
+                                  <div class="field__item">
+                                    <article
+                                      about="/culinary-arts/cubp110"
+                                      class="node node--type-class node--view-mode-course-table-item row degree-row"
+                                    >
+                                      <div class="col-3">
+                                        <a href="/culinary-arts/cubp110"
+                                          >CUBP110</a
+                                        >
+                                      </div>
+                                      <div class="col-7">
+                                        <a href="/culinary-arts/cubp110">
+                                          <span
+                                            class="field field--name-field-item field--type-string field--label-hidden field__item"
+                                            >Foundations of the Bakeshop</span
+                                          >
+                                        </a>
+                                      </div>
+                                      <div class="col-2">
+                                        <span
+                                          class="field field--name-field-credits field--type-decimal field--label-hidden field__item"
+                                          >2</span
+                                        >
+                                      </div>
+                                    </article>
+                                  </div>
+                                  <div class="field__item">
+                                    <article
+                                      about="/culinary-arts/cubp120"
+                                      class="node node--type-class node--view-mode-course-table-item row degree-row"
+                                    >
+                                      <div class="col-3">
+                                        <a href="/culinary-arts/cubp120"
+                                          >CUBP120</a
+                                        >
+                                      </div>
+                                      <div class="col-7">
+                                        <a href="/culinary-arts/cubp120">
+                                          <span
+                                            class="field field--name-field-item field--type-string field--label-hidden field__item"
+                                            >Introduction to the Art of
+                                            Pastry</span
+                                          >
+                                        </a>
+                                      </div>
+                                      <div class="col-2">
+                                        <span
+                                          class="field field--name-field-credits field--type-decimal field--label-hidden field__item"
+                                          >2</span
+                                        >
+                                      </div>
+                                    </article>
+                                  </div>
+                                  <div class="field__item">
+                                    <article
+                                      about="/culinary-arts/cubp150"
+                                      class="node node--type-class node--view-mode-course-table-item row degree-row"
+                                    >
+                                      <div class="col-3">
+                                        <a href="/culinary-arts/cubp150"
+                                          >CUBP150</a
+                                        >
+                                      </div>
+                                      <div class="col-7">
+                                        <a href="/culinary-arts/cubp150">
+                                          <span
+                                            class="field field--name-field-item field--type-string field--label-hidden field__item"
+                                            >Plated Desserts</span
+                                          >
+                                        </a>
+                                      </div>
+                                      <div class="col-2">
+                                        <span
+                                          class="field field--name-field-credits field--type-decimal field--label-hidden field__item"
+                                          >2</span
+                                        >
+                                      </div>
+                                    </article>
+                                  </div>
+                                  <div class="field__item">
+                                    <article
+                                      about="/culinary-arts/cubp210"
+                                      class="node node--type-class node--view-mode-course-table-item row degree-row"
+                                    >
+                                      <div class="col-3">
+                                        <a href="/culinary-arts/cubp210"
+                                          >CUBP210</a
+                                        >
+                                      </div>
+                                      <div class="col-7">
+                                        <a href="/culinary-arts/cubp210">
+                                          <span
+                                            class="field field--name-field-item field--type-string field--label-hidden field__item"
+                                            >Advanced Baking Techniques</span
+                                          >
+                                        </a>
+                                      </div>
+                                      <div class="col-2">
+                                        <span
+                                          class="field field--name-field-credits field--type-decimal field--label-hidden field__item"
+                                          >2</span
+                                        >
+                                      </div>
+                                    </article>
+                                  </div>
+                                  <div class="field__item">
+                                    <article
+                                      about="/culinary-arts/cubp211"
+                                      class="node node--type-class node--view-mode-course-table-item row degree-row"
+                                    >
+                                      <div class="col-3">
+                                        <a href="/culinary-arts/cubp211"
+                                          >CUBP211</a
+                                        >
+                                      </div>
+                                      <div class="col-7">
+                                        <a href="/culinary-arts/cubp211">
+                                          <span
+                                            class="field field--name-field-item field--type-string field--label-hidden field__item"
+                                            >The Art of Bread Making</span
+                                          >
+                                        </a>
+                                      </div>
+                                      <div class="col-2">
+                                        <span
+                                          class="field field--name-field-credits field--type-decimal field--label-hidden field__item"
+                                          >2</span
+                                        >
+                                      </div>
+                                    </article>
+                                  </div>
+                                  <div class="field__item">
+                                    <article
+                                      about="/culinary-arts/cubp227"
+                                      class="node node--type-class node--view-mode-course-table-item row degree-row"
+                                    >
+                                      <div class="col-3">
+                                        <a href="/culinary-arts/cubp227"
+                                          >CUBP227</a
+                                        >
+                                      </div>
+                                      <div class="col-7">
+                                        <a href="/culinary-arts/cubp227">
+                                          <span
+                                            class="field field--name-field-item field--type-string field--label-hidden field__item"
+                                            >Retail Bakery Production &amp;
+                                            Management</span
+                                          >
+                                        </a>
+                                      </div>
+                                      <div class="col-2">
+                                        <span
+                                          class="field field--name-field-credits field--type-decimal field--label-hidden field__item"
+                                          >3</span
+                                        >
+                                      </div>
+                                    </article>
+                                  </div>
+                                  <div class="field__item">
+                                    <article
+                                      about="/culinary-arts/cubp240"
+                                      class="node node--type-class node--view-mode-course-table-item row degree-row"
+                                    >
+                                      <div class="col-3">
+                                        <a href="/culinary-arts/cubp240"
+                                          >CUBP240</a
+                                        >
+                                      </div>
+                                      <div class="col-7">
+                                        <a href="/culinary-arts/cubp240">
+                                          <span
+                                            class="field field--name-field-item field--type-string field--label-hidden field__item"
+                                            >Borders, Piping and Runouts</span
+                                          >
+                                        </a>
+                                      </div>
+                                      <div class="col-2">
+                                        <span
+                                          class="field field--name-field-credits field--type-decimal field--label-hidden field__item"
+                                          >1</span
+                                        >
+                                      </div>
+                                    </article>
+                                  </div>
+                                  <div class="field__item">
+                                    <article
+                                      about="/culinary-arts/culn111"
+                                      class="node node--type-class node--view-mode-course-table-item row degree-row"
+                                    >
+                                      <div class="col-3">
+                                        <a href="/culinary-arts/culn111"
+                                          >CULN111</a
+                                        >
+                                      </div>
+                                      <div class="col-7">
+                                        <a href="/culinary-arts/culn111">
+                                          <span
+                                            class="field field--name-field-item field--type-string field--label-hidden field__item"
+                                            >Culinary Fundamentals</span
+                                          >
+                                        </a>
+                                      </div>
+                                      <div class="col-2">
+                                        <span
+                                          class="field field--name-field-credits field--type-decimal field--label-hidden field__item"
+                                          >2</span
+                                        >
+                                      </div>
+                                    </article>
+                                  </div>
+                                  <div class="field__item">
+                                    <article
+                                      about="/culinary-arts/culn113"
+                                      class="node node--type-class node--view-mode-course-table-item row degree-row"
+                                    >
+                                      <div class="col-3">
+                                        <a href="/culinary-arts/culn113"
+                                          >CULN113</a
+                                        >
+                                      </div>
+                                      <div class="col-7">
+                                        <a href="/culinary-arts/culn113">
+                                          <span
+                                            class="field field--name-field-item field--type-string field--label-hidden field__item"
+                                            >Fundamentals of Garde Manger</span
+                                          >
+                                        </a>
+                                      </div>
+                                      <div class="col-2">
+                                        <span
+                                          class="field field--name-field-credits field--type-decimal field--label-hidden field__item"
+                                          >2</span
+                                        >
+                                      </div>
+                                    </article>
+                                  </div>
+                                  <div class="field__item">
+                                    <article
+                                      about="/culinary-arts/culn114"
+                                      class="node node--type-class node--view-mode-course-table-item row degree-row"
+                                    >
+                                      <div class="col-3">
+                                        <a href="/culinary-arts/culn114"
+                                          >CULN114</a
+                                        >
+                                      </div>
+                                      <div class="col-7">
+                                        <a href="/culinary-arts/culn114">
+                                          <span
+                                            class="field field--name-field-item field--type-string field--label-hidden field__item"
+                                            >Purchasing, Inventory and Cost
+                                            Management</span
+                                          >
+                                        </a>
+                                      </div>
+                                      <div class="col-2">
+                                        <span
+                                          class="field field--name-field-credits field--type-decimal field--label-hidden field__item"
+                                          >1</span
+                                        >
+                                      </div>
+                                    </article>
+                                  </div>
+                                  <div class="field__item">
+                                    <article
+                                      about="/culinary-arts/culn125"
+                                      class="node node--type-class node--view-mode-course-table-item row degree-row"
+                                    >
+                                      <div class="col-3">
+                                        <a href="/culinary-arts/culn125"
+                                          >CULN125</a
+                                        >
+                                      </div>
+                                      <div class="col-7">
+                                        <a href="/culinary-arts/culn125">
+                                          <span
+                                            class="field field--name-field-item field--type-string field--label-hidden field__item"
+                                            >Kitchen Foundations: Stocks, Soups
+                                            and Sauces</span
+                                          >
+                                        </a>
+                                      </div>
+                                      <div class="col-2">
+                                        <span
+                                          class="field field--name-field-credits field--type-decimal field--label-hidden field__item"
+                                          >2</span
+                                        >
+                                      </div>
+                                    </article>
+                                  </div>
+                                </div>
+                                <div class="row degree-row degree-row-subtotal">
+                                  <div class="col-10">Sub-Total Credits</div>
+                                  <div class="col-2">24.00</div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div class="row degree-row degree-row-total">
+                            <div class="col-10">Total Credits</div>
+                            <div class="col-2">30</div>
+                          </div>
+                          <div
+                            class="field field--name-field-course-sequencing field--type-entity-reference-revisions field--label-above"
+                          >
+                            <div class="field__label">
+                              Recommended Sequence of Courses
+                            </div>
+                            <div class="field__items">
+                              <div class="field__item">
+                                <div class="accordion" id="accordion">
+                                  <div
+                                    class="paragraph paragraph--type--degree-section paragraph--view-mode--default"
+                                  >
+                                    <div class="card-header" id="heading-7051">
+                                      <button
+                                        type="button"
+                                        class="btn accordion-heading bar-heading collapsed"
+                                        style="width: 100%"
+                                        data-bs-toggle="collapse"
+                                        data-bs-target="#collapse-7051"
+                                        aria-expanded="false"
+                                        aria-controls="collapseOne"
+                                      >
+                                        <span
+                                          class="accordion-indicator"
+                                        ></span>
+                                        <h2
+                                          class="field field--name-field-degree-section-title field--type-string field--label-hidden field__item"
+                                        >
+                                          First Semester
+                                        </h2>
+                                      </button>
+                                    </div>
+                                    <div
+                                      id="collapse-7051"
+                                      class="collapse"
+                                      aria-labelledby="heading-7051"
+                                      data-parent="#accordion"
+                                    >
+                                      <div class="card-body">
+                                        <div
+                                          class="row degree-row degree-row-header"
+                                        >
+                                          <div class="col-3">Course #</div>
+                                          <div class="col-7">Title</div>
+                                          <div class="col-2">Credits</div>
+                                        </div>
+                                        <div
+                                          class="field field--name-field-degree-section-courses field--type-entity-reference field--label-hidden field__items"
+                                        >
+                                          <div class="field__item">
+                                            <article
+                                              about="/english/engl101"
+                                              class="node node--type-class node--view-mode-course-table-item row degree-row"
+                                            >
+                                              <div class="col-3">
+                                                <a href="/english/engl101"
+                                                  >ENGL101</a
+                                                >
+                                              </div>
+                                              <div class="col-7">
+                                                <a href="/english/engl101">
+                                                  <span
+                                                    class="field field--name-field-item field--type-string field--label-hidden field__item"
+                                                    >Composition I</span
+                                                  >
+                                                </a>
+                                              </div>
+                                              <div class="col-2">
+                                                <span
+                                                  class="field field--name-field-credits field--type-decimal field--label-hidden field__item"
+                                                  >3</span
+                                                >
+                                              </div>
+                                            </article>
+                                          </div>
+                                          <div class="field__item">
+                                            <article
+                                              about="/hospitality/hosp132"
+                                              class="node node--type-class node--view-mode-course-table-item row degree-row"
+                                            >
+                                              <div class="col-3">
+                                                <a href="/hospitality/hosp132"
+                                                  >HOSP132</a
+                                                >
+                                              </div>
+                                              <div class="col-7">
+                                                <a href="/hospitality/hosp132">
+                                                  <span
+                                                    class="field field--name-field-item field--type-string field--label-hidden field__item"
+                                                    >Food Service
+                                                    Sanitation</span
+                                                  >
+                                                </a>
+                                              </div>
+                                              <div class="col-2">
+                                                <span
+                                                  class="field field--name-field-credits field--type-decimal field--label-hidden field__item"
+                                                  >1</span
+                                                >
+                                              </div>
+                                            </article>
+                                          </div>
+                                          <div class="field__item">
+                                            <article
+                                              about="/culinary-arts/culn111"
+                                              class="node node--type-class node--view-mode-course-table-item row degree-row"
+                                            >
+                                              <div class="col-3">
+                                                <a href="/culinary-arts/culn111"
+                                                  >CULN111</a
+                                                >
+                                              </div>
+                                              <div class="col-7">
+                                                <a
+                                                  href="/culinary-arts/culn111"
+                                                >
+                                                  <span
+                                                    class="field field--name-field-item field--type-string field--label-hidden field__item"
+                                                    >Culinary Fundamentals</span
+                                                  >
+                                                </a>
+                                              </div>
+                                              <div class="col-2">
+                                                <span
+                                                  class="field field--name-field-credits field--type-decimal field--label-hidden field__item"
+                                                  >2</span
+                                                >
+                                              </div>
+                                            </article>
+                                          </div>
+                                          <div class="field__item">
+                                            <article
+                                              about="/culinary-arts/cubp101"
+                                              class="node node--type-class node--view-mode-course-table-item row degree-row"
+                                            >
+                                              <div class="col-3">
+                                                <a href="/culinary-arts/cubp101"
+                                                  >CUBP101</a
+                                                >
+                                              </div>
+                                              <div class="col-7">
+                                                <a
+                                                  href="/culinary-arts/cubp101"
+                                                >
+                                                  <span
+                                                    class="field field--name-field-item field--type-string field--label-hidden field__item"
+                                                    >The Science Behind the
+                                                    Ingredients</span
+                                                  >
+                                                </a>
+                                              </div>
+                                              <div class="col-2">
+                                                <span
+                                                  class="field field--name-field-credits field--type-decimal field--label-hidden field__item"
+                                                  >2</span
+                                                >
+                                              </div>
+                                            </article>
+                                          </div>
+                                          <div class="field__item">
+                                            <article
+                                              about="/culinary-arts/cubp110"
+                                              class="node node--type-class node--view-mode-course-table-item row degree-row"
+                                            >
+                                              <div class="col-3">
+                                                <a href="/culinary-arts/cubp110"
+                                                  >CUBP110</a
+                                                >
+                                              </div>
+                                              <div class="col-7">
+                                                <a
+                                                  href="/culinary-arts/cubp110"
+                                                >
+                                                  <span
+                                                    class="field field--name-field-item field--type-string field--label-hidden field__item"
+                                                    >Foundations of the
+                                                    Bakeshop</span
+                                                  >
+                                                </a>
+                                              </div>
+                                              <div class="col-2">
+                                                <span
+                                                  class="field field--name-field-credits field--type-decimal field--label-hidden field__item"
+                                                  >2</span
+                                                >
+                                              </div>
+                                            </article>
+                                          </div>
+                                          <div class="field__item">
+                                            <article
+                                              about="/culinary-arts/cubp210"
+                                              class="node node--type-class node--view-mode-course-table-item row degree-row"
+                                            >
+                                              <div class="col-3">
+                                                <a href="/culinary-arts/cubp210"
+                                                  >CUBP210</a
+                                                >
+                                              </div>
+                                              <div class="col-7">
+                                                <a
+                                                  href="/culinary-arts/cubp210"
+                                                >
+                                                  <span
+                                                    class="field field--name-field-item field--type-string field--label-hidden field__item"
+                                                    >Advanced Baking
+                                                    Techniques</span
+                                                  >
+                                                </a>
+                                              </div>
+                                              <div class="col-2">
+                                                <span
+                                                  class="field field--name-field-credits field--type-decimal field--label-hidden field__item"
+                                                  >2</span
+                                                >
+                                              </div>
+                                            </article>
+                                          </div>
+                                          <div class="field__item">
+                                            <article
+                                              about="/culinary-arts/cubp120"
+                                              class="node node--type-class node--view-mode-course-table-item row degree-row"
+                                            >
+                                              <div class="col-3">
+                                                <a href="/culinary-arts/cubp120"
+                                                  >CUBP120</a
+                                                >
+                                              </div>
+                                              <div class="col-7">
+                                                <a
+                                                  href="/culinary-arts/cubp120"
+                                                >
+                                                  <span
+                                                    class="field field--name-field-item field--type-string field--label-hidden field__item"
+                                                    >Introduction to the Art of
+                                                    Pastry</span
+                                                  >
+                                                </a>
+                                              </div>
+                                              <div class="col-2">
+                                                <span
+                                                  class="field field--name-field-credits field--type-decimal field--label-hidden field__item"
+                                                  >2</span
+                                                >
+                                              </div>
+                                            </article>
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="row degree-row degree-row-subtotal"
+                                        >
+                                          <div class="col-10">
+                                            Sub-Total Credits
+                                          </div>
+                                          <div class="col-2">14.00</div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                              <div class="field__item">
+                                <div class="accordion" id="accordion">
+                                  <div
+                                    class="paragraph paragraph--type--degree-section paragraph--view-mode--default"
+                                  >
+                                    <div class="card-header" id="heading-7052">
+                                      <button
+                                        type="button"
+                                        class="btn accordion-heading bar-heading collapsed"
+                                        style="width: 100%"
+                                        data-bs-toggle="collapse"
+                                        data-bs-target="#collapse-7052"
+                                        aria-expanded="false"
+                                        aria-controls="collapseOne"
+                                      >
+                                        <span
+                                          class="accordion-indicator"
+                                        ></span>
+                                        <h2
+                                          class="field field--name-field-degree-section-title field--type-string field--label-hidden field__item"
+                                        >
+                                          Second Semester
+                                        </h2>
+                                      </button>
+                                    </div>
+                                    <div
+                                      id="collapse-7052"
+                                      class="collapse"
+                                      aria-labelledby="heading-7052"
+                                      data-parent="#accordion"
+                                    >
+                                      <div class="card-body">
+                                        <div
+                                          class="row degree-row degree-row-header"
+                                        >
+                                          <div class="col-3">Course #</div>
+                                          <div class="col-7">Title</div>
+                                          <div class="col-2">Credits</div>
+                                        </div>
+                                        <div
+                                          class="field field--name-field-degree-section-courses field--type-entity-reference field--label-hidden field__items"
+                                        >
+                                          <div class="field__item">
+                                            <article
+                                              about="/computer-information-systems/cism125"
+                                              class="node node--type-class node--view-mode-course-table-item row degree-row"
+                                            >
+                                              <div class="col-3">
+                                                <a
+                                                  href="/computer-information-systems/cism125"
+                                                  >CISM125</a
+                                                >
+                                              </div>
+                                              <div class="col-7">
+                                                <a
+                                                  href="/computer-information-systems/cism125"
+                                                >
+                                                  <span
+                                                    class="field field--name-field-item field--type-string field--label-hidden field__item"
+                                                    >Introduction to
+                                                    Computers</span
+                                                  >
+                                                </a>
+                                              </div>
+                                              <div class="col-2">
+                                                <span
+                                                  class="field field--name-field-credits field--type-decimal field--label-hidden field__item"
+                                                  >3</span
+                                                >
+                                              </div>
+                                            </article>
+                                          </div>
+                                          <div class="field__item">
+                                            <article
+                                              about="/culinary-arts/culn125"
+                                              class="node node--type-class node--view-mode-course-table-item row degree-row"
+                                            >
+                                              <div class="col-3">
+                                                <a href="/culinary-arts/culn125"
+                                                  >CULN125</a
+                                                >
+                                              </div>
+                                              <div class="col-7">
+                                                <a
+                                                  href="/culinary-arts/culn125"
+                                                >
+                                                  <span
+                                                    class="field field--name-field-item field--type-string field--label-hidden field__item"
+                                                    >Kitchen Foundations:
+                                                    Stocks, Soups and
+                                                    Sauces</span
+                                                  >
+                                                </a>
+                                              </div>
+                                              <div class="col-2">
+                                                <span
+                                                  class="field field--name-field-credits field--type-decimal field--label-hidden field__item"
+                                                  >2</span
+                                                >
+                                              </div>
+                                            </article>
+                                          </div>
+                                          <div class="field__item">
+                                            <article
+                                              about="/culinary-arts/cubp211"
+                                              class="node node--type-class node--view-mode-course-table-item row degree-row"
+                                            >
+                                              <div class="col-3">
+                                                <a href="/culinary-arts/cubp211"
+                                                  >CUBP211</a
+                                                >
+                                              </div>
+                                              <div class="col-7">
+                                                <a
+                                                  href="/culinary-arts/cubp211"
+                                                >
+                                                  <span
+                                                    class="field field--name-field-item field--type-string field--label-hidden field__item"
+                                                    >The Art of Bread
+                                                    Making</span
+                                                  >
+                                                </a>
+                                              </div>
+                                              <div class="col-2">
+                                                <span
+                                                  class="field field--name-field-credits field--type-decimal field--label-hidden field__item"
+                                                  >2</span
+                                                >
+                                              </div>
+                                            </article>
+                                          </div>
+                                          <div class="field__item">
+                                            <article
+                                              about="/culinary-arts/cubp150"
+                                              class="node node--type-class node--view-mode-course-table-item row degree-row"
+                                            >
+                                              <div class="col-3">
+                                                <a href="/culinary-arts/cubp150"
+                                                  >CUBP150</a
+                                                >
+                                              </div>
+                                              <div class="col-7">
+                                                <a
+                                                  href="/culinary-arts/cubp150"
+                                                >
+                                                  <span
+                                                    class="field field--name-field-item field--type-string field--label-hidden field__item"
+                                                    >Plated Desserts</span
+                                                  >
+                                                </a>
+                                              </div>
+                                              <div class="col-2">
+                                                <span
+                                                  class="field field--name-field-credits field--type-decimal field--label-hidden field__item"
+                                                  >2</span
+                                                >
+                                              </div>
+                                            </article>
+                                          </div>
+                                          <div class="field__item">
+                                            <article
+                                              about="/culinary-arts/culn113"
+                                              class="node node--type-class node--view-mode-course-table-item row degree-row"
+                                            >
+                                              <div class="col-3">
+                                                <a href="/culinary-arts/culn113"
+                                                  >CULN113</a
+                                                >
+                                              </div>
+                                              <div class="col-7">
+                                                <a
+                                                  href="/culinary-arts/culn113"
+                                                >
+                                                  <span
+                                                    class="field field--name-field-item field--type-string field--label-hidden field__item"
+                                                    >Fundamentals of Garde
+                                                    Manger</span
+                                                  >
+                                                </a>
+                                              </div>
+                                              <div class="col-2">
+                                                <span
+                                                  class="field field--name-field-credits field--type-decimal field--label-hidden field__item"
+                                                  >2</span
+                                                >
+                                              </div>
+                                            </article>
+                                          </div>
+                                          <div class="field__item">
+                                            <article
+                                              about="/culinary-arts/cubp240"
+                                              class="node node--type-class node--view-mode-course-table-item row degree-row"
+                                            >
+                                              <div class="col-3">
+                                                <a href="/culinary-arts/cubp240"
+                                                  >CUBP240</a
+                                                >
+                                              </div>
+                                              <div class="col-7">
+                                                <a
+                                                  href="/culinary-arts/cubp240"
+                                                >
+                                                  <span
+                                                    class="field field--name-field-item field--type-string field--label-hidden field__item"
+                                                    >Borders, Piping and
+                                                    Runouts</span
+                                                  >
+                                                </a>
+                                              </div>
+                                              <div class="col-2">
+                                                <span
+                                                  class="field field--name-field-credits field--type-decimal field--label-hidden field__item"
+                                                  >1</span
+                                                >
+                                              </div>
+                                            </article>
+                                          </div>
+                                          <div class="field__item">
+                                            <article
+                                              about="/culinary-arts/culn114"
+                                              class="node node--type-class node--view-mode-course-table-item row degree-row"
+                                            >
+                                              <div class="col-3">
+                                                <a href="/culinary-arts/culn114"
+                                                  >CULN114</a
+                                                >
+                                              </div>
+                                              <div class="col-7">
+                                                <a
+                                                  href="/culinary-arts/culn114"
+                                                >
+                                                  <span
+                                                    class="field field--name-field-item field--type-string field--label-hidden field__item"
+                                                    >Purchasing, Inventory and
+                                                    Cost Management</span
+                                                  >
+                                                </a>
+                                              </div>
+                                              <div class="col-2">
+                                                <span
+                                                  class="field field--name-field-credits field--type-decimal field--label-hidden field__item"
+                                                  >1</span
+                                                >
+                                              </div>
+                                            </article>
+                                          </div>
+                                          <div class="field__item">
+                                            <article
+                                              about="/culinary-arts/cubp227"
+                                              class="node node--type-class node--view-mode-course-table-item row degree-row"
+                                            >
+                                              <div class="col-3">
+                                                <a href="/culinary-arts/cubp227"
+                                                  >CUBP227</a
+                                                >
+                                              </div>
+                                              <div class="col-7">
+                                                <a
+                                                  href="/culinary-arts/cubp227"
+                                                >
+                                                  <span
+                                                    class="field field--name-field-item field--type-string field--label-hidden field__item"
+                                                    >Retail Bakery Production
+                                                    &amp; Management</span
+                                                  >
+                                                </a>
+                                              </div>
+                                              <div class="col-2">
+                                                <span
+                                                  class="field field--name-field-credits field--type-decimal field--label-hidden field__item"
+                                                  >3</span
+                                                >
+                                              </div>
+                                            </article>
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="row degree-row degree-row-subtotal"
+                                        >
+                                          <div class="col-10">
+                                            Sub-Total Credits
+                                          </div>
+                                          <div class="col-2">16.00</div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </article>
+              </div>
+            </div>
+          </main>
+        </div>
+      </div>
+      <footer role="contentinfo" class="site-footer">
+        <div class="footer-top">
+          <div class="container">
+            <div class="row">
+              <div class="col-6">
+                <a class="footer-logo" href="/">
+                  <img
+                    src="/themes/custom/atlantic21/images/logo.png"
+                    alt="Atlantic Cape Community College catalog"
+                  />
+                </a>
+              </div>
+              <div class="col-6">
+                <div class="site-footer-menu">
+                  <div class="region region-footer">
+                    <nav
+                      role="navigation"
+                      aria-labelledby="block-atlantic21-aatlantic21ount-menu-menu"
+                      id="block-atlantic21-aatlantic21ount-menu"
+                    >
+                      <h2
+                        class="visually-hidden"
+                        id="block-atlantic21-aatlantic21ount-menu-menu"
+                      >
+                        User account menu
+                      </h2>
+                      <ul>
+                        <li>
+                          <a
+                            href="/user/login"
+                            data-drupal-link-system-path="user/login"
+                            >Staff Login</a
+                          >
+                        </li>
+                      </ul>
+                    </nav>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <small class="footer-copyright"
+              >© 2025 Atlantic Cape Community College</small
+            >
+          </div>
+        </div>
+        <div class="container footer-bottom">
+          <small class="footer-cc-link">
+            <a href="https://cleancatalog.com/" target="_blank"
+              >Course Catalog Software by Clean Catalog</a
+            >
+          </small>
+        </div>
+      </footer>
+    </div>
+    <script type="application/json" data-drupal-selector="drupal-settings-json">
+      {
+        "path": {
+          "baseUrl": "\/",
+          "pathPrefix": "",
+          "currentPath": "node\/756",
+          "currentPathIsAdmin": false,
+          "isFront": false,
+          "currentLanguage": "en"
+        },
+        "pluralDelimiter": "\u0003",
+        "suppressDeprecationErrors": true,
+        "field_group": {
+          "html_element": {
+            "mode": "default",
+            "context": "view",
+            "settings": {
+              "classes": "",
+              "show_empty_fields": false,
+              "id": "",
+              "element": "div",
+              "show_label": false,
+              "label_element": "h3",
+              "label_element_classes": "",
+              "attributes": "",
+              "effect": "none",
+              "speed": "fast"
+            }
+          }
+        },
+        "ajaxTrustedUrl": { "\/search": true },
+        "user": {
+          "uid": 0,
+          "permissionsHash": "36fa418e4112626dc2c5846be86977b72cc75acf4f7597f77066ba103be15b3d"
+        }
+      }
+    </script>
+    <script src="/sites/default/files/js/js_1exA4Ufr85ZH6wELYx3sYwk_Ynt_0GUYrsOUqNxExCU.js?scope=footer&amp;delta=0&amp;language=en&amp;theme=atlantic21&amp;include=eJxLTjYyMDLUTy4tLsnP1UlOjk-tKEktykvMic_JzMsu1scQAakpzkxJTUos0kcwQaIlGam5qfrJGanJ2fEFKWkQ5QDVkiTE"></script>
+  </body>
+</html>

--- a/server/tests/fixtures/doc_simplified.md
+++ b/server/tests/fixtures/doc_simplified.md
@@ -1,0 +1,313 @@
+[Skip to main content](#main-content)
+
+[](/)
+
+College Catalog
+
+Main navigation
+---------------
+
+*   [Catalog Home](/)
+*   [Degrees & Certificates](/degrees)
+*   [Courses](/classes)
+*   [Student Handbook](/student-handbook)
+*   [Archived Catalogs](/#pdf-links)
+
+Breadcrumb
+----------
+
+1.  [Home](/)
+2.  [Culinary Arts](/culinary-arts)
+3.  Baking and Pastry I
+
+Certificate
+
+Baking and Pastry I
+===================
+
+[Download as PDF](/node/756/download-pdf)
+
+Program
+
+[Culinary Arts](/culinary-arts)
+
+This two semester certificate program is designed to provide students with career training for entry-level positions in baking and pastry. The certificate can also be used as a foundation for completing the Baking and Pastry Option in Culinary Arts, A.A.S. degree at the Academy of Culinary Arts.
+
+In addition to coursework, students are required to complete 200 hours of documented work experience (Cooperative Education, Internship, Externship or Service-Learning).
+
+For additional program information, please contact the Culinary department at (609) 343-4944.
+
+Upon completion of this program students will be able to:
+
+*   Demonstrate an understanding of professionalism and exceptional work ethics;
+*   Work effectively in teams;
+*   Explain the environmental and conservation issues related to the culinary industries;
+*   Demonstrate the knowledge and skills appropriate for entry-level positions in the baking and pastry culinary field;
+*   Articulate the need and value of life-long learning as it relates to career goals;
+*   Compare and contrast traditional and non-traditional career opportunities;
+*   Demonstrate industry sanitation standards;
+*   Demonstrate industry equipment safety standards;
+*   Demonstrate effective communication and computation skills;
+*   Apply baking theories;
+*   Create classic and artisan yeast products, quick breads and puff dough;
+*   Create classical and decorative pastries;
+*   Evaluate and interpret menus and recipes in terms of human nutrition and apply principles in menu planning and food preparation;
+*   Apply basic culinary cooking methods.
+
+(_BKPI-Fall_ 2022)
+
+General Education Courses
+-------------------------
+
+Communication
+-------------
+
+Course #
+
+Title
+
+Credits
+
+[ENGL101](/english/engl101)
+
+[Composition I](/english/engl101)
+
+3
+
+Sub-Total Credits
+
+3.00
+
+Mathematics-Science-Technology
+------------------------------
+
+Course #
+
+Title
+
+Credits
+
+[CISM125](/computer-information-systems/cism125)
+
+[Introduction to Computers](/computer-information-systems/cism125)
+
+3
+
+Sub-Total Credits
+
+3.00
+
+Program Courses
+---------------
+
+Note: In addition to coursework, students are required to complete 200 hours of documented work experience (Cooperative Education, Internship, Externship or Service-Learning).
+
+Course #
+
+Title
+
+Credits
+
+[HOSP132](/hospitality/hosp132)
+
+[Food Service Sanitation](/hospitality/hosp132)
+
+1
+
+[CUBP101](/culinary-arts/cubp101)
+
+[The Science Behind the Ingredients](/culinary-arts/cubp101)
+
+2
+
+[CUBP110](/culinary-arts/cubp110)
+
+[Foundations of the Bakeshop](/culinary-arts/cubp110)
+
+2
+
+[CUBP120](/culinary-arts/cubp120)
+
+[Introduction to the Art of Pastry](/culinary-arts/cubp120)
+
+2
+
+[CUBP150](/culinary-arts/cubp150)
+
+[Plated Desserts](/culinary-arts/cubp150)
+
+2
+
+[CUBP210](/culinary-arts/cubp210)
+
+[Advanced Baking Techniques](/culinary-arts/cubp210)
+
+2
+
+[CUBP211](/culinary-arts/cubp211)
+
+[The Art of Bread Making](/culinary-arts/cubp211)
+
+2
+
+[CUBP227](/culinary-arts/cubp227)
+
+[Retail Bakery Production & Management](/culinary-arts/cubp227)
+
+3
+
+[CUBP240](/culinary-arts/cubp240)
+
+[Borders, Piping and Runouts](/culinary-arts/cubp240)
+
+1
+
+[CULN111](/culinary-arts/culn111)
+
+[Culinary Fundamentals](/culinary-arts/culn111)
+
+2
+
+[CULN113](/culinary-arts/culn113)
+
+[Fundamentals of Garde Manger](/culinary-arts/culn113)
+
+2
+
+[CULN114](/culinary-arts/culn114)
+
+[Purchasing, Inventory and Cost Management](/culinary-arts/culn114)
+
+1
+
+[CULN125](/culinary-arts/culn125)
+
+[Kitchen Foundations: Stocks, Soups and Sauces](/culinary-arts/culn125)
+
+2
+
+Sub-Total Credits
+
+24.00
+
+Total Credits
+
+30
+
+Recommended Sequence of Courses
+
+First Semester
+--------------
+
+Course #
+
+Title
+
+Credits
+
+[ENGL101](/english/engl101)
+
+[Composition I](/english/engl101)
+
+3
+
+[HOSP132](/hospitality/hosp132)
+
+[Food Service Sanitation](/hospitality/hosp132)
+
+1
+
+[CULN111](/culinary-arts/culn111)
+
+[Culinary Fundamentals](/culinary-arts/culn111)
+
+2
+
+[CUBP101](/culinary-arts/cubp101)
+
+[The Science Behind the Ingredients](/culinary-arts/cubp101)
+
+2
+
+[CUBP110](/culinary-arts/cubp110)
+
+[Foundations of the Bakeshop](/culinary-arts/cubp110)
+
+2
+
+[CUBP210](/culinary-arts/cubp210)
+
+[Advanced Baking Techniques](/culinary-arts/cubp210)
+
+2
+
+[CUBP120](/culinary-arts/cubp120)
+
+[Introduction to the Art of Pastry](/culinary-arts/cubp120)
+
+2
+
+Sub-Total Credits
+
+14.00
+
+Second Semester
+---------------
+
+Course #
+
+Title
+
+Credits
+
+[CISM125](/computer-information-systems/cism125)
+
+[Introduction to Computers](/computer-information-systems/cism125)
+
+3
+
+[CULN125](/culinary-arts/culn125)
+
+[Kitchen Foundations: Stocks, Soups and Sauces](/culinary-arts/culn125)
+
+2
+
+[CUBP211](/culinary-arts/cubp211)
+
+[The Art of Bread Making](/culinary-arts/cubp211)
+
+2
+
+[CUBP150](/culinary-arts/cubp150)
+
+[Plated Desserts](/culinary-arts/cubp150)
+
+2
+
+[CULN113](/culinary-arts/culn113)
+
+[Fundamentals of Garde Manger](/culinary-arts/culn113)
+
+2
+
+[CUBP240](/culinary-arts/cubp240)
+
+[Borders, Piping and Runouts](/culinary-arts/cubp240)
+
+1
+
+[CULN114](/culinary-arts/culn114)
+
+[Purchasing, Inventory and Cost Management](/culinary-arts/culn114)
+
+1
+
+[CUBP227](/culinary-arts/cubp227)
+
+[Retail Bakery Production & Management](/culinary-arts/cubp227)
+
+3
+
+Sub-Total Credits
+
+16.00

--- a/server/tests/index.ts
+++ b/server/tests/index.ts
@@ -6,17 +6,17 @@ import {
   LearningProgramStructuredData,
   RecipeConfiguration,
 } from "../../common/types";
+import { findCrawlPageByUrl } from "../src/data/extractions";
+import { readContent, readScreenshot } from "../src/data/schema";
 import {
   fetchBrowserPage,
   simplifiedMarkdown,
 } from "../src/extraction/browser";
 import { getCatalogueTypeDefinition } from "../src/extraction/catalogueTypes";
-import { extractAndVerifyEntityData } from "../src/extraction/llm/extractAndVerifyEntityData";
-import { exploreAdditionalPages } from "../src/extraction/llm/exploreAdditionalPages";
-import recursivelyDetectConfiguration from "../src/extraction/recursivelyDetectConfiguration";
-import { readContent, readScreenshot } from "../src/data/schema";
-import { findCrawlPageByUrl } from "../src/data/extractions";
 import { determinePresenceOfEntity } from "../src/extraction/llm/determinePresenceOfEntity";
+import { exploreAdditionalPages } from "../src/extraction/llm/exploreAdditionalPages";
+import { extractAndVerifyEntityData } from "../src/extraction/llm/extractAndVerifyEntityData";
+import recursivelyDetectConfiguration from "../src/extraction/recursivelyDetectConfiguration";
 
 export const EXTRACTION_TIMEOUT = 1000 * 60 * 10;
 
@@ -34,7 +34,10 @@ async function getPageWithFallback(url: string) {
   try {
     page = await findCrawlPageByUrl(url);
   } catch (e) {
-    console.error(`Page ${url} not found in database, fetching from browser`, e);
+    console.error(
+      `Page ${url} not found in database, fetching from browser`,
+      e
+    );
   }
 
   if (page?.content) {
@@ -228,55 +231,55 @@ export async function assertExtraction<
       }
     }
   }
+  return extractions;
 }
 
-export async function extractCompetencies(
-  url: string,
-) {
-  const page = await fetchBrowserPage(url)
-    .then(page => page.content
-      ? page
-      : Promise.reject(new Error(`Page ${url} not found`))
-    );
+export async function extractCompetencies(url: string) {
+  const page = await fetchBrowserPage(url).then((page) =>
+    page.content ? page : Promise.reject(new Error(`Page ${url} not found`))
+  );
   const simplifiedContent = await simplifiedMarkdown(page.content);
-  
+
   const extractionOptions = {
     content: simplifiedContent,
     url: page.url,
     screenshot: page.screenshot,
     catalogueType: CatalogueType.COMPETENCIES,
   };
-  
+
   // Check if competencies are present on the page
   const entityDef = getCatalogueTypeDefinition(CatalogueType.COMPETENCIES);
   if (entityDef.presencePrompt) {
-    const presenceResult = await determinePresenceOfEntity(extractionOptions, entityDef);
+    const presenceResult = await determinePresenceOfEntity(
+      extractionOptions,
+      entityDef
+    );
     if (!presenceResult.present) {
       return []; // Return empty array if no competencies are present
     }
   }
-  
+
   const extractions = await extractAndVerifyEntityData(extractionOptions);
-  return extractions.map(e => e.entity);
+  return extractions.map((e) => e.entity);
 }
 
 export async function detectExploratoryPages(
   url: string,
   catalogueType: CatalogueType = CatalogueType.COMPETENCIES
 ) {
-  const page = await getPageWithFallback(url)
-    .then(page => page.content
-      ? page
-      : Promise.reject(new Error(`Page ${url} not found`))
-    );
+  const page = await getPageWithFallback(url).then((page) =>
+    page.content ? page : Promise.reject(new Error(`Page ${url} not found`))
+  );
   const simplifiedContent = await simplifiedMarkdown(page.content);
-  
-  const { data: urls } = await exploreAdditionalPages({
-    url: page.url,
-    content: simplifiedContent,
-    screenshot: page.screenshot,
-  }, catalogueType);
+
+  const { data: urls } = await exploreAdditionalPages(
+    {
+      url: page.url,
+      content: simplifiedContent,
+      screenshot: page.screenshot,
+    },
+    catalogueType
+  );
 
   return urls;
 }
-


### PR DESCRIPTION
Addresses #74, #73, #72, #81

- Do not show duplicate IDs in CSV exports
- Keep `header` elements when simplifying HTML
- Drop `form` and `iframe` elements
- In the learning program extraction prompt, encourage the model to focus on the first few paragraphs of the description
- Improve extraction for long single-page catalogues