### PR TITLE
Update extraction status more quickly after completion

### DIFF
--- a/server/src/extraction/retryFailedItems.ts
+++ b/server/src/extraction/retryFailedItems.ts
@@ -4,7 +4,12 @@ import {
   findFailedAndNoDataPageIds,
   updateExtraction,
 } from "../data/extractions";
-import { Queues, submitJobs, submitRepeatableJob } from "../workers";
+import {
+  Queues,
+  REPEAT_UPDATE_COMPLETION_EVERY_MS,
+  submitJobs,
+  submitRepeatableJob,
+} from "../workers";
 
 export async function retryFailedItems(extractionId: number) {
   const extraction = await findExtractionById(extractionId);
@@ -37,7 +42,7 @@ export async function retryFailedItems(extractionId: number) {
   await submitJobs(
     Queues.FetchPage,
     pageIds.map((id) => ({
-      data: { crawlPageId: id },
+      data: { crawlPageId: id, extractionId },
       options: { jobId: `fetchPage.${id}` },
     }))
   );
@@ -45,7 +50,7 @@ export async function retryFailedItems(extractionId: number) {
     Queues.UpdateExtractionCompletion,
     { extractionId: extraction.id },
     `updateExtractionCompletion.${extraction.id}`,
-    { every: 5 * 60 * 1000 }
+    { every: REPEAT_UPDATE_COMPLETION_EVERY_MS }
   );
   return;
 }

--- a/server/src/extraction/startExtraction.ts
+++ b/server/src/extraction/startExtraction.ts
@@ -2,7 +2,12 @@ import { RecipeDetectionStatus, Step } from "../../../common/types";
 import { findCatalogueById } from "../data/catalogues";
 import { createExtraction, createPage, createStep } from "../data/extractions";
 import { extractions, recipes } from "../data/schema";
-import { Queues, submitJob, submitRepeatableJob } from "../workers";
+import {
+  Queues,
+  REPEAT_UPDATE_COMPLETION_EVERY_MS,
+  submitJob,
+  submitRepeatableJob,
+} from "../workers";
 
 export async function startExtraction(catalogueId: number, recipeId: number) {
   const catalogue = await findCatalogueById(catalogueId);
@@ -43,14 +48,14 @@ async function launchLLMExtraction(
   });
   submitJob(
     Queues.FetchPage,
-    { crawlPageId: crawlPage.id },
+    { crawlPageId: crawlPage.id, extractionId: extraction.id },
     `fetchPage.${crawlPage.id}`
   );
   submitRepeatableJob(
     Queues.UpdateExtractionCompletion,
     { extractionId: extraction.id },
     `updateExtractionCompletion.${extraction.id}`,
-    { every: 5 * 60 * 1000 }
+    { every: REPEAT_UPDATE_COMPLETION_EVERY_MS }
   );
 }
 
@@ -72,13 +77,13 @@ async function launchAPIExtraction(
   });
   submitJob(
     Queues.ExtractDataWithAPI,
-    { crawlPageId: crawlPage.id },
+    { crawlPageId: crawlPage.id, extractionId: extraction.id },
     `extractWithApi.${crawlPage.id}`
   );
   submitRepeatableJob(
     Queues.UpdateExtractionCompletion,
     { extractionId: extraction.id },
     `updateExtractionCompletion.${extraction.id}`,
-    { every: 5 * 60 * 1000 }
+    { every: REPEAT_UPDATE_COMPLETION_EVERY_MS }
   );
 }

--- a/server/src/workers/extractData.ts
+++ b/server/src/workers/extractData.ts
@@ -160,7 +160,10 @@ export default createProcessor<ExtractDataJob, ExtractDataProgress>(
             await submitJobs(
               Queues.FetchPage,
               stepAndPages.pages.map((page) => ({
-                data: { crawlPageId: page.id },
+                data: {
+                  crawlPageId: page.id,
+                  extractionId: crawlPage.extractionId,
+                },
                 options: {
                   jobId: `fetchPage.${page.id}`,
                   lifo: true,

--- a/server/src/workers/fetchPage.ts
+++ b/server/src/workers/fetchPage.ts
@@ -64,7 +64,7 @@ async function enqueueExtraction(
   logger.info(`Enqueuing extraction for page ${crawlPage.url}`);
   return submitJob(
     Queues.ExtractData,
-    { crawlPageId: crawlPage.id },
+    { crawlPageId: crawlPage.id, extractionId: crawlPage.extractionId },
     `extractData.${crawlPage.id}`
   );
 }
@@ -125,7 +125,7 @@ async function enqueuePages(
   await submitJobs(
     Queues.FetchPage,
     stepAndPages.pages.map((page) => ({
-      data: { crawlPageId: page.id },
+      data: { crawlPageId: page.id, extractionId: crawlPage.extractionId },
       options: { jobId: `fetchPage.${page.id}`, lifo: true },
     })),
     delayOptions
@@ -175,7 +175,10 @@ async function processLinks(
   await submitJobs(
     Queues.FetchPage,
     stepAndPages.pages.map((page) => ({
-      data: { crawlPageId: page.id },
+      data: {
+        crawlPageId: page.id,
+        extractionId: crawlPage.extractionId,
+      },
       options: {
         jobId: `fetchPage.${page.id}`,
         lifo: true,


### PR DESCRIPTION
Currently we wait for an hour after the extraction apparently completes for it to 'settle' before marking it as completed or stale.

We can improve on this by querying Bull MQ's jobs - if there are pending jobs for the current extraction, we keep waiting, otherwise we can mark it as completed.