### PR TITLE
Refine Credential description prompts and allow catalgues to be searchable by their URL 

### DIFF
--- a/client/src/components/app/catalogues/index.tsx
+++ b/client/src/components/app/catalogues/index.tsx
@@ -115,7 +115,7 @@ export default function Catalogues() {
         <div className="relative flex-1">
           <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
           <Input
-            placeholder="Search catalogues..."
+            placeholder="Search catalogues by name or URL..."
             className="pl-8"
             onChange={(e) => debouncedSetSearch(e.target.value)}
           />

--- a/server/src/data/catalogues.ts
+++ b/server/src/data/catalogues.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, ilike, sql } from "drizzle-orm";
+import { and, desc, eq, ilike, or, sql } from "drizzle-orm";
 import { CatalogueType } from "../../../common/types";
 import db from "../data";
 import { catalogues, extractions, recipes } from "../data/schema";
@@ -22,7 +22,10 @@ export async function getCatalogueCount(
           ? eq(catalogues.catalogueType, options.catalogueType)
           : undefined,
         options.search
-          ? ilike(catalogues.name, `%${options.search}%`)
+          ? or(
+              ilike(catalogues.name, `%${options.search}%`),
+              ilike(catalogues.url, `%${options.search}%`)
+            )
           : undefined
       )
     );
@@ -82,7 +85,12 @@ export async function findCatalogues(options: FindCatalogueOptions) {
     },
     where: and(
       catalogueType ? eq(catalogues.catalogueType, catalogueType) : undefined,
-      search ? ilike(catalogues.name, `%${search}%`) : undefined
+      search
+        ? or(
+            ilike(catalogues.name, `%${search}%`),
+            ilike(catalogues.url, `%${search}%`)
+          )
+        : undefined
     ),
   });
 }

--- a/server/src/extraction/catalogueTypes.ts
+++ b/server/src/extraction/catalogueTypes.ts
@@ -406,9 +406,7 @@ export const catalogueTypes: Record<CatalogueType, CatalogueTypeDefinition> = {
       },
       credential_description: {
         description:
-          "the description of the credential. Can be a short description or a long description, make sure to include all the details of the credential such as the opportunities it provides or descriptions of roles in the industry. " +
-          "Do not confuse the description of the credential with the description of the program or the program overview. " + 
-          "If the credential is a degree, capture the selling points of the degree even if they are not directly listed in the same section as the credential.",
+          "the description of the credential. Can be a short description or a long description, make sure to include all the details of the credential such as the opportunities it provides or descriptions of roles in the industry.",
         required: true,
       },
       credential_type: {

--- a/server/src/extraction/catalogueTypes.ts
+++ b/server/src/extraction/catalogueTypes.ts
@@ -406,7 +406,7 @@ export const catalogueTypes: Record<CatalogueType, CatalogueTypeDefinition> = {
       },
       credential_description: {
         description:
-          "the concise description of the credential, make sure to include all the details of the credential.",
+          "the description of the credential. Can be a short description or a long description, make sure to include all the details of the credential such as the opportunities it provides or descriptions of roles in the industry.",
         required: true,
       },
       credential_type: {

--- a/server/src/extraction/catalogueTypes.ts
+++ b/server/src/extraction/catalogueTypes.ts
@@ -406,7 +406,9 @@ export const catalogueTypes: Record<CatalogueType, CatalogueTypeDefinition> = {
       },
       credential_description: {
         description:
-          "the description of the credential. Can be a short description or a long description, make sure to include all the details of the credential such as the opportunities it provides or descriptions of roles in the industry.",
+          "the description of the credential. Can be a short description or a long description, make sure to include all the details of the credential such as the opportunities it provides or descriptions of roles in the industry. " +
+          "Do not confuse the description of the credential with the description of the program or the program overview. " + 
+          "If the credential is a degree, capture the selling points of the degree even if they are not directly listed in the same section as the credential.",
         required: true,
       },
       credential_type: {

--- a/server/tests/extractions/credentials/pennhighlands.test.ts
+++ b/server/tests/extractions/credentials/pennhighlands.test.ts
@@ -50,7 +50,7 @@ describe("Pennsylvania Highlands Community College", { timeout: EXTRACTION_TIMEO
         {
           credential_name: expect.like("Accounting"),
           credential_description: expect.like(
-            "Associate in Applied Science degree program that prepares students for careers in accounting, bookkeeping, and financial management"
+            "Accountants analyze financial information and consult with upper management about important business decisions. Those completing this program will have demonstrated an understanding and application of accounting theory and practice and will have achieved a level of proficiency in related areas, including economics, management, marketing, IT, and business sub-disciplines.\n\nThe Associate of Applied Science (A.A.S.) degree in Accounting is designed to provide the foundation necessary for optimal transfer to bachelor degree programs in Accounting or related fields. It also simultaneously prepares students for immediate employment in a wide range of businesses requiring advanced skills and knowledge in accounting and business. This program will prepare you for whichever path you decide to take.\n\nGraduates will have the opportunity to earn the Certified Bookkeeper designation offered through the American Institute of Professional Bookkeepers (AIPB). This will increase the ability of graduates to showcase their skills and obtain employment."
           ),
           credential_type: "AssociateDegree",
           language: "English",


### PR DESCRIPTION
This PR:
- improves prompts for the Penn Highlands example in https://github.com/CredentialEngine/ctdl-xtra/issues/107 while reverting further improvements that exceed the LLM instructions threshold.
- adds search lookup in catalogue URL to make searching catalogues a little easier