### PR TITLE
Remove unused state and mutation causing build failure

### DIFF
--- a/client/src/components/app/recipes/create.tsx
+++ b/client/src/components/app/recipes/create.tsx
@@ -398,10 +398,6 @@ export default function CreateRecipe() {
   const createRecipe = trpc.recipes.create.useMutation();
   const detectPagination = trpc.recipes.detectPagination.useMutation();
   const detectUrlRegexp = trpc.recipes.detectUrlRegexp.useMutation();
-  const testRecipeRegex = trpc.recipes.testRecipeRegex.useMutation();
-  const [testResult, setTestResult] = useState<{regexp: string; urls: string[]} | null>(null);
-  const [isTesting, setIsTesting] = useState(false);
-  const [testError, setTestError] = useState<string | null>(null);
   const form = useForm<z.infer<typeof FormSchema>>({
     resolver: zodResolver(FormSchema),
     defaultValues: {


### PR DESCRIPTION
The unused state and mutation cause our build to fail. Removing them.