### PR TITLE
Upgrade model to GPT5 and report model used in cost breakdown

### DIFF
--- a/common/types.ts
+++ b/common/types.ts
@@ -60,6 +60,7 @@ export enum ProviderModel {
   Gpt41 = "gpt-4.1",
   O3Mini = "o3-mini",
   O4Mini = "o4-mini",
+  Gpt5 = "gpt-5",
 }
 
 export enum ExtractionStatus {
@@ -138,6 +139,7 @@ export interface StepCompletionStats {
 
 export interface CostCallSite {
   callSite: string;
+  model: ProviderModel;
   totalInputTokens: number;
   totalOutputTokens: number;
   estimatedCost: number;

--- a/server/migrations/0008_chunky_frog_thor.sql
+++ b/server/migrations/0008_chunky_frog_thor.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "provider_model" ADD VALUE 'gpt-5';

--- a/server/migrations/meta/0008_snapshot.json
+++ b/server/migrations/meta/0008_snapshot.json
@@ -1,0 +1,1108 @@
+{
+  "id": "17474bbd-96ad-403f-87c7-9060bab8f1a9",
+  "prevId": "3da35b28-c419-4e15-a82d-187ec61c47d2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.catalogues": {
+      "name": "catalogues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "catalogue_type": {
+          "name": "catalogue_type",
+          "type": "catalogue_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COURSES'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "catalogues_url_catalogue_type_unique": {
+          "name": "catalogues_url_catalogue_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url",
+            "catalogue_type"
+          ]
+        }
+      }
+    },
+    "public.crawl_pages": {
+      "name": "crawl_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "extraction_id": {
+          "name": "extraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crawl_step_id": {
+          "name": "crawl_step_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step": {
+          "name": "step",
+          "type": "step",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "page_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'WAITING'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshot": {
+          "name": "screenshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetch_failure_reason": {
+          "name": "fetch_failure_reason",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_type": {
+          "name": "page_type",
+          "type": "page_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_extraction_started_at": {
+          "name": "data_extraction_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crawl_pages_extraction_idx": {
+          "name": "crawl_pages_extraction_idx",
+          "columns": [
+            {
+              "expression": "extraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crawl_pages_status_idx": {
+          "name": "crawl_pages_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crawl_pages_data_type_idx": {
+          "name": "crawl_pages_data_type_idx",
+          "columns": [
+            {
+              "expression": "page_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crawl_pages_step_idx": {
+          "name": "crawl_pages_step_idx",
+          "columns": [
+            {
+              "expression": "crawl_step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crawl_pages_extraction_id_extractions_id_fk": {
+          "name": "crawl_pages_extraction_id_extractions_id_fk",
+          "tableFrom": "crawl_pages",
+          "tableTo": "extractions",
+          "columnsFrom": [
+            "extraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crawl_pages_crawl_step_id_crawl_steps_id_fk": {
+          "name": "crawl_pages_crawl_step_id_crawl_steps_id_fk",
+          "tableFrom": "crawl_pages",
+          "tableTo": "crawl_steps",
+          "columnsFrom": [
+            "crawl_step_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "crawl_pages_extraction_id_url_step_unique": {
+          "name": "crawl_pages_extraction_id_url_step_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "extraction_id",
+            "url",
+            "step"
+          ]
+        }
+      }
+    },
+    "public.crawl_steps": {
+      "name": "crawl_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "extraction_id": {
+          "name": "extraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step": {
+          "name": "step",
+          "type": "step",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_step_id": {
+          "name": "parent_step_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crawl_steps_extraction_idx": {
+          "name": "crawl_steps_extraction_idx",
+          "columns": [
+            {
+              "expression": "extraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crawl_steps_parent_step_idx": {
+          "name": "crawl_steps_parent_step_idx",
+          "columns": [
+            {
+              "expression": "parent_step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crawl_steps_extraction_id_extractions_id_fk": {
+          "name": "crawl_steps_extraction_id_extractions_id_fk",
+          "tableFrom": "crawl_steps",
+          "tableTo": "extractions",
+          "columnsFrom": [
+            "extraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crawl_steps_parent_step_id_crawl_steps_id_fk": {
+          "name": "crawl_steps_parent_step_id_crawl_steps_id_fk",
+          "tableFrom": "crawl_steps",
+          "tableTo": "crawl_steps",
+          "columnsFrom": [
+            "parent_step_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.data_items": {
+      "name": "data_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crawl_page_id": {
+          "name": "crawl_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "structured_data": {
+          "name": "structured_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_inclusion": {
+          "name": "text_inclusion",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_items_dataset_idx": {
+          "name": "data_items_dataset_idx",
+          "columns": [
+            {
+              "expression": "dataset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "data_items_crawl_page_idx": {
+          "name": "data_items_crawl_page_idx",
+          "columns": [
+            {
+              "expression": "crawl_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "data_items_dataset_id_datasets_id_fk": {
+          "name": "data_items_dataset_id_datasets_id_fk",
+          "tableFrom": "data_items",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "data_items_crawl_page_id_crawl_pages_id_fk": {
+          "name": "data_items_crawl_page_id_crawl_pages_id_fk",
+          "tableFrom": "data_items",
+          "tableTo": "crawl_pages",
+          "columnsFrom": [
+            "crawl_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.datasets": {
+      "name": "datasets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "catalogue_id": {
+          "name": "catalogue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extraction_id": {
+          "name": "extraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "datasets_catalogue_idx": {
+          "name": "datasets_catalogue_idx",
+          "columns": [
+            {
+              "expression": "catalogue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "datasets_extraction_idx": {
+          "name": "datasets_extraction_idx",
+          "columns": [
+            {
+              "expression": "extraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "datasets_catalogue_id_catalogues_id_fk": {
+          "name": "datasets_catalogue_id_catalogues_id_fk",
+          "tableFrom": "datasets",
+          "tableTo": "catalogues",
+          "columnsFrom": [
+            "catalogue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "datasets_extraction_id_extractions_id_fk": {
+          "name": "datasets_extraction_id_extractions_id_fk",
+          "tableFrom": "datasets",
+          "tableTo": "extractions",
+          "columnsFrom": [
+            "extraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "datasets_catalogue_id_extraction_id_unique": {
+          "name": "datasets_catalogue_id_extraction_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "catalogue_id",
+            "extraction_id"
+          ]
+        }
+      }
+    },
+    "public.extraction_logs": {
+      "name": "extraction_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "extraction_id": {
+          "name": "extraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "log": {
+          "name": "log",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "log_level": {
+          "name": "log_level",
+          "type": "log_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INFO'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "extraction_logs_extraction_idx": {
+          "name": "extraction_logs_extraction_idx",
+          "columns": [
+            {
+              "expression": "extraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "extraction_logs_extraction_id_extractions_id_fk": {
+          "name": "extraction_logs_extraction_id_extractions_id_fk",
+          "tableFrom": "extraction_logs",
+          "tableTo": "extractions",
+          "columnsFrom": [
+            "extraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.extractions": {
+      "name": "extractions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completion_stats": {
+          "name": "completion_stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "extraction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'WAITING'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "extractions_recipe_idx": {
+          "name": "extractions_recipe_idx",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "extractions_recipe_id_recipes_id_fk": {
+          "name": "extractions_recipe_id_recipes_id_fk",
+          "tableFrom": "extractions",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.model_api_calls": {
+      "name": "model_api_calls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "extraction_id": {
+          "name": "extraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "provider_model",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "call_site": {
+          "name": "call_site",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_token_count": {
+          "name": "input_token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_token_count": {
+          "name": "output_token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "model_api_calls_extraction_idx": {
+          "name": "model_api_calls_extraction_idx",
+          "columns": [
+            {
+              "expression": "extraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_api_calls_extraction_id_extractions_id_fk": {
+          "name": "model_api_calls_extraction_id_extractions_id_fk",
+          "tableFrom": "model_api_calls",
+          "tableTo": "extractions",
+          "columnsFrom": [
+            "extraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.recipes": {
+      "name": "recipes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "catalogue_id": {
+          "name": "catalogue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "detection_failure_reason": {
+          "name": "detection_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "recipe_detection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'WAITING'"
+        },
+        "robots_txt": {
+          "name": "robots_txt",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acknowledged_skip_robots_txt": {
+          "name": "acknowledged_skip_robots_txt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recipes_catalogue_idx": {
+          "name": "recipes_catalogue_idx",
+          "columns": [
+            {
+              "expression": "catalogue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipes_catalogue_id_catalogues_id_fk": {
+          "name": "recipes_catalogue_id_catalogues_id_fk",
+          "tableFrom": "recipes",
+          "tableTo": "catalogues",
+          "columnsFrom": [
+            "catalogue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_encrypted": {
+          "name": "is_encrypted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "encrypted_preview": {
+          "name": "encrypted_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "settings_key_unique": {
+          "name": "settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      }
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "public.catalogue_type": {
+      "name": "catalogue_type",
+      "schema": "public",
+      "values": [
+        "COURSES",
+        "LEARNING_PROGRAMS",
+        "COMPETENCIES",
+        "CREDENTIALS"
+      ]
+    },
+    "public.extraction_status": {
+      "name": "extraction_status",
+      "schema": "public",
+      "values": [
+        "WAITING",
+        "IN_PROGRESS",
+        "COMPLETE",
+        "STALE",
+        "CANCELLED"
+      ]
+    },
+    "public.log_level": {
+      "name": "log_level",
+      "schema": "public",
+      "values": [
+        "INFO",
+        "ERROR"
+      ]
+    },
+    "public.page_status": {
+      "name": "page_status",
+      "schema": "public",
+      "values": [
+        "WAITING",
+        "IN_PROGRESS",
+        "SUCCESS",
+        "ERROR"
+      ]
+    },
+    "public.page_type": {
+      "name": "page_type",
+      "schema": "public",
+      "values": [
+        "DETAIL",
+        "CATEGORY_LINKS",
+        "DETAIL_LINKS",
+        "API_REQUEST",
+        "EXPLORATORY"
+      ]
+    },
+    "public.provider": {
+      "name": "provider",
+      "schema": "public",
+      "values": [
+        "openai"
+      ]
+    },
+    "public.provider_model": {
+      "name": "provider_model",
+      "schema": "public",
+      "values": [
+        "gpt-4o",
+        "gpt-4.1",
+        "o3-mini",
+        "o4-mini",
+        "gpt-5"
+      ]
+    },
+    "public.recipe_detection_status": {
+      "name": "recipe_detection_status",
+      "schema": "public",
+      "values": [
+        "WAITING",
+        "IN_PROGRESS",
+        "SUCCESS",
+        "ERROR"
+      ]
+    },
+    "public.step": {
+      "name": "step",
+      "schema": "public",
+      "values": [
+        "FETCH_ROOT",
+        "FETCH_PAGINATED",
+        "FETCH_LINKS",
+        "FETCH_VIA_API"
+      ]
+    },
+    "public.url_pattern_type": {
+      "name": "url_pattern_type",
+      "schema": "public",
+      "values": [
+        "page_num",
+        "offset"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/migrations/meta/_journal.json
+++ b/server/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1753123960718,
       "tag": "0007_nappy_paladin",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1758043982523,
+      "tag": "0008_chunky_frog_thor",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/data/extractions.ts
+++ b/server/src/data/extractions.ts
@@ -121,6 +121,9 @@ export async function findExtractionForDetailPage(id: number) {
           itemCount: sql<number>`0`.as("item_count"),
         },
       },
+      modelApiCalls: {
+        orderBy: (e) => e.createdAt,
+      },
       logs: {
         orderBy: (e) => e.createdAt,
       },

--- a/server/src/extraction/catalogueTypes.ts
+++ b/server/src/extraction/catalogueTypes.ts
@@ -303,7 +303,7 @@ export const catalogueTypes: Record<CatalogueType, CatalogueTypeDefinition> = {
     exampleDescription:
       "The ability to analyze information objectively and make reasoned judgments.",
     identifierProperty: "competency_id",
-    model: ProviderModel.Gpt4o,
+    model: ProviderModel.Gpt5,
     extractionParameters: {
       temperature: 1,
       top_p: 0.5,
@@ -397,7 +397,7 @@ export const catalogueTypes: Record<CatalogueType, CatalogueTypeDefinition> = {
       Do not confuse credentials with courses or skills or learning outcomes. Do not list Certifications, those are not credentials. Return only the credentials that are offered by the institution.
       Ignore stackable certificates.
     `,
-    model: ProviderModel.Gpt4o,
+    model: ProviderModel.Gpt5,
     properties: {
       credential_name: {
         description:

--- a/server/src/extraction/llm/detectChunkSplitRegexp.ts
+++ b/server/src/extraction/llm/detectChunkSplitRegexp.ts
@@ -115,7 +115,7 @@ export default async function detectChunkSplitRegexp(
         content: completionContent,
       },
     ],
-    model: ProviderModel.Gpt41,
+    model: ProviderModel.Gpt5,
     toolName: "regexp",
     parameters: {
       regexp: {

--- a/server/src/extraction/llm/determinePresenceOfEntity.ts
+++ b/server/src/extraction/llm/determinePresenceOfEntity.ts
@@ -56,10 +56,15 @@ ${MD_END}
     },
   ];
 
-  const result = await structuredCompletion({
+  const model = entityDef.model || ProviderModel.Gpt5;
+
+  type PresenceCompletion = { present: boolean; explanation: string };
+
+  const requestOptions: Parameters<
+    typeof structuredCompletion<PresenceCompletion>
+  >[0] = {
     messages,
-    model: entityDef.model || ProviderModel.Gpt4o,
-    top_p: 0.3,
+    model,
     schema: {
       type: "object",
       additionalProperties: false,
@@ -81,7 +86,13 @@ ${MD_END}
           callSite: "determinePresenceOfEntity",
         }
       : undefined,
-  });
+  };
+
+  if (model !== ProviderModel.Gpt5) {
+    requestOptions.top_p = 0.3;
+  }
+
+  const result = await structuredCompletion<PresenceCompletion>(requestOptions);
 
   if (!result || !result.result || typeof result.result.present !== 'boolean') {
     return { prompt, present: false };

--- a/server/src/extraction/llm/exploreAdditionalPages.ts
+++ b/server/src/extraction/llm/exploreAdditionalPages.ts
@@ -59,7 +59,7 @@ ${MD_END}
 
   const result = await structuredCompletion({
     messages,
-    model: entityDef.model || ProviderModel.Gpt4o,
+    model: entityDef.model || ProviderModel.Gpt5,
     schema: {
       type: "object",
       additionalProperties: false,

--- a/server/src/extraction/llm/extractEntityData.ts
+++ b/server/src/extraction/llm/extractEntityData.ts
@@ -260,7 +260,13 @@ ${basePrompt}
     const results = await structuredCompletion({
       messages,
       schema: entityDef.schema,
-      model: entityDef.model || ProviderModel.Gpt4o,
+      model: entityDef.model || ProviderModel.Gpt5,
+      logApiCall: options?.logApiCalls
+        ? {
+            extractionId: options.logApiCalls.extractionId,
+            callSite: "extractEntityData",
+          }
+        : undefined,
     });
 
     if (!results.result) {
@@ -276,7 +282,7 @@ ${basePrompt}
     const completionParameters = {
       messages,
       toolName: "result",
-      model: entityDef.model || ProviderModel.Gpt4o,
+      model: entityDef.model || ProviderModel.Gpt5,
       parameters: {
         items: {
           type: "array",

--- a/server/src/workers/updateExtractionCompletion.ts
+++ b/server/src/workers/updateExtractionCompletion.ts
@@ -99,6 +99,7 @@ async function computeCosts(
     totalOutputTokens += summary.totalOutputTokens;
     callSites.push({
       callSite: summary.callSite,
+      model: summary.model as ProviderModel,
       totalInputTokens: summary.totalInputTokens,
       totalOutputTokens: summary.totalOutputTokens,
       estimatedCost: estimateCost(


### PR DESCRIPTION
This PR introduces the GPT 5 for all OpenAI calls along with small improvements in the cost accuracy and a badge showing which models were used in the extraction.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/75ad60ae-b4b9-4523-9657-fa1b16a29055" />
