### PR TITLE
Add items extracted and cost columns to extractions list

### DIFF
--- a/client/src/components/app/extractions/index.tsx
+++ b/client/src/components/app/extractions/index.tsx
@@ -21,10 +21,23 @@ type ExtractionSummary = IterableElement<
   RouterOutput["extractions"]["list"]["results"]
 >;
 
-type SortKey = "catalogue" | "type" | "status" | "date";
+type SortKey =
+  | "catalogue"
+  | "type"
+  | "status"
+  | "date"
+  | "items"
+  | "cost";
 type SortOrder = "asc" | "desc";
 
-const VALID_SORT_KEYS: SortKey[] = ["catalogue", "type", "status", "date"];
+const VALID_SORT_KEYS: SortKey[] = [
+  "catalogue",
+  "type",
+  "status",
+  "date",
+  "items",
+  "cost",
+];
 
 function toStartOfDayIso(date?: string) {
   return date ? `${date}T00:00:00.000Z` : undefined;
@@ -43,11 +56,12 @@ function getNextSortOrder(
   clickedKey: SortKey,
   currentOrder: SortOrder
 ): SortOrder {
+  const defaultDesc: SortKey[] = ["date", "items", "cost"];
   return currentKey === clickedKey
     ? currentOrder === "asc"
       ? "desc"
       : "asc"
-    : clickedKey === "date"
+    : defaultDesc.includes(clickedKey)
       ? "desc"
       : "asc";
 }
@@ -115,6 +129,14 @@ const ExtractionListItem = (extraction: ExtractionSummary) => {
             ? `${Math.floor((totalExtractionsAttempted / totalExtractionsPossible) * 100)}%`
             : "0%"
           : "Pending"}
+      </TableCell>
+      <TableCell className="text-xs">
+        {extraction.itemsCount ?? "-"}
+      </TableCell>
+      <TableCell className="text-xs">
+        {extraction.completionStats?.costs?.estimatedCost != null
+          ? `$${extraction.completionStats.costs.estimatedCost.toFixed(2)}`
+          : "-"}
       </TableCell>
       <TableCell className="text-xs">
         {prettyPrintDate(extraction.createdAt)}
@@ -289,6 +311,18 @@ export default function Extractions() {
                   <span>Extractions</span>
                 </TableHead>
                 <TableHead
+                  className="cursor-pointer w-40"
+                  onClick={() => handleSort("items")}
+                >
+                  {renderHeader("Items extracted", "items")}
+                </TableHead>
+                <TableHead
+                  className="cursor-pointer"
+                  onClick={() => handleSort("cost")}
+                >
+                  {renderHeader("Cost", "cost")}
+                </TableHead>
+                <TableHead
                   className="cursor-pointer"
                   onClick={() => handleSort("date")}
                 >
@@ -301,7 +335,7 @@ export default function Extractions() {
                 <ExtractionListItem key={extraction.id} {...extraction} />
               )) || (
                 <TableRow>
-                  <TableCell colSpan={3}>
+                  <TableCell colSpan={8}>
                     <div className="flex items-center justify-center">
                       Loading extractions...
                     </div>

--- a/server/src/data/extractions.ts
+++ b/server/src/data/extractions.ts
@@ -1,6 +1,18 @@
 import { inspect } from "util";
-import { and, asc, desc, eq, gte, isNotNull, isNull, lte, or, SQL } from "drizzle-orm";
-import { sql } from "drizzle-orm/sql/sql";
+import {
+  and,
+  asc,
+  count,
+  desc,
+  eq,
+  gte,
+  isNotNull,
+  isNull,
+  lte,
+  or,
+  SQL,
+  sql,
+} from "drizzle-orm";
 import { SQLiteUpdateSetSource } from "drizzle-orm/sqlite-core";
 import db from "../data";
 import {
@@ -8,6 +20,7 @@ import {
   crawlPages,
   crawlSteps,
   dataItems,
+  datasets,
   extractionLogs,
   extractions,
   extractionsAuditLog,
@@ -239,7 +252,13 @@ export async function findExtractions(limit: number = 20, offset?: number) {
   });
 }
 
-export type ExtractionsSortKey = "date" | "status" | "catalogue" | "type";
+export type ExtractionsSortKey =
+  | "date"
+  | "status"
+  | "catalogue"
+  | "type"
+  | "items"
+  | "cost";
 export type ExtractionsSortOrder = "asc" | "desc";
 
 export async function findExtractionsSorted(
@@ -252,6 +271,20 @@ export async function findExtractionsSorted(
 ) {
   const dir = sortOrder === "asc" ? asc : desc;
 
+  const whereClauses: SQL[] = [];
+  if (dateFrom) whereClauses.push(gte(extractions.createdAt, dateFrom));
+  if (dateTo) whereClauses.push(lte(extractions.createdAt, dateTo));
+
+  const itemsCountByExtraction = db
+    .select({
+      extractionId: datasets.extractionId,
+      itemsCount: count(dataItems.id).as("items_count"),
+    })
+    .from(dataItems)
+    .innerJoin(datasets, eq(datasets.id, dataItems.datasetId))
+    .groupBy(datasets.extractionId)
+    .as("items_count_by_extraction");
+
   const orderExpr = (() => {
     switch (sortKey) {
       case "status":
@@ -260,21 +293,32 @@ export async function findExtractionsSorted(
         return dir(catalogues.name);
       case "type":
         return dir(catalogues.catalogueType);
+      case "items":
+        return dir(sql`coalesce(${itemsCountByExtraction.itemsCount}, 0)`);
+      case "cost":
+        return dir(
+          sql`(${extractions.completionStats}->'costs'->>'estimatedCost')::double precision`
+        );
       case "date":
       default:
         return dir(extractions.createdAt);
     }
   })();
 
-  const whereClauses: SQL[] = [];
-  if (dateFrom) whereClauses.push(gte(extractions.createdAt, dateFrom));
-  if (dateTo) whereClauses.push(lte(extractions.createdAt, dateTo));
-
   const rows = await db
-    .select({ extraction: extractions, recipe: recipes, catalogue: catalogues })
+    .select({
+      extraction: extractions,
+      recipe: recipes,
+      catalogue: catalogues,
+      itemsCount: itemsCountByExtraction.itemsCount,
+    })
     .from(extractions)
     .leftJoin(recipes, eq(recipes.id, extractions.recipeId))
     .leftJoin(catalogues, eq(catalogues.id, recipes.catalogueId))
+    .leftJoin(
+      itemsCountByExtraction,
+      eq(itemsCountByExtraction.extractionId, extractions.id)
+    )
     .where(whereClauses.length ? and(...whereClauses) : undefined)
     .orderBy(orderExpr)
     .limit(limit)
@@ -282,6 +326,7 @@ export async function findExtractionsSorted(
 
   return rows.map((r) => ({
     ...r.extraction,
+    itemsCount: r.itemsCount ?? 0,
     recipe: {
       ...r.recipe,
       catalogue: r.catalogue,

--- a/server/src/routers/extractions.ts
+++ b/server/src/routers/extractions.ts
@@ -230,7 +230,9 @@ export const extractionsRouter = router({
       z
         .object({
           page: z.number().int().positive().default(1),
-          sortKey: z.enum(["date", "status", "catalogue", "type"]).default("date"),
+          sortKey: z
+            .enum(["date", "status", "catalogue", "type", "items", "cost"])
+            .default("date"),
           sortOrder: z.enum(["asc", "desc"]).default("desc"),
           dateFrom: z.string().datetime().optional(),
           dateTo: z.string().datetime().optional(),


### PR DESCRIPTION
Adds the two columns as discussed.

<img width="1295" height="344" alt="image" src="https://github.com/user-attachments/assets/651df4df-3547-4f91-abf8-ee3cecbed2f4" />

Closes #146 
