### PR TITLE
Respect exact Regex match option and add page text copy in recipe edit screen

### DIFF
--- a/client/src/components/app/recipes/TestLinkRegex.tsx
+++ b/client/src/components/app/recipes/TestLinkRegex.tsx
@@ -7,13 +7,18 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Copy } from "lucide-react";
 import { trpc } from "@/utils";
+import { useToast } from "@/components/ui/use-toast";
+
+type TestResult = { regexp: string; urls: string[]; markdownContent?: string };
 
 function MatchedLinks({
   result,
+  onCopySimplifiedText,
 }: {
-  result: { regexp: string; urls: string[] };
+  result: TestResult;
+  onCopySimplifiedText?: (text: string) => void;
 }) {
   return (
     <div className="mt-4">
@@ -33,6 +38,20 @@ function MatchedLinks({
       ) : (
         <div className="text-xs text-muted-foreground">No links matched.</div>
       )}
+      <div className="flex items-center gap-2 mt-4">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={!result.markdownContent}
+          onClick={() =>
+            result.markdownContent && onCopySimplifiedText?.(result.markdownContent)
+          }
+        >
+          <Copy className="w-4 h-4 mr-2" />
+          Copy simplified page text
+        </Button>
+      </div>
     </div>
   );
 }
@@ -57,6 +76,16 @@ export default function TestLinkRegex({
   const [url, setUrl] = useState(defaultUrl);
   const [regex, setRegex] = useState(defaultRegex || "");
   const testRecipeRegex = trpc.recipes.testRecipeRegex.useMutation();
+  const { toast } = useToast();
+
+  const handleCopySimplifiedText = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      toast({ title: "Copied to clipboard" });
+    } catch {
+      toast({ title: "Failed to copy", variant: "destructive" });
+    }
+  };
 
   useEffect(() => {
     setUrl(defaultUrl);
@@ -126,7 +155,10 @@ export default function TestLinkRegex({
           )}
 
           {testRecipeRegex.isSuccess && (
-            <MatchedLinks result={testRecipeRegex.data} />
+            <MatchedLinks
+              result={testRecipeRegex.data}
+              onCopySimplifiedText={handleCopySimplifiedText}
+            />
           )}
         </div>
       </>
@@ -215,7 +247,10 @@ export default function TestLinkRegex({
         )}
 
         {testRecipeRegex.isSuccess && (
-          <MatchedLinks result={testRecipeRegex.data} />
+          <MatchedLinks
+            result={testRecipeRegex.data}
+            onCopySimplifiedText={handleCopySimplifiedText}
+          />
         )}
       </CardContent>
     </Card>

--- a/server/src/routers/recipes.ts
+++ b/server/src/routers/recipes.ts
@@ -27,6 +27,7 @@ import {
 } from "../extraction/robotsParser";
 import { submitRecipeDetection } from "../extraction/submitRecipeDetection";
 import getLogger from "../logging";
+import { SimplifiedMarkdown } from "../types";
 import { bestOutOf, exponentialRetry } from "../utils";
 import { Queues, submitJob } from "../workers";
 
@@ -342,6 +343,7 @@ export const recipesRouter = router({
 
       try {
         let urls: string[];
+        let markdownContent: SimplifiedMarkdown;
 
         // Use dynamic links harvesting if clickSelector is provided
         if (opts.input.clickSelector) {
@@ -354,10 +356,25 @@ export const recipesRouter = router({
           // If regex is provided, filter the discovered URLs by the regex
           if (regexp) {
             const testRegex = new RegExp(regexp, "g");
-            urls = urls.filter((url) => testRegex.test(url));
-            // Reset regex lastIndex for next use
+            const exactMatch = opts.input.exactLinkPatternMatch ?? false;
+            if (exactMatch) {
+              urls = urls.flatMap((url) => {
+                const matches = url.match(testRegex);
+                return matches ?? [];
+              });
+            } else {
+              urls = urls.filter((url) => testRegex.test(url));
+            }
             testRegex.lastIndex = 0;
           }
+
+          // Fetch page content for simplified markdown
+          const { content } = await fetchBrowserPage({
+            url: opts.input.url,
+            skipProxy: false,
+            pageLoadWaitTime: opts.input.pageLoadWaitTime,
+          });
+          markdownContent = await simplifiedMarkdown(content);
         } else {
           // Use traditional regex-based extraction (regex is required when no clickSelector)
           if (!regexp) {
@@ -368,7 +385,7 @@ export const recipesRouter = router({
             skipProxy: false,
             pageLoadWaitTime: opts.input.pageLoadWaitTime,
           });
-          const markdownContent = await simplifiedMarkdown(content);
+          markdownContent = await simplifiedMarkdown(content);
 
           const testRegex = new RegExp(regexp, "g");
           const extractor = createUrlExtractor(testRegex);
@@ -382,6 +399,7 @@ export const recipesRouter = router({
         return {
           regexp: regexp || "",
           urls: normalizedUrls,
+          markdownContent: markdownContent as string,
         };
       } catch (error) {
         if (error instanceof BrowserFetchError) {


### PR DESCRIPTION
Small improvement to the recipe troubleshooting flow for Regex link matching, ensuring the recipe is fully respected in regards to how the regex applies to the links and a new small button allowing users to get the exact text that xTRA operates on which can be further adjusted in 3rd party regex tester tools.

<img width="776" height="447" alt="image" src="https://github.com/user-attachments/assets/0569afa8-e477-419b-81e0-450e1d05ab8b" />
