### PR TITLE
Show extracted data in the page view

### DIFF
--- a/client/src/components/app/extractions/page.tsx
+++ b/client/src/components/app/extractions/page.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/components/ui/accordion";
 import BreadcrumbTrail from "@/components/ui/breadcrumb-trail";
 import { Button } from "@/components/ui/button";
+import { JsonView } from "@/components/ui/jsonview";
 import {
   Table,
   TableBody,
@@ -15,7 +16,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { concisePrintDate, trpc } from "@/utils";
+import { concisePrintDate, prettyPrintDate, trpc } from "@/utils";
 import { ExternalLink } from "lucide-react";
 import { useState } from "react";
 import { useParams } from "wouter";
@@ -67,23 +68,69 @@ export default function CrawlPageDetail() {
     },
   ];
 
+  const dataItems = item.dataItems ?? [];
+
   const tabTriggers = [
-    <TabsTrigger value="raw_content">Raw content</TabsTrigger>,
+    <TabsTrigger key="data" value="data">Data</TabsTrigger>,
+    <TabsTrigger key="raw_content" value="raw_content">Raw content</TabsTrigger>,
   ];
   const tabContents = [
-    <TabsContent value="raw_content">
+    <TabsContent key="data" value="data">
+      {dataItems.length > 0 ? (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>ID</TableHead>
+              <TableHead>Dataset ID</TableHead>
+              <TableHead>Crawl Page ID</TableHead>
+              <TableHead>Created At</TableHead>
+              <TableHead>Content (JSON)</TableHead>
+              <TableHead>Text Inclusion</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {dataItems.map((di) => (
+              <TableRow key={di.id}>
+                <TableCell className="text-sm">{di.id}</TableCell>
+                <TableCell className="text-sm">{di.datasetId}</TableCell>
+                <TableCell className="text-sm">{di.crawlPageId}</TableCell>
+                <TableCell className="text-sm">
+                  {prettyPrintDate(di.createdAt)}
+                </TableCell>
+                <TableCell className="max-w-md">
+                  <JsonView data={di.structuredData} initialExpanded={true} />
+                </TableCell>
+                <TableCell className="max-w-md">
+                  {di.textInclusion != null ? (
+                    <JsonView data={di.textInclusion} initialExpanded={false} />
+                  ) : (
+                    <span className="text-muted-foreground">—</span>
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      ) : (
+        <div className="text-muted-foreground">
+          No data items yet. They will appear here once the data extraction has
+          run for this page.
+        </div>
+      )}
+    </TabsContent>,
+    <TabsContent key="raw_content" value="raw_content">
       <code>{item.content}</code>
     </TabsContent>,
   ];
 
-  let defaultTab = "raw_content";
+  const defaultTab = "data";
 
   if (item.markdownContent) {
     tabTriggers.push(
-      <TabsTrigger value="simplified_content">Simplified Content</TabsTrigger>
+      <TabsTrigger key="simplified_content" value="simplified_content">Simplified Content</TabsTrigger>
     );
     tabContents.push(
-      <TabsContent value="simplified_content" key="simplified_content">
+      <TabsContent key="simplified_content" value="simplified_content">
         <pre className="whitespace-pre-wrap break-all">
           {item.markdownContent}
         </pre>
@@ -92,11 +139,11 @@ export default function CrawlPageDetail() {
   }
 
   tabTriggers.push(
-    <TabsTrigger value="operation_logs">Operation logs</TabsTrigger>
+    <TabsTrigger key="operation_logs" value="operation_logs">Operation logs</TabsTrigger>
   );
   const pageLogs = crawlPageLogsQuery.data ?? [];
   tabContents.push(
-    <TabsContent value="operation_logs">
+    <TabsContent key="operation_logs" value="operation_logs">
       <div className="space-y-4">
         {pageLogs.length > 0 ? (
           <Table>
@@ -140,13 +187,8 @@ export default function CrawlPageDetail() {
 
   const screenshot = item.screenshot ? base64Img(item.screenshot) : null;
   if (screenshot) {
-    defaultTab = "screenshot";
-    tabTriggers.unshift(
-      <TabsTrigger value="screenshot">Screenshot</TabsTrigger>
-    );
-    tabContents.unshift(
-      <TabsContent value="screenshot">{screenshot}</TabsContent>
-    );
+    tabTriggers.splice(1, 0, <TabsTrigger key="screenshot" value="screenshot">Screenshot</TabsTrigger>);
+    tabContents.splice(1, 0, <TabsContent key="screenshot" value="screenshot">{screenshot}</TabsContent>);
   }
 
   const formattedSimulatedData = simulatedExtractedData?.data

--- a/client/src/components/app/extractions/page.tsx
+++ b/client/src/components/app/extractions/page.tsx
@@ -83,8 +83,10 @@ export default function CrawlPageDetail() {
       <TabsTrigger value="simplified_content">Simplified Content</TabsTrigger>
     );
     tabContents.push(
-      <TabsContent value="simplified_content">
-        <pre>{item.markdownContent}</pre>
+      <TabsContent value="simplified_content" key="simplified_content">
+        <pre className="whitespace-pre-wrap break-all">
+          {item.markdownContent}
+        </pre>
       </TabsContent>
     );
   }

--- a/client/src/components/ui/jsonview.tsx
+++ b/client/src/components/ui/jsonview.tsx
@@ -103,12 +103,33 @@ const JsonNode: React.FC<JsonNodeProps> = ({
     );
   };
 
+  const renderObjectShape = (onExpand: () => void) => (
+    <div className="flex items-start">
+      <button
+        onClick={onExpand}
+        className="mr-1 p-0.5 hover:bg-gray-200 rounded"
+      >
+        <ChevronRight className="h-3 w-3" />
+      </button>
+      <span
+        onClick={onExpand}
+        className="cursor-pointer text-gray-500"
+      >
+        {type === "array"
+          ? `[...${Object.keys(data).length} items]`
+          : `{...${Object.keys(data).length} properties}`}
+      </span>
+    </div>
+  );
+
   if (name === "root" && level === 0) {
     if (isExpandable) {
-      return renderChildren();
-    } else {
-      return renderValue();
+      if (isExpanded) {
+        return renderChildren();
+      }
+      return renderObjectShape(() => setIsExpanded(true));
     }
+    return renderValue();
   }
 
   return (

--- a/server/src/data/datasets.ts
+++ b/server/src/data/datasets.ts
@@ -202,3 +202,17 @@ export async function findDataItems(
   const totalItems = await getItemsCount(datasetId);
   return { totalItems, items };
 }
+
+export async function findDataItemsByCrawlPageId(crawlPageId: number) {
+  return db
+    .select({
+      id: dataItems.id,
+      datasetId: dataItems.datasetId,
+      crawlPageId: dataItems.crawlPageId,
+      structuredData: dataItems.structuredData,
+      textInclusion: dataItems.textInclusion,
+      createdAt: dataItems.createdAt,
+    })
+    .from(dataItems)
+    .where(eq(dataItems.crawlPageId, crawlPageId));
+}

--- a/server/src/routers/extractions.ts
+++ b/server/src/routers/extractions.ts
@@ -2,7 +2,10 @@ import { z } from "zod";
 import { publicProcedure, router } from ".";
 import { CatalogueType, ExtractionStatus } from "../../../common/types";
 import { AppError, AppErrors } from "../appErrors";
-import { findExtractionDatasets } from "../data/datasets";
+import {
+  findDataItemsByCrawlPageId,
+  findExtractionDatasets,
+} from "../data/datasets";
 import {
   createExtractionAuditLog,
   destroyExtraction,
@@ -197,9 +200,11 @@ export const extractionsRouter = router({
       if (!crawlPage) {
         throw new AppError("Step item not found", AppErrors.NOT_FOUND);
       }
+      const dataItems = await findDataItemsByCrawlPageId(opts.input.crawlPageId);
       try {
         return {
           crawlPage,
+          dataItems,
           content: await readContent(
             crawlPage.extractionId,
             crawlPage.crawlStepId,
@@ -219,6 +224,7 @@ export const extractionsRouter = router({
       } catch (error) {
         return {
           crawlPage,
+          dataItems,
           content: null,
           markdownContent: null,
           screenshot: null,


### PR DESCRIPTION
This PR adds a new "Data" tab in the crawl page detail screen and is a stepping stone into further work allowing sampling of large extractions in order to asses the performance and correctness.

<img height="400" alt="image" src="https://github.com/user-attachments/assets/0f5d96c7-bff6-4e42-9b65-64d628c9ce55" />

The PR also contains a fix of a bug that makes the page difficult to use when accessing the Simplified content tab which extends the width to the longest text line leading to unnecessary horizontal scrolling.
