### PR TITLE
Fix extraction completion logic failing due to undefined job

### DIFF
--- a/client/src/components/app/catalogues/extract.tsx
+++ b/client/src/components/app/catalogues/extract.tsx
@@ -27,6 +27,10 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import {
+  DEFAULT_EXTRACTION_MODEL,
+  MODEL_METADATA,
+} from "@common/modelMetadata";
 import { Recipe, RecipeDetectionStatus, trpc } from "@/utils";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { HelpCircle, Pickaxe } from "lucide-react";
@@ -38,6 +42,17 @@ import { displayRecipeDetails } from "../recipes/util";
 
 const FormSchema = z.object({
   recipeId: z.string(),
+  model: z.enum([
+    "gpt-4o",
+    "gpt-4.1",
+    "o3-mini",
+    "o4-mini",
+    "gpt-5",
+    "gpt-5-nano",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+    "gpt-5.4-nano",
+  ]),
 });
 
 export default function CatalogueCreateExtraction() {
@@ -52,6 +67,7 @@ export default function CatalogueCreateExtraction() {
     resolver: zodResolver(FormSchema),
     defaultValues: {
       recipeId: recipeId || "",
+      model: DEFAULT_EXTRACTION_MODEL,
     },
   });
   const [_location, navigate] = useLocation();
@@ -59,7 +75,7 @@ export default function CatalogueCreateExtraction() {
   useEffect(() => {
     if (!catalogueDetail.data) {
       setRecipe(null);
-      form.reset({ recipeId: "" });
+      form.reset({ recipeId: "", model: DEFAULT_EXTRACTION_MODEL });
     } else {
       const parsedRecipeId = parseInt(recipeId || "");
       const foundRecipe = parsedRecipeId
@@ -67,7 +83,10 @@ export default function CatalogueCreateExtraction() {
         : catalogueDetail.data.recipes.find((r) => r.isDefault);
       if (foundRecipe) {
         setRecipe(foundRecipe as Recipe);
-        form.reset({ recipeId: foundRecipe.id.toString() });
+        form.reset({
+          recipeId: foundRecipe.id.toString(),
+          model: DEFAULT_EXTRACTION_MODEL,
+        });
       }
     }
   }, [catalogueDetail.data, recipeId]);
@@ -76,6 +95,7 @@ export default function CatalogueCreateExtraction() {
     await createExtraction.mutateAsync({
       catalogueId: parseInt(catalogueId!),
       recipeId: parseInt(data.recipeId),
+      model: data.model,
     });
     navigate(`~/extractions`);
   }
@@ -102,7 +122,48 @@ export default function CatalogueCreateExtraction() {
                 <CardHeader>
                   <CardDescription>Recipe settings</CardDescription>
                 </CardHeader>
-                <CardContent>
+                <CardContent className="space-y-4">
+                  <FormField
+                    control={form.control}
+                    name="model"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Model</FormLabel>
+                        <Select
+                          onValueChange={field.onChange}
+                          value={field.value}
+                        >
+                          <FormControl>
+                            <SelectTrigger>
+                              <SelectValue placeholder="Select model" />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent>
+                            {MODEL_METADATA.map((meta) => (
+                              <SelectItem
+                                key={meta.model}
+                                value={meta.model}
+                                className="cursor-pointer"
+                              >
+                                {meta.label}
+                                {meta.isCheapest ? " (Lowest cost)" : ""}
+                                {meta.bestValue ? " (Best Value)" : ""}
+                                {meta.isFlagship ? " (Flagship)" : ""}
+                                <span className="opacity-60">
+                                  {" — "}
+                                  {new Date(meta.releaseDate).toLocaleDateString(
+                                    "en-US",
+                                    { year: "numeric", month: "short", day: "numeric" }
+                                  )}
+                                </span>
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
                   <FormField
                     control={form.control}
                     name="recipeId"
@@ -158,7 +219,13 @@ export default function CatalogueCreateExtraction() {
                 </CardContent>
               </Card>
             </div>
-            <Button>
+            <Button
+              disabled={
+                !form.watch("model") ||
+                !form.watch("recipeId") ||
+                createExtraction.isLoading
+              }
+            >
               <Pickaxe className="h-4 w-4 mr-2" /> Start extraction
             </Button>
           </form>

--- a/client/src/components/app/extractions/detail.tsx
+++ b/client/src/components/app/extractions/detail.tsx
@@ -35,6 +35,7 @@ import {
   RecipeDetectionStatus,
   concisePrintDate,
   prettyPrintDate,
+  resolveCrawlPageUrl,
   trpc,
 } from "@/utils";
 import { CookingPot, LibraryBig, List } from "lucide-react";
@@ -711,7 +712,10 @@ export default function ExtractionDetail() {
                                       </TableCell>
                                       <TableCell className="break-all align-top">
                                         <a
-                                          href={p.url}
+                                          href={resolveCrawlPageUrl(
+                                            p.url,
+                                            extraction.recipe.url
+                                          )}
                                           target="_blank"
                                           rel="noreferrer"
                                           className="underline"
@@ -784,7 +788,10 @@ export default function ExtractionDetail() {
                                     </TableCell>
                                     <TableCell className="break-all align-top">
                                       <a
-                                        href={p.url}
+                                        href={resolveCrawlPageUrl(
+                                          p.url,
+                                          extraction.recipe.url
+                                        )}
                                         target="_blank"
                                         rel="noreferrer"
                                         className="underline"

--- a/client/src/components/app/extractions/page.tsx
+++ b/client/src/components/app/extractions/page.tsx
@@ -16,7 +16,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { concisePrintDate, prettyPrintDate, trpc } from "@/utils";
+import { concisePrintDate, prettyPrintDate, resolveCrawlPageUrl, trpc } from "@/utils";
 import { ExternalLink } from "lucide-react";
 import { useState } from "react";
 import { useParams } from "wouter";
@@ -244,7 +244,14 @@ export default function CrawlPageDetail() {
           <Button
             variant="outline"
             size="sm"
-            onClick={() => window.open(item.crawlPage.url, "_blank", "noopener,noreferrer")}
+            onClick={() => {
+              const url = item.crawlPage.url;
+              const baseUrl = item.crawlPage.extraction?.recipe?.url;
+              const resolved = baseUrl
+                ? resolveCrawlPageUrl(url, baseUrl)
+                : url;
+              window.open(resolved, "_blank", "noopener,noreferrer");
+            }}
           >
             <ExternalLink className="w-4 h-4 mr-2" />
             Open Page URL

--- a/client/src/components/app/extractions/step.tsx
+++ b/client/src/components/app/extractions/step.tsx
@@ -10,7 +10,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { concisePrintDate, trpc } from "@/utils";
+import { concisePrintDate, resolveCrawlPageUrl, trpc } from "@/utils";
 import { Link, useParams } from "wouter";
 import { PageType } from "../../../../../common/types";
 import usePagination from "../usePagination";
@@ -85,7 +85,14 @@ export default function CrawlStepDetail() {
                   </TableCell>
                   <TableCell>{concisePrintDate(item.createdAt)}</TableCell>
                   <TableCell className="max-w-40 overflow-hidden whitespace-nowrap text-ellipsis text-blue-800 underline">
-                    <a href={item.url} target="_blank">
+                    <a
+                      href={resolveCrawlPageUrl(
+                        item.url,
+                        extractionQuery.data.recipe.url
+                      )}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
                       {item.url}
                     </a>
                   </TableCell>

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -108,6 +108,19 @@ export function formatCatalogueType(catalogueType: string): string {
   return typeMap[catalogueType] || catalogueType;
 }
 
+/**
+ * Resolves a crawl page URL to an absolute URL. Relative URLs (e.g. /courses/math)
+ * are resolved against the catalogue base URL so they open on the extracted
+ * website rather than the app origin.
+ */
+export function resolveCrawlPageUrl(url: string, baseUrl: string): string {
+  try {
+    return new URL(url, baseUrl).href;
+  } catch {
+    return url;
+  }
+}
+
 export type IterableElement<TargetIterable> =
   TargetIterable extends Iterable<infer ElementType>
   ? ElementType

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      "@common": path.resolve(__dirname, "../common"),
     },
   },
 });

--- a/common/catalogueTypes.ts
+++ b/common/catalogueTypes.ts
@@ -80,7 +80,9 @@ export interface CatalogueTypeDefinition {
   explorationPrompt?: string;
 
   /**
-   * The model to use for the LLM.
+   * The model to use for the LLM when extracting entities of this catalogue type.
+   * Used when no model is specified at extraction creation time (e.g. user-selected model
+   * on the extraction form). The extraction's model takes precedence when set.
    */
   model?: ProviderModel;
 
@@ -207,6 +209,7 @@ export const catalogueTypes: Record<CatalogueType, CatalogueTypeDefinition> = {
     displayTitle: "Courses",
     displayDescription: "Optimized for extracting and transforming course information from web pages that meet specific formatting criteria.",
     isActive: true,
+    model: ProviderModel.Gpt54Mini,
     properties: {
       course_id: {
         description: 'code/identifier for the course (example: "AGRI 101")',
@@ -299,6 +302,7 @@ export const catalogueTypes: Record<CatalogueType, CatalogueTypeDefinition> = {
     displayTitle: "Learning Programs",
     displayDescription: "Capture information about learning programs, training pathways, and educational offerings.",
     isActive: true,
+    model: ProviderModel.Gpt54Mini,
     properties: {
       learning_program_id: {
         description:
@@ -338,7 +342,7 @@ export const catalogueTypes: Record<CatalogueType, CatalogueTypeDefinition> = {
     displayTitle: "Competencies",
     displayDescription: "Identify and structure competency frameworks and skill requirements from educational resources.",
     isActive: true,
-    model: ProviderModel.Gpt5,
+    model: ProviderModel.Gpt54Mini,
     extractionParameters: {
       temperature: 1,
       top_p: 0.5,
@@ -435,7 +439,7 @@ export const catalogueTypes: Record<CatalogueType, CatalogueTypeDefinition> = {
       Do not confuse credentials with courses or skills or learning outcomes. Do not list Certifications, those are not credentials. Return only the credentials that are offered by the institution.
       Ignore stackable certificates.
     `,
-    model: ProviderModel.Gpt5,
+    model: ProviderModel.Gpt54Mini,
     properties: {
       credential_name: {
         description:

--- a/common/modelMetadata.ts
+++ b/common/modelMetadata.ts
@@ -1,0 +1,64 @@
+import { ProviderModel } from "./types";
+
+export interface ModelMetadata {
+  model: ProviderModel;
+  label: string;
+  releaseDate: string;
+  isCheapest?: boolean;
+  isFlagship?: boolean;
+  bestValue?: boolean;
+}
+
+export const MODEL_METADATA: ModelMetadata[] = [
+  {
+    model: ProviderModel.Gpt5Nano,
+    label: "GPT-5 Nano",
+    releaseDate: "2024-05-31",
+    isCheapest: true,
+  },
+  {
+    model: ProviderModel.Gpt54Nano,
+    label: "GPT-5.4 Nano",
+    releaseDate: "2025-03-01",
+  },
+  {
+    model: ProviderModel.Gpt54Mini,
+    label: "GPT-5.4 Mini",
+    releaseDate: "2025-03-01",
+    bestValue: true,
+  },
+  {
+    model: ProviderModel.Gpt5,
+    label: "GPT-5",
+    releaseDate: "2025-01-15",
+  },
+  {
+    model: ProviderModel.Gpt54,
+    label: "GPT-5.4",
+    releaseDate: "2025-03-01",
+    isFlagship: true,
+  },
+  {
+    model: ProviderModel.Gpt4o,
+    label: "GPT-4o",
+    releaseDate: "2024-04-01",
+  },
+  {
+    model: ProviderModel.Gpt41,
+    label: "GPT-4.1",
+    releaseDate: "2024-06-01",
+  },
+  {
+    model: ProviderModel.O3Mini,
+    label: "O3 Mini",
+    releaseDate: "2024-07-01",
+  },
+  {
+    model: ProviderModel.O4Mini,
+    label: "O4 Mini",
+    releaseDate: "2024-09-01",
+  },
+];
+
+export const DEFAULT_EXTRACTION_MODEL: ProviderModel =
+  MODEL_METADATA.find((m) => m.bestValue)?.model ?? ProviderModel.Gpt54Mini;

--- a/common/types.ts
+++ b/common/types.ts
@@ -89,6 +89,10 @@ export enum ProviderModel {
   O3Mini = "o3-mini",
   O4Mini = "o4-mini",
   Gpt5 = "gpt-5",
+  Gpt5Nano = "gpt-5-nano",
+  Gpt54 = "gpt-5.4",
+  Gpt54Mini = "gpt-5.4-mini",
+  Gpt54Nano = "gpt-5.4-nano",
 }
 
 export enum ExtractionStatus {

--- a/server/migrations/0016_gorgeous_franklin_richards.sql
+++ b/server/migrations/0016_gorgeous_franklin_richards.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "model_api_calls" ADD COLUMN IF NOT EXISTS "crawl_page_id" integer;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "model_api_calls" ADD CONSTRAINT "model_api_calls_crawl_page_id_crawl_pages_id_fk" FOREIGN KEY ("crawl_page_id") REFERENCES "public"."crawl_pages"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "model_api_calls_crawl_page_idx" ON "model_api_calls" USING btree ("crawl_page_id");

--- a/server/migrations/0017_wide_mole_man.sql
+++ b/server/migrations/0017_wide_mole_man.sql
@@ -1,0 +1,4 @@
+DO $$ BEGIN ALTER TYPE "provider_model" ADD VALUE 'gpt-5-nano'; EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
+DO $$ BEGIN ALTER TYPE "provider_model" ADD VALUE 'gpt-5.4'; EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
+DO $$ BEGIN ALTER TYPE "provider_model" ADD VALUE 'gpt-5.4-mini'; EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
+DO $$ BEGIN ALTER TYPE "provider_model" ADD VALUE 'gpt-5.4-nano'; EXCEPTION WHEN duplicate_object THEN null; END $$;

--- a/server/migrations/0018_bitter_tyrannus.sql
+++ b/server/migrations/0018_bitter_tyrannus.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "extractions" ADD COLUMN IF NOT EXISTS "model" "provider_model";

--- a/server/migrations/meta/0016_snapshot.json
+++ b/server/migrations/meta/0016_snapshot.json
@@ -1,0 +1,1411 @@
+{
+  "id": "8f663c37-ac02-4e87-a400-7bbc69ce1250",
+  "prevId": "8e00c73c-f91a-4010-8bd4-f0d15a32e60e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.catalogues": {
+      "name": "catalogues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "catalogue_type": {
+          "name": "catalogue_type",
+          "type": "catalogue_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COURSES'"
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "catalogues_institution_id_institutions_id_fk": {
+          "name": "catalogues_institution_id_institutions_id_fk",
+          "tableFrom": "catalogues",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "catalogues_url_catalogue_type_unique": {
+          "name": "catalogues_url_catalogue_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url",
+            "catalogue_type"
+          ]
+        }
+      }
+    },
+    "public.crawl_pages": {
+      "name": "crawl_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "extraction_id": {
+          "name": "extraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crawl_step_id": {
+          "name": "crawl_step_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step": {
+          "name": "step",
+          "type": "step",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "page_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'WAITING'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshot": {
+          "name": "screenshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetch_failure_reason": {
+          "name": "fetch_failure_reason",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_type": {
+          "name": "page_type",
+          "type": "page_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_extraction_started_at": {
+          "name": "data_extraction_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crawl_pages_extraction_idx": {
+          "name": "crawl_pages_extraction_idx",
+          "columns": [
+            {
+              "expression": "extraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crawl_pages_status_idx": {
+          "name": "crawl_pages_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crawl_pages_data_type_idx": {
+          "name": "crawl_pages_data_type_idx",
+          "columns": [
+            {
+              "expression": "page_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crawl_pages_step_idx": {
+          "name": "crawl_pages_step_idx",
+          "columns": [
+            {
+              "expression": "crawl_step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crawl_pages_extraction_id_extractions_id_fk": {
+          "name": "crawl_pages_extraction_id_extractions_id_fk",
+          "tableFrom": "crawl_pages",
+          "tableTo": "extractions",
+          "columnsFrom": [
+            "extraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crawl_pages_crawl_step_id_crawl_steps_id_fk": {
+          "name": "crawl_pages_crawl_step_id_crawl_steps_id_fk",
+          "tableFrom": "crawl_pages",
+          "tableTo": "crawl_steps",
+          "columnsFrom": [
+            "crawl_step_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "crawl_pages_extraction_id_url_step_unique": {
+          "name": "crawl_pages_extraction_id_url_step_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "extraction_id",
+            "url",
+            "step"
+          ]
+        }
+      }
+    },
+    "public.crawl_steps": {
+      "name": "crawl_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "extraction_id": {
+          "name": "extraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step": {
+          "name": "step",
+          "type": "step",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_step_id": {
+          "name": "parent_step_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crawl_steps_extraction_idx": {
+          "name": "crawl_steps_extraction_idx",
+          "columns": [
+            {
+              "expression": "extraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crawl_steps_parent_step_idx": {
+          "name": "crawl_steps_parent_step_idx",
+          "columns": [
+            {
+              "expression": "parent_step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crawl_steps_extraction_id_extractions_id_fk": {
+          "name": "crawl_steps_extraction_id_extractions_id_fk",
+          "tableFrom": "crawl_steps",
+          "tableTo": "extractions",
+          "columnsFrom": [
+            "extraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crawl_steps_parent_step_id_crawl_steps_id_fk": {
+          "name": "crawl_steps_parent_step_id_crawl_steps_id_fk",
+          "tableFrom": "crawl_steps",
+          "tableTo": "crawl_steps",
+          "columnsFrom": [
+            "parent_step_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.data_items": {
+      "name": "data_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crawl_page_id": {
+          "name": "crawl_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "structured_data": {
+          "name": "structured_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_inclusion": {
+          "name": "text_inclusion",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_items_dataset_idx": {
+          "name": "data_items_dataset_idx",
+          "columns": [
+            {
+              "expression": "dataset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "data_items_crawl_page_idx": {
+          "name": "data_items_crawl_page_idx",
+          "columns": [
+            {
+              "expression": "crawl_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "data_items_dataset_id_datasets_id_fk": {
+          "name": "data_items_dataset_id_datasets_id_fk",
+          "tableFrom": "data_items",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "data_items_crawl_page_id_crawl_pages_id_fk": {
+          "name": "data_items_crawl_page_id_crawl_pages_id_fk",
+          "tableFrom": "data_items",
+          "tableTo": "crawl_pages",
+          "columnsFrom": [
+            "crawl_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.datasets": {
+      "name": "datasets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "catalogue_id": {
+          "name": "catalogue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extraction_id": {
+          "name": "extraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "datasets_catalogue_idx": {
+          "name": "datasets_catalogue_idx",
+          "columns": [
+            {
+              "expression": "catalogue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "datasets_extraction_idx": {
+          "name": "datasets_extraction_idx",
+          "columns": [
+            {
+              "expression": "extraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "datasets_catalogue_id_catalogues_id_fk": {
+          "name": "datasets_catalogue_id_catalogues_id_fk",
+          "tableFrom": "datasets",
+          "tableTo": "catalogues",
+          "columnsFrom": [
+            "catalogue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "datasets_extraction_id_extractions_id_fk": {
+          "name": "datasets_extraction_id_extractions_id_fk",
+          "tableFrom": "datasets",
+          "tableTo": "extractions",
+          "columnsFrom": [
+            "extraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.extraction_logs": {
+      "name": "extraction_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "extraction_id": {
+          "name": "extraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crawl_page_id": {
+          "name": "crawl_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log": {
+          "name": "log",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "log_level": {
+          "name": "log_level",
+          "type": "log_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INFO'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "extraction_logs_extraction_idx": {
+          "name": "extraction_logs_extraction_idx",
+          "columns": [
+            {
+              "expression": "extraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "extraction_logs_crawl_page_idx": {
+          "name": "extraction_logs_crawl_page_idx",
+          "columns": [
+            {
+              "expression": "crawl_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "extraction_logs_extraction_id_extractions_id_fk": {
+          "name": "extraction_logs_extraction_id_extractions_id_fk",
+          "tableFrom": "extraction_logs",
+          "tableTo": "extractions",
+          "columnsFrom": [
+            "extraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "extraction_logs_crawl_page_id_crawl_pages_id_fk": {
+          "name": "extraction_logs_crawl_page_id_crawl_pages_id_fk",
+          "tableFrom": "extraction_logs",
+          "tableTo": "crawl_pages",
+          "columnsFrom": [
+            "crawl_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.extractions": {
+      "name": "extractions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completion_stats": {
+          "name": "completion_stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "extraction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'WAITING'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "extractions_recipe_idx": {
+          "name": "extractions_recipe_idx",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "extractions_recipe_id_recipes_id_fk": {
+          "name": "extractions_recipe_id_recipes_id_fk",
+          "tableFrom": "extractions",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.extractions_audit_log": {
+      "name": "extractions_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "extraction_id": {
+          "name": "extraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(180)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "extractions_audit_log_extraction_idx": {
+          "name": "extractions_audit_log_extraction_idx",
+          "columns": [
+            {
+              "expression": "extraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "extractions_audit_log_user_idx": {
+          "name": "extractions_audit_log_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "extractions_audit_log_extraction_id_extractions_id_fk": {
+          "name": "extractions_audit_log_extraction_id_extractions_id_fk",
+          "tableFrom": "extractions_audit_log",
+          "tableTo": "extractions",
+          "columnsFrom": [
+            "extraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "extractions_audit_log_user_id_users_id_fk": {
+          "name": "extractions_audit_log_user_id_users_id_fk",
+          "tableFrom": "extractions_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.institutions": {
+      "name": "institutions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domains": {
+          "name": "domains",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "institutions_name_unique": {
+          "name": "institutions_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.model_api_calls": {
+      "name": "model_api_calls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "extraction_id": {
+          "name": "extraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "provider_model",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "call_site": {
+          "name": "call_site",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_token_count": {
+          "name": "input_token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_token_count": {
+          "name": "output_token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crawl_page_id": {
+          "name": "crawl_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "model_api_calls_extraction_idx": {
+          "name": "model_api_calls_extraction_idx",
+          "columns": [
+            {
+              "expression": "extraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "model_api_calls_datasaet_idx": {
+          "name": "model_api_calls_datasaet_idx",
+          "columns": [
+            {
+              "expression": "dataset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "model_api_calls_crawl_page_idx": {
+          "name": "model_api_calls_crawl_page_idx",
+          "columns": [
+            {
+              "expression": "crawl_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_api_calls_extraction_id_extractions_id_fk": {
+          "name": "model_api_calls_extraction_id_extractions_id_fk",
+          "tableFrom": "model_api_calls",
+          "tableTo": "extractions",
+          "columnsFrom": [
+            "extraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_api_calls_dataset_id_datasets_id_fk": {
+          "name": "model_api_calls_dataset_id_datasets_id_fk",
+          "tableFrom": "model_api_calls",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_api_calls_crawl_page_id_crawl_pages_id_fk": {
+          "name": "model_api_calls_crawl_page_id_crawl_pages_id_fk",
+          "tableFrom": "model_api_calls",
+          "tableTo": "crawl_pages",
+          "columnsFrom": [
+            "crawl_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.recipes": {
+      "name": "recipes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_template": {
+          "name": "is_template",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "catalogue_id": {
+          "name": "catalogue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "detection_failure_reason": {
+          "name": "detection_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "recipe_detection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'WAITING'"
+        },
+        "robots_txt": {
+          "name": "robots_txt",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acknowledged_skip_robots_txt": {
+          "name": "acknowledged_skip_robots_txt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recipes_catalogue_idx": {
+          "name": "recipes_catalogue_idx",
+          "columns": [
+            {
+              "expression": "catalogue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recipes_template_idx": {
+          "name": "recipes_template_idx",
+          "columns": [
+            {
+              "expression": "is_template",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "catalogue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipes_catalogue_id_catalogues_id_fk": {
+          "name": "recipes_catalogue_id_catalogues_id_fk",
+          "tableFrom": "recipes",
+          "tableTo": "catalogues",
+          "columnsFrom": [
+            "catalogue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_encrypted": {
+          "name": "is_encrypted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "encrypted_preview": {
+          "name": "encrypted_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "settings_key_unique": {
+          "name": "settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      }
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "public.catalogue_type": {
+      "name": "catalogue_type",
+      "schema": "public",
+      "values": [
+        "COURSES",
+        "LEARNING_PROGRAMS",
+        "COMPETENCIES",
+        "CREDENTIALS"
+      ]
+    },
+    "public.extraction_status": {
+      "name": "extraction_status",
+      "schema": "public",
+      "values": [
+        "WAITING",
+        "IN_PROGRESS",
+        "COMPLETE",
+        "STALE",
+        "CANCELLED"
+      ]
+    },
+    "public.log_level": {
+      "name": "log_level",
+      "schema": "public",
+      "values": [
+        "INFO",
+        "ERROR"
+      ]
+    },
+    "public.page_status": {
+      "name": "page_status",
+      "schema": "public",
+      "values": [
+        "WAITING",
+        "IN_PROGRESS",
+        "DOWNLOADED",
+        "SUCCESS",
+        "EXTRACTED_NO_DATA",
+        "ERROR"
+      ]
+    },
+    "public.page_type": {
+      "name": "page_type",
+      "schema": "public",
+      "values": [
+        "DETAIL",
+        "CATEGORY_LINKS",
+        "DETAIL_LINKS",
+        "API_REQUEST",
+        "EXPLORATORY"
+      ]
+    },
+    "public.provider": {
+      "name": "provider",
+      "schema": "public",
+      "values": [
+        "openai"
+      ]
+    },
+    "public.provider_model": {
+      "name": "provider_model",
+      "schema": "public",
+      "values": [
+        "gpt-4o",
+        "gpt-4.1",
+        "o3-mini",
+        "o4-mini",
+        "gpt-5"
+      ]
+    },
+    "public.recipe_detection_status": {
+      "name": "recipe_detection_status",
+      "schema": "public",
+      "values": [
+        "WAITING",
+        "IN_PROGRESS",
+        "SUCCESS",
+        "ERROR"
+      ]
+    },
+    "public.step": {
+      "name": "step",
+      "schema": "public",
+      "values": [
+        "FETCH_ROOT",
+        "FETCH_PAGINATED",
+        "FETCH_LINKS",
+        "FETCH_VIA_API"
+      ]
+    },
+    "public.url_pattern_type": {
+      "name": "url_pattern_type",
+      "schema": "public",
+      "values": [
+        "page_num",
+        "offset"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/migrations/meta/0017_snapshot.json
+++ b/server/migrations/meta/0017_snapshot.json
@@ -1,0 +1,1415 @@
+{
+  "id": "e0e92807-7294-4d13-8eeb-3ee3929c24ef",
+  "prevId": "8f663c37-ac02-4e87-a400-7bbc69ce1250",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.catalogues": {
+      "name": "catalogues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "catalogue_type": {
+          "name": "catalogue_type",
+          "type": "catalogue_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COURSES'"
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "catalogues_institution_id_institutions_id_fk": {
+          "name": "catalogues_institution_id_institutions_id_fk",
+          "tableFrom": "catalogues",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "catalogues_url_catalogue_type_unique": {
+          "name": "catalogues_url_catalogue_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url",
+            "catalogue_type"
+          ]
+        }
+      }
+    },
+    "public.crawl_pages": {
+      "name": "crawl_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "extraction_id": {
+          "name": "extraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crawl_step_id": {
+          "name": "crawl_step_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step": {
+          "name": "step",
+          "type": "step",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "page_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'WAITING'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshot": {
+          "name": "screenshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetch_failure_reason": {
+          "name": "fetch_failure_reason",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_type": {
+          "name": "page_type",
+          "type": "page_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_extraction_started_at": {
+          "name": "data_extraction_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crawl_pages_extraction_idx": {
+          "name": "crawl_pages_extraction_idx",
+          "columns": [
+            {
+              "expression": "extraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crawl_pages_status_idx": {
+          "name": "crawl_pages_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crawl_pages_data_type_idx": {
+          "name": "crawl_pages_data_type_idx",
+          "columns": [
+            {
+              "expression": "page_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crawl_pages_step_idx": {
+          "name": "crawl_pages_step_idx",
+          "columns": [
+            {
+              "expression": "crawl_step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crawl_pages_extraction_id_extractions_id_fk": {
+          "name": "crawl_pages_extraction_id_extractions_id_fk",
+          "tableFrom": "crawl_pages",
+          "tableTo": "extractions",
+          "columnsFrom": [
+            "extraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crawl_pages_crawl_step_id_crawl_steps_id_fk": {
+          "name": "crawl_pages_crawl_step_id_crawl_steps_id_fk",
+          "tableFrom": "crawl_pages",
+          "tableTo": "crawl_steps",
+          "columnsFrom": [
+            "crawl_step_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "crawl_pages_extraction_id_url_step_unique": {
+          "name": "crawl_pages_extraction_id_url_step_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "extraction_id",
+            "url",
+            "step"
+          ]
+        }
+      }
+    },
+    "public.crawl_steps": {
+      "name": "crawl_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "extraction_id": {
+          "name": "extraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step": {
+          "name": "step",
+          "type": "step",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_step_id": {
+          "name": "parent_step_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crawl_steps_extraction_idx": {
+          "name": "crawl_steps_extraction_idx",
+          "columns": [
+            {
+              "expression": "extraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crawl_steps_parent_step_idx": {
+          "name": "crawl_steps_parent_step_idx",
+          "columns": [
+            {
+              "expression": "parent_step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crawl_steps_extraction_id_extractions_id_fk": {
+          "name": "crawl_steps_extraction_id_extractions_id_fk",
+          "tableFrom": "crawl_steps",
+          "tableTo": "extractions",
+          "columnsFrom": [
+            "extraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crawl_steps_parent_step_id_crawl_steps_id_fk": {
+          "name": "crawl_steps_parent_step_id_crawl_steps_id_fk",
+          "tableFrom": "crawl_steps",
+          "tableTo": "crawl_steps",
+          "columnsFrom": [
+            "parent_step_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.data_items": {
+      "name": "data_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crawl_page_id": {
+          "name": "crawl_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "structured_data": {
+          "name": "structured_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_inclusion": {
+          "name": "text_inclusion",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_items_dataset_idx": {
+          "name": "data_items_dataset_idx",
+          "columns": [
+            {
+              "expression": "dataset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "data_items_crawl_page_idx": {
+          "name": "data_items_crawl_page_idx",
+          "columns": [
+            {
+              "expression": "crawl_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "data_items_dataset_id_datasets_id_fk": {
+          "name": "data_items_dataset_id_datasets_id_fk",
+          "tableFrom": "data_items",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "data_items_crawl_page_id_crawl_pages_id_fk": {
+          "name": "data_items_crawl_page_id_crawl_pages_id_fk",
+          "tableFrom": "data_items",
+          "tableTo": "crawl_pages",
+          "columnsFrom": [
+            "crawl_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.datasets": {
+      "name": "datasets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "catalogue_id": {
+          "name": "catalogue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extraction_id": {
+          "name": "extraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "datasets_catalogue_idx": {
+          "name": "datasets_catalogue_idx",
+          "columns": [
+            {
+              "expression": "catalogue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "datasets_extraction_idx": {
+          "name": "datasets_extraction_idx",
+          "columns": [
+            {
+              "expression": "extraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "datasets_catalogue_id_catalogues_id_fk": {
+          "name": "datasets_catalogue_id_catalogues_id_fk",
+          "tableFrom": "datasets",
+          "tableTo": "catalogues",
+          "columnsFrom": [
+            "catalogue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "datasets_extraction_id_extractions_id_fk": {
+          "name": "datasets_extraction_id_extractions_id_fk",
+          "tableFrom": "datasets",
+          "tableTo": "extractions",
+          "columnsFrom": [
+            "extraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.extraction_logs": {
+      "name": "extraction_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "extraction_id": {
+          "name": "extraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crawl_page_id": {
+          "name": "crawl_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log": {
+          "name": "log",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "log_level": {
+          "name": "log_level",
+          "type": "log_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INFO'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "extraction_logs_extraction_idx": {
+          "name": "extraction_logs_extraction_idx",
+          "columns": [
+            {
+              "expression": "extraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "extraction_logs_crawl_page_idx": {
+          "name": "extraction_logs_crawl_page_idx",
+          "columns": [
+            {
+              "expression": "crawl_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "extraction_logs_extraction_id_extractions_id_fk": {
+          "name": "extraction_logs_extraction_id_extractions_id_fk",
+          "tableFrom": "extraction_logs",
+          "tableTo": "extractions",
+          "columnsFrom": [
+            "extraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "extraction_logs_crawl_page_id_crawl_pages_id_fk": {
+          "name": "extraction_logs_crawl_page_id_crawl_pages_id_fk",
+          "tableFrom": "extraction_logs",
+          "tableTo": "crawl_pages",
+          "columnsFrom": [
+            "crawl_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.extractions": {
+      "name": "extractions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completion_stats": {
+          "name": "completion_stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "extraction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'WAITING'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "extractions_recipe_idx": {
+          "name": "extractions_recipe_idx",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "extractions_recipe_id_recipes_id_fk": {
+          "name": "extractions_recipe_id_recipes_id_fk",
+          "tableFrom": "extractions",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.extractions_audit_log": {
+      "name": "extractions_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "extraction_id": {
+          "name": "extraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(180)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "extractions_audit_log_extraction_idx": {
+          "name": "extractions_audit_log_extraction_idx",
+          "columns": [
+            {
+              "expression": "extraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "extractions_audit_log_user_idx": {
+          "name": "extractions_audit_log_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "extractions_audit_log_extraction_id_extractions_id_fk": {
+          "name": "extractions_audit_log_extraction_id_extractions_id_fk",
+          "tableFrom": "extractions_audit_log",
+          "tableTo": "extractions",
+          "columnsFrom": [
+            "extraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "extractions_audit_log_user_id_users_id_fk": {
+          "name": "extractions_audit_log_user_id_users_id_fk",
+          "tableFrom": "extractions_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.institutions": {
+      "name": "institutions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domains": {
+          "name": "domains",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "institutions_name_unique": {
+          "name": "institutions_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.model_api_calls": {
+      "name": "model_api_calls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "extraction_id": {
+          "name": "extraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "provider_model",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "call_site": {
+          "name": "call_site",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_token_count": {
+          "name": "input_token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_token_count": {
+          "name": "output_token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crawl_page_id": {
+          "name": "crawl_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "model_api_calls_extraction_idx": {
+          "name": "model_api_calls_extraction_idx",
+          "columns": [
+            {
+              "expression": "extraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "model_api_calls_datasaet_idx": {
+          "name": "model_api_calls_datasaet_idx",
+          "columns": [
+            {
+              "expression": "dataset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "model_api_calls_crawl_page_idx": {
+          "name": "model_api_calls_crawl_page_idx",
+          "columns": [
+            {
+              "expression": "crawl_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_api_calls_extraction_id_extractions_id_fk": {
+          "name": "model_api_calls_extraction_id_extractions_id_fk",
+          "tableFrom": "model_api_calls",
+          "tableTo": "extractions",
+          "columnsFrom": [
+            "extraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_api_calls_dataset_id_datasets_id_fk": {
+          "name": "model_api_calls_dataset_id_datasets_id_fk",
+          "tableFrom": "model_api_calls",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_api_calls_crawl_page_id_crawl_pages_id_fk": {
+          "name": "model_api_calls_crawl_page_id_crawl_pages_id_fk",
+          "tableFrom": "model_api_calls",
+          "tableTo": "crawl_pages",
+          "columnsFrom": [
+            "crawl_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.recipes": {
+      "name": "recipes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_template": {
+          "name": "is_template",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "catalogue_id": {
+          "name": "catalogue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "detection_failure_reason": {
+          "name": "detection_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "recipe_detection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'WAITING'"
+        },
+        "robots_txt": {
+          "name": "robots_txt",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acknowledged_skip_robots_txt": {
+          "name": "acknowledged_skip_robots_txt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recipes_catalogue_idx": {
+          "name": "recipes_catalogue_idx",
+          "columns": [
+            {
+              "expression": "catalogue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recipes_template_idx": {
+          "name": "recipes_template_idx",
+          "columns": [
+            {
+              "expression": "is_template",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "catalogue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipes_catalogue_id_catalogues_id_fk": {
+          "name": "recipes_catalogue_id_catalogues_id_fk",
+          "tableFrom": "recipes",
+          "tableTo": "catalogues",
+          "columnsFrom": [
+            "catalogue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_encrypted": {
+          "name": "is_encrypted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "encrypted_preview": {
+          "name": "encrypted_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "settings_key_unique": {
+          "name": "settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      }
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "public.catalogue_type": {
+      "name": "catalogue_type",
+      "schema": "public",
+      "values": [
+        "COURSES",
+        "LEARNING_PROGRAMS",
+        "COMPETENCIES",
+        "CREDENTIALS"
+      ]
+    },
+    "public.extraction_status": {
+      "name": "extraction_status",
+      "schema": "public",
+      "values": [
+        "WAITING",
+        "IN_PROGRESS",
+        "COMPLETE",
+        "STALE",
+        "CANCELLED"
+      ]
+    },
+    "public.log_level": {
+      "name": "log_level",
+      "schema": "public",
+      "values": [
+        "INFO",
+        "ERROR"
+      ]
+    },
+    "public.page_status": {
+      "name": "page_status",
+      "schema": "public",
+      "values": [
+        "WAITING",
+        "IN_PROGRESS",
+        "DOWNLOADED",
+        "SUCCESS",
+        "EXTRACTED_NO_DATA",
+        "ERROR"
+      ]
+    },
+    "public.page_type": {
+      "name": "page_type",
+      "schema": "public",
+      "values": [
+        "DETAIL",
+        "CATEGORY_LINKS",
+        "DETAIL_LINKS",
+        "API_REQUEST",
+        "EXPLORATORY"
+      ]
+    },
+    "public.provider": {
+      "name": "provider",
+      "schema": "public",
+      "values": [
+        "openai"
+      ]
+    },
+    "public.provider_model": {
+      "name": "provider_model",
+      "schema": "public",
+      "values": [
+        "gpt-4o",
+        "gpt-4.1",
+        "o3-mini",
+        "o4-mini",
+        "gpt-5",
+        "gpt-5-nano",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.4-nano"
+      ]
+    },
+    "public.recipe_detection_status": {
+      "name": "recipe_detection_status",
+      "schema": "public",
+      "values": [
+        "WAITING",
+        "IN_PROGRESS",
+        "SUCCESS",
+        "ERROR"
+      ]
+    },
+    "public.step": {
+      "name": "step",
+      "schema": "public",
+      "values": [
+        "FETCH_ROOT",
+        "FETCH_PAGINATED",
+        "FETCH_LINKS",
+        "FETCH_VIA_API"
+      ]
+    },
+    "public.url_pattern_type": {
+      "name": "url_pattern_type",
+      "schema": "public",
+      "values": [
+        "page_num",
+        "offset"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/migrations/meta/_journal.json
+++ b/server/migrations/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1773819352103,
       "tag": "0017_wide_mole_man",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1773774697355,
+      "tag": "0018_bitter_tyrannus",
+      "breakpoints": true
     }
   ]
 }

--- a/server/migrations/meta/_journal.json
+++ b/server/migrations/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1772713584974,
       "tag": "0015_chemical_power_man",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1773773542129,
+      "tag": "0016_gorgeous_franklin_richards",
+      "breakpoints": true
     }
   ]
 }

--- a/server/migrations/meta/_journal.json
+++ b/server/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1773773542129,
       "tag": "0016_gorgeous_franklin_richards",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1773819352103,
+      "tag": "0017_wide_mole_man",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/data/extractions.ts
+++ b/server/src/data/extractions.ts
@@ -827,7 +827,8 @@ export async function createModelApiCallLog(
   callSite: string,
   inputTokenCount: number,
   outputTokenCount: number,
-  datasetId?: number
+  datasetId?: number,
+  crawlPageId?: number
 ) {
   const result = await db
     .insert(modelApiCalls)
@@ -838,7 +839,8 @@ export async function createModelApiCallLog(
       callSite,
       input_token_count: inputTokenCount,
       output_token_count: outputTokenCount,
-      datasetId
+      datasetId,
+      crawlPageId,
     })
     .returning();
   return result[0];

--- a/server/src/data/extractions.ts
+++ b/server/src/data/extractions.ts
@@ -608,6 +608,11 @@ export async function findPage(crawlPageId: number) {
     where: (crawlPages, { eq }) => eq(crawlPages.id, crawlPageId),
     with: {
       crawlStep: true,
+      extraction: {
+        with: {
+          recipe: true,
+        },
+      },
     },
   });
   return result;

--- a/server/src/data/extractions.ts
+++ b/server/src/data/extractions.ts
@@ -41,11 +41,15 @@ import {
 import { findLatestDataset } from "./datasets";
 import getLogger from "../logging";
 
-export async function createExtraction(recipeId: number) {
+export async function createExtraction(
+  recipeId: number,
+  model?: ProviderModel
+) {
   const result = await db
     .insert(extractions)
     .values({
       recipeId,
+      model: model ?? null,
     })
     .returning();
   return result[0];

--- a/server/src/data/schema.ts
+++ b/server/src/data/schema.ts
@@ -339,11 +339,15 @@ const modelApiCalls = pgTable(
     createdAt: timestamp("created_at").notNull().defaultNow(),
     datasetId: integer("dataset_id").references(() => datasets.id, {
       onDelete: "cascade"
-    })
+    }),
+    crawlPageId: integer("crawl_page_id").references(() => crawlPages.id, {
+      onDelete: "cascade",
+    }),
   },
   (t) => ({
     extractionIdx: index("model_api_calls_extraction_idx").on(t.extractionId),
     datasetIdx: index("model_api_calls_datasaet_idx").on(t.datasetId),
+    crawlPageIdx: index("model_api_calls_crawl_page_idx").on(t.crawlPageId),
   })
 );
 
@@ -355,7 +359,11 @@ const modelApiCallsRelations = relations(modelApiCalls, ({ one }) => ({
   dataset: one(datasets, {
     fields: [modelApiCalls.datasetId],
     references: [datasets.id]
-  })
+  }),
+  crawlPage: one(crawlPages, {
+    fields: [modelApiCalls.crawlPageId],
+    references: [crawlPages.id],
+  }),
 }));
 
 const extractionLogs = pgTable(

--- a/server/src/data/schema.ts
+++ b/server/src/data/schema.ts
@@ -301,6 +301,7 @@ const extractions = pgTable(
     recipeId: integer("recipe_id")
       .notNull()
       .references(() => recipes.id, { onDelete: "cascade" }),
+    model: providerModelEnum("model"),
     completionStats: jsonb("completion_stats").$type<CompletionStats>(),
     status: extractionStatusEnum("status")
       .notNull()

--- a/server/src/extraction/llm/determinePresenceOfEntity.ts
+++ b/server/src/extraction/llm/determinePresenceOfEntity.ts
@@ -83,6 +83,7 @@ ${MD_END}
     logApiCall: options?.logApiCalls
       ? {
           extractionId: options.logApiCalls.extractionId,
+          crawlPageId: options.logApiCalls.crawlPageId,
           callSite: "determinePresenceOfEntity",
         }
       : undefined,

--- a/server/src/extraction/llm/determinePresenceOfEntity.ts
+++ b/server/src/extraction/llm/determinePresenceOfEntity.ts
@@ -56,7 +56,8 @@ ${MD_END}
     },
   ];
 
-  const model = entityDef.model || ProviderModel.Gpt5;
+  const model =
+    options.modelOverride ?? entityDef.model ?? ProviderModel.Gpt5;
 
   type PresenceCompletion = { present: boolean; explanation: string };
 

--- a/server/src/extraction/llm/exploreAdditionalPages.ts
+++ b/server/src/extraction/llm/exploreAdditionalPages.ts
@@ -57,9 +57,12 @@ ${MD_END}
     },
   ];
 
+  const model =
+    options.modelOverride ?? entityDef.model ?? ProviderModel.Gpt5;
+
   const result = await structuredCompletion({
     messages,
-    model: entityDef.model || ProviderModel.Gpt5,
+    model,
     schema: {
       type: "object",
       additionalProperties: false,

--- a/server/src/extraction/llm/exploreAdditionalPages.ts
+++ b/server/src/extraction/llm/exploreAdditionalPages.ts
@@ -76,6 +76,7 @@ ${MD_END}
     logApiCall: options?.logApiCalls
       ? {
           extractionId: options.logApiCalls.extractionId,
+          crawlPageId: options.logApiCalls.crawlPageId,
           callSite: "exploreAdditionalPages",
         }
       : undefined,

--- a/server/src/extraction/llm/extractEntityData.ts
+++ b/server/src/extraction/llm/extractEntityData.ts
@@ -266,11 +266,14 @@ ${basePrompt}
     }
   }
 
+  const model =
+    options.modelOverride ?? entityDef.model ?? ProviderModel.Gpt5;
+
   if (entityDef.schema) {
     const results = await structuredCompletion({
       messages,
       schema: entityDef.schema,
-      model: entityDef.model || ProviderModel.Gpt5,
+      model,
       logApiCall: options?.logApiCalls
         ? {
             extractionId: options.logApiCalls.extractionId,
@@ -294,7 +297,7 @@ ${basePrompt}
     const completionParameters = {
       messages,
       toolName: "result",
-      model: entityDef.model || ProviderModel.Gpt5,
+      model,
       parameters: {
         items: {
           type: "array",

--- a/server/src/extraction/llm/extractEntityData.ts
+++ b/server/src/extraction/llm/extractEntityData.ts
@@ -273,10 +273,11 @@ ${basePrompt}
       model: entityDef.model || ProviderModel.Gpt5,
       logApiCall: options?.logApiCalls
         ? {
-          extractionId: options.logApiCalls.extractionId,
-          datasetId: options.logApiCalls.datasetId,
-          callSite: "extractEntityData",
-        }
+            extractionId: options.logApiCalls.extractionId,
+            datasetId: options.logApiCalls.datasetId,
+            crawlPageId: options.logApiCalls.crawlPageId,
+            callSite: "extractEntityData",
+          }
         : undefined,
     });
 
@@ -307,10 +308,11 @@ ${basePrompt}
       requiredParameters: ["items"],
       logApiCall: options?.logApiCalls
         ? {
-          extractionId: options.logApiCalls.extractionId,
-          datasetId: options.logApiCalls.datasetId,
-          callSite: "extractEntityData",
-        }
+            extractionId: options.logApiCalls.extractionId,
+            datasetId: options.logApiCalls.datasetId,
+            crawlPageId: options.logApiCalls.crawlPageId,
+            callSite: "extractEntityData",
+          }
         : undefined,
     };
 

--- a/server/src/extraction/llm/index.ts
+++ b/server/src/extraction/llm/index.ts
@@ -15,6 +15,7 @@ export interface DefaultLlmPageOptions {
   logApiCalls?: {
     extractionId: number;
     datasetId?: number;
+    crawlPageId?: number;
   };
   additionalContext?: {
     message: string;

--- a/server/src/extraction/llm/index.ts
+++ b/server/src/extraction/llm/index.ts
@@ -1,4 +1,4 @@
-import { CatalogueType } from "../../../../common/types";
+import { CatalogueType, ProviderModel } from "../../../../common/types";
 import getLogger from "../../logging";
 import { SimplifiedMarkdown } from "../../types";
 
@@ -12,6 +12,7 @@ export interface DefaultLlmPageOptions {
   url: string;
   screenshot: string;
   catalogueType?: CatalogueType;
+  modelOverride?: ProviderModel;
   logApiCalls?: {
     extractionId: number;
     datasetId?: number;

--- a/server/src/extraction/startExtraction.ts
+++ b/server/src/extraction/startExtraction.ts
@@ -1,4 +1,9 @@
-import { ExtractionStatus, RecipeDetectionStatus, Step } from "../../../common/types";
+import {
+  ExtractionStatus,
+  ProviderModel,
+  RecipeDetectionStatus,
+  Step,
+} from "../../../common/types";
 import { findCatalogueById } from "../data/catalogues";
 import { createDataset } from "../data/datasets";
 import {
@@ -28,7 +33,8 @@ const logger = getLogger("extraction.startExtraction");
 export async function startExtraction(
   catalogueId: number,
   recipeId: number,
-  userId?: number
+  userId?: number,
+  model?: ProviderModel
 ) {
   const catalogue = await findCatalogueById(catalogueId);
   if (!catalogue) {
@@ -41,7 +47,7 @@ export async function startExtraction(
   if (recipe.status != RecipeDetectionStatus.SUCCESS) {
     throw new Error(`Recipe ${recipeId} hasn't been configured for extraction`);
   }
-  const extraction = await createExtraction(recipe.id);
+  const extraction = await createExtraction(recipe.id, model);
 
   // Log audit entry if user is provided
   if (userId) {

--- a/server/src/openai.ts
+++ b/server/src/openai.ts
@@ -14,9 +14,25 @@ import { exponentialRetry } from "./utils";
 const logger = getLogger("openai");
 
 export const ModelPrices = {
+  [ProviderModel.Gpt54]: {
+    per1MInput: 2.5,
+    per1MOutput: 15.0,
+  },
+  [ProviderModel.Gpt54Mini]: {
+    per1MInput: 0.75,
+    per1MOutput: 4.5,
+  },
+  [ProviderModel.Gpt54Nano]: {
+    per1MInput: 0.2,
+    per1MOutput: 1.25,
+  },
   [ProviderModel.Gpt5]: {
     per1MInput: 1.25,
     per1MOutput: 10.0,
+  },
+  [ProviderModel.Gpt5Nano]: {
+    per1MInput: 0.05,
+    per1MOutput: 0.4,
   },
   [ProviderModel.Gpt4o]: {
     per1MInput: 2.5,
@@ -119,7 +135,13 @@ export async function simpleToolCompletion<
       },
     };
 
-    if (Number.isFinite(options?.top_p) && selectedModel !== ProviderModel.Gpt5) {
+    const noTopP =
+      selectedModel === ProviderModel.Gpt5 ||
+      selectedModel === ProviderModel.Gpt5Nano ||
+      selectedModel === ProviderModel.Gpt54 ||
+      selectedModel === ProviderModel.Gpt54Mini ||
+      selectedModel === ProviderModel.Gpt54Nano;
+    if (Number.isFinite(options?.top_p) && !noTopP) {
       completionOptions.top_p = options?.top_p;
     }
     try {
@@ -239,7 +261,13 @@ export async function structuredCompletion<
       } as any,
     };
 
-    if (Number.isFinite(options?.top_p) && selectedModel !== ProviderModel.Gpt5) {
+    const noTopP =
+      selectedModel === ProviderModel.Gpt5 ||
+      selectedModel === ProviderModel.Gpt5Nano ||
+      selectedModel === ProviderModel.Gpt54 ||
+      selectedModel === ProviderModel.Gpt54Mini ||
+      selectedModel === ProviderModel.Gpt54Nano;
+    if (Number.isFinite(options?.top_p) && !noTopP) {
       completionOptions.top_p = options?.top_p;
     }
 

--- a/server/src/openai.ts
+++ b/server/src/openai.ts
@@ -83,6 +83,7 @@ export async function simpleToolCompletion<
   logApiCall?: {
     callSite: string;
     extractionId: number;
+    crawlPageId?: number;
   };
 }): Promise<{
   toolCallArgs: ToolCallReturn<T> | null;
@@ -171,7 +172,9 @@ export async function simpleToolCompletion<
         (completionOptions.model as ProviderModel) || ProviderModel.Gpt5,
         options.logApiCall.callSite,
         inputTokenCount,
-        outputTokenCount
+        outputTokenCount,
+        undefined,
+        options.logApiCall.crawlPageId
       );
     }
 
@@ -208,6 +211,7 @@ export async function structuredCompletion<
     callSite: string;
     extractionId: number;
     datasetId?: number;
+    crawlPageId?: number;
   };
 }): Promise<{
   result: ToolCallReturn<T> | null;
@@ -294,7 +298,8 @@ export async function structuredCompletion<
         options.logApiCall.callSite,
         inputTokenCount,
         outputTokenCount,
-        options.logApiCall.datasetId
+        options.logApiCall.datasetId,
+        options.logApiCall.crawlPageId
       );
     }
 

--- a/server/src/routers/extractions.ts
+++ b/server/src/routers/extractions.ts
@@ -321,7 +321,10 @@ export const extractionsRouter = router({
           url: crawlPage.url,
           content,
           screenshot,
-          logApiCalls: { extractionId: crawlPage.extractionId },
+          logApiCalls: {
+            extractionId: crawlPage.extractionId,
+            crawlPageId: crawlPage.id,
+          },
         },
         crawlPage.extraction.recipe.catalogue.catalogueType as CatalogueType
       );

--- a/server/src/routers/extractions.ts
+++ b/server/src/routers/extractions.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
 import { publicProcedure, router } from ".";
-import { CatalogueType, ExtractionStatus } from "../../../common/types";
+import {
+  CatalogueType,
+  ExtractionStatus,
+  ProviderModel,
+} from "../../../common/types";
 import { AppError, AppErrors } from "../appErrors";
 import {
   findDataItemsByCrawlPageId,
@@ -45,6 +49,17 @@ export const extractionsRouter = router({
       z.object({
         catalogueId: z.number().positive(),
         recipeId: z.number().positive(),
+        model: z.enum([
+          "gpt-4o",
+          "gpt-4.1",
+          "o3-mini",
+          "o4-mini",
+          "gpt-5",
+          "gpt-5-nano",
+          "gpt-5.4",
+          "gpt-5.4-mini",
+          "gpt-5.4-nano",
+        ]),
       })
     )
     .mutation(async (opts) => {
@@ -52,7 +67,8 @@ export const extractionsRouter = router({
       return startExtraction(
         opts.input.catalogueId,
         opts.input.recipeId,
-        userId
+        userId,
+        opts.input.model as ProviderModel,
       );
     }),
   cancel: publicProcedure
@@ -321,6 +337,8 @@ export const extractionsRouter = router({
           url: crawlPage.url,
           content,
           screenshot,
+          modelOverride: (crawlPage.extraction.model ??
+            undefined) as ProviderModel | undefined,
           logApiCalls: {
             extractionId: crawlPage.extractionId,
             crawlPageId: crawlPage.id,

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -1,4 +1,4 @@
-import { BrowserFetchError, BrowserTaskResult } from "./extraction/browser";
+import { BrowserFetchError } from "./extraction/browser";
 import getLogger from "./logging";
 
 const logger = getLogger("utils");

--- a/server/src/workers/extractData.ts
+++ b/server/src/workers/extractData.ts
@@ -25,6 +25,7 @@ import {
   PageStatus,
   LogLevel,
   PageType,
+  ProviderModel,
   Step,
 } from "../../../common/types";
 import { getCatalogueTypeDefinition } from "../extraction/catalogueTypes";
@@ -76,6 +77,9 @@ export default createProcessor<ExtractDataJob, ExtractDataProgress>(
         content,
         screenshot,
         catalogueType,
+        modelOverride: (crawlPage.extraction.model ?? undefined) as
+          | ProviderModel
+          | undefined,
         logApiCalls: {
           extractionId: crawlPage.extractionId,
           datasetId: dataset.id,

--- a/server/src/workers/extractData.ts
+++ b/server/src/workers/extractData.ts
@@ -76,7 +76,11 @@ export default createProcessor<ExtractDataJob, ExtractDataProgress>(
         content,
         screenshot,
         catalogueType,
-        logApiCalls: { extractionId: crawlPage.extractionId, datasetId: dataset.id },
+        logApiCalls: {
+          extractionId: crawlPage.extractionId,
+          datasetId: dataset.id,
+          crawlPageId: crawlPage.id,
+        },
       };
 
       let skipExtraction = false,

--- a/server/src/workers/fetchPage.ts
+++ b/server/src/workers/fetchPage.ts
@@ -95,7 +95,10 @@ async function enqueuePages(
         crawlPage.crawlStepId,
         crawlPage.id
       ),
-      logApiCalls: { extractionId: crawlPage.extractionId },
+      logApiCalls: {
+        extractionId: crawlPage.extractionId,
+        crawlPageId: crawlPage.id,
+      },
       url: crawlPage.url,
       catalogueType,
     },

--- a/server/src/workers/index.ts
+++ b/server/src/workers/index.ts
@@ -204,6 +204,9 @@ export async function detectExtractionJobs(extractionId: number) {
         break;
       }
       for (const job of jobs) {
+        if (!job || !job.data)
+          continue;
+
         if (job.data.extractionId === extractionId) {
           return true;
         }


### PR DESCRIPTION
BullMQ can return entries of jobs with undefined data, skip processing those.