### PR TITLE
Accumulated work PR - April 2026

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,14 +26,15 @@ RUN npm install pm2 -g
 RUN npm install pnpm -g
 
 # Build the app
-COPY client/package.json client/pnpm-lock.yaml /build/app/client/
-COPY server/package.json server/pnpm-lock.yaml /build/app/server/
+COPY client/package.json client/pnpm-lock.yaml client/pnpm-workspace.yaml /build/app/client/
+COPY server/package.json server/pnpm-lock.yaml server/pnpm-workspace.yaml /build/app/server/
 RUN (cd /build/app/client && pnpm install) & \
   (cd /build/app/server && pnpm install) & \
   wait
 
 USER pptruser
 RUN /build/app/server/node_modules/.bin/rebrowser-puppeteer browsers install chrome
+RUN /build/app/server/node_modules/.bin/rebrowser-puppeteer browsers install chrome-headless-shell
 
 USER root
 COPY client/ /build/app/client

--- a/client/pnpm-workspace.yaml
+++ b/client/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  '@swc/core': true
+  esbuild: true

--- a/client/pnpm-workspace.yaml
+++ b/client/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+packages: []
+
 allowBuilds:
   '@swc/core': true
   esbuild: true

--- a/client/src/components/app/extractions/SampleModal.tsx
+++ b/client/src/components/app/extractions/SampleModal.tsx
@@ -1,0 +1,531 @@
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { UIPageStatus } from "@common/types";
+import { concisePrintDate, resolveCrawlPageUrl, trpc } from "@/utils";
+import { ExtractionStatus, PageStatus } from "@/utils";
+import {
+  ChevronsUpDown,
+  ExternalLink as ExternalLinkIcon,
+  FileJson,
+  FileText as FileTextIcon,
+  HelpCircle,
+  ScrollText as ScrollTextIcon,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+interface MultiSelectOption<T> {
+  value: T;
+  label: string;
+}
+
+interface MultiSelectProps<T> {
+  label?: string;
+  options: MultiSelectOption<T>[];
+  value: T[];
+  onChange: (value: T[]) => void;
+  searchPlaceholder?: string;
+  emptyMessage?: string;
+}
+
+function MultiSelect<T extends string>({
+  label,
+  options,
+  value,
+  onChange,
+  searchPlaceholder = "Search...",
+  emptyMessage = "No results found.",
+}: MultiSelectProps<T>) {
+  const [open, setOpen] = useState(false);
+
+  const triggerLabel =
+    value.length === 0
+      ? "None"
+      : value.length === options.length
+        ? "All"
+        : value
+            .map((v) => options.find((o) => o.value === v)?.label ?? v)
+            .join(", ");
+
+  const toggle = (itemValue: T) => {
+    onChange(
+      value.includes(itemValue)
+        ? value.filter((v) => v !== itemValue)
+        : [...value, itemValue]
+    );
+  };
+
+  const selectAll = () => onChange(options.map((o) => o.value));
+  const selectNone = () => onChange([]);
+
+  return (
+    <div>
+      {label && (
+        <label className="text-sm font-medium mb-1 block">{label}</label>
+      )}
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            className="w-full justify-between font-normal"
+          >
+            <span className="truncate">{triggerLabel}</span>
+            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[200px] p-0" align="start">
+          <Command>
+            <CommandInput placeholder={searchPlaceholder} />
+            <CommandList>
+              <CommandEmpty>{emptyMessage}</CommandEmpty>
+              <CommandGroup>
+                <CommandItem
+                  value="all"
+                  onSelect={selectAll}
+                  className="justify-center font-medium"
+                >
+                  All
+                </CommandItem>
+                <CommandItem
+                  value="none"
+                  onSelect={selectNone}
+                  className="justify-center font-medium"
+                >
+                  None
+                </CommandItem>
+                {options.map((opt) => (
+                  <CommandItem
+                    key={opt.value}
+                    value={opt.label}
+                    onSelect={() => toggle(opt.value)}
+                  >
+                    <Checkbox
+                      checked={value.includes(opt.value)}
+                      className="mr-2"
+                    />
+                    {opt.label}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}
+
+const DATA_STATUS_OPTIONS: { value: "present" | "absent"; label: string }[] = [
+  { value: "present", label: "Present" },
+  { value: "absent", label: "Absent" },
+];
+
+const SORT_OPTIONS = [
+  { value: "random", label: "Random" },
+  { value: "most_expensive", label: "Most expensive" },
+  { value: "most_data_items", label: "Most data items" },
+  { value: "least_data_items", label: "Least data items" },
+];
+
+const STATUS_HELP: Record<string, string> = {
+  [PageStatus.WAITING]:
+    "Queued — The page hasn't been processed yet; it's waiting its turn.",
+  [PageStatus.IN_PROGRESS]:
+    "In progress — The system is currently working on this page.",
+  [PageStatus.DOWNLOADED]:
+    "Downloaded — The page content was successfully retrieved from the website and is awaiting extraction.",
+  [PageStatus.SUCCESS]:
+    "Success — Useful information was successfully pulled from this page.",
+  [PageStatus.EXTRACTED_NO_DATA]:
+    "No data found — either the data is not present in the page, the model couldn't find the expected information or the page was not correctly converted to the simplified content form.",
+  [PageStatus.ERROR]:
+    "Error — Something went wrong (e.g. the page couldn't load or timed out).",
+};
+
+type SampledPage = {
+  id: number;
+  extractionId: number;
+  crawlStepId: number;
+  url: string;
+  status: string;
+  pageType: string | null;
+  createdAt: string;
+  dataItemCount: number;
+  tokenSum: number;
+};
+
+function formatThousands(n: number): string {
+  if (n === 0) return "0";
+  const k = n / 1_000;
+  return k % 1 === 0 ? `${k}K` : `${k.toFixed(1)}K`;
+}
+
+interface SampleModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  extractionId: number;
+  extractionStatus?: string;
+  /** Catalogue base URL for resolving relative crawl page URLs */
+  recipeUrl?: string;
+}
+
+export default function SampleModal({
+  open,
+  onOpenChange,
+  extractionId,
+  extractionStatus,
+  recipeUrl,
+}: SampleModalProps) {
+  const isExtractionInProgress = [
+    ExtractionStatus.IN_PROGRESS,
+    ExtractionStatus.WAITING,
+  ].includes(extractionStatus as ExtractionStatus);
+  const [sampleSizePercent, setSampleSizePercent] = useState(5);
+  const [dataStatus, setDataStatus] = useState<("present" | "absent")[]>([
+    "present",
+  ]);
+  const [statuses, setStatuses] = useState<PageStatus[]>(() =>
+    UIPageStatus.map((o) => o.value)
+  );
+  const [sortBy, setSortBy] = useState<
+    "random" | "most_expensive" | "most_data_items" | "least_data_items"
+  >("random");
+
+  const [appliedFilters, setAppliedFilters] = useState<{
+    sampleSizePercent: number;
+    dataStatus: ("present" | "absent")[];
+    statuses: PageStatus[];
+    sortBy: "random" | "most_expensive" | "most_data_items" | "least_data_items";
+    applyKey: number;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setAppliedFilters(null);
+    }
+  }, [open]);
+
+  const filtersDirty = useMemo(() => {
+    if (!appliedFilters) return false;
+    const arrEq = (a: string[], b: string[]) =>
+      a.length === b.length && a.every((v, i) => v === b[i]);
+    return (
+      appliedFilters.sampleSizePercent !== sampleSizePercent ||
+      !arrEq([...appliedFilters.dataStatus].sort(), [...dataStatus].sort()) ||
+      !arrEq([...appliedFilters.statuses].sort(), [...statuses].sort()) ||
+      appliedFilters.sortBy !== sortBy
+    );
+  }, [appliedFilters, sampleSizePercent, dataStatus, statuses, sortBy]);
+
+  const sampleQuery = trpc.extractions.samplePages.useQuery(
+    {
+      extractionId,
+      sampleSizePercent: appliedFilters?.sampleSizePercent ?? 5,
+      dataStatus: appliedFilters?.dataStatus ?? ["present"],
+      statuses: appliedFilters?.statuses ?? [],
+      sortBy: appliedFilters?.sortBy ?? "random",
+      applyKey: appliedFilters?.applyKey ?? 0,
+    },
+    {
+      enabled: appliedFilters !== null && open,
+    }
+  );
+
+  const sampledPages = (sampleQuery.data ?? []) as SampledPage[];
+
+  const onApplyFilter = useCallback(() => {
+    setAppliedFilters((prev) => ({
+      sampleSizePercent,
+      dataStatus: [...dataStatus],
+      statuses: [...statuses],
+      sortBy,
+      applyKey: (prev?.applyKey ?? 0) + 1,
+    }));
+  }, [sampleSizePercent, dataStatus, statuses, sortBy]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="sm:max-w-[66vw] w-[66vw] max-h-[66vh] h-[66vh] flex flex-col p-0 gap-0"
+        onPointerDownOutside={(e) => e.preventDefault()}
+      >
+        <DialogHeader className="px-6 pt-6 pb-4 shrink-0">
+          <DialogTitle>Sample extraction items</DialogTitle>
+          {appliedFilters && !sampleQuery.isLoading && (
+            <p className="text-sm text-muted-foreground mt-1">
+              {sampledPages.length} item{sampledPages.length !== 1 ? "s" : ""}
+            </p>
+          )}
+        </DialogHeader>
+
+        {isExtractionInProgress && (
+          <div className="mx-6 mb-4 px-4 py-3 rounded-md bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 text-amber-800 dark:text-amber-200 text-sm shrink-0">
+            Extraction is in progress. Data will change.
+          </div>
+        )}
+
+        <div className="flex flex-col flex-1 min-h-0 px-6 pb-6">
+          {/* Filter section */}
+          <div className="grid grid-cols-2 md:grid-cols-5 gap-4 mb-4 shrink-0">
+            <div>
+              <label className="text-sm font-medium mb-1 block">
+                Sample size (%)
+              </label>
+              <Input
+                type="number"
+                min={0}
+                max={100}
+                value={sampleSizePercent}
+                onChange={(e) =>
+                  setSampleSizePercent(
+                    Math.min(100, Math.max(0, parseInt(e.target.value) || 0))
+                  )
+                }
+              />
+            </div>
+            <MultiSelect
+              label="Data status"
+              options={DATA_STATUS_OPTIONS}
+              value={dataStatus}
+              onChange={setDataStatus}
+              searchPlaceholder="Search..."
+              emptyMessage="No option found."
+            />
+            <div>
+              <label className="text-sm font-medium mb-1 block">
+                <span className="inline-flex items-center gap-1">
+                  Status
+                  <TooltipProvider>
+                    <Tooltip delayDuration={200}>
+                      <TooltipTrigger asChild>
+                        <HelpCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help shrink-0" />
+                      </TooltipTrigger>
+                      <TooltipContent
+                        side="top"
+                        align="start"
+                        className="max-w-[280px] space-y-1.5 p-3"
+                      >
+                        {UIPageStatus.map(({ value, label }) => (
+                          <p key={value} className="text-xs leading-snug">
+                            <span className="font-medium">{label}:</span>{" "}
+                            {STATUS_HELP[value]}
+                          </p>
+                        ))}
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                </span>
+              </label>
+              <MultiSelect
+                options={UIPageStatus}
+                value={statuses}
+                onChange={setStatuses}
+                searchPlaceholder="Search status..."
+                emptyMessage="No status found."
+              />
+            </div>
+            <div>
+              <label className="text-sm font-medium mb-1 block">Sort by</label>
+              <Select
+                value={sortBy}
+                onValueChange={(
+                  v:
+                    | "random"
+                    | "most_expensive"
+                    | "most_data_items"
+                    | "least_data_items"
+                ) => setSortBy(v)}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {SORT_OPTIONS.map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex items-end col-span-2 md:col-span-1">
+              <Button
+                onClick={onApplyFilter}
+                disabled={sampleQuery.isFetching}
+              >
+                {sampleQuery.isFetching ? "Applying..." : "Apply filter"}
+              </Button>
+            </div>
+          </div>
+
+          {filtersDirty && (
+            <div className="mb-4 px-4 py-3 rounded-md bg-muted border text-muted-foreground text-sm shrink-0">
+              Filters have changed. Click Apply filter to update results.
+            </div>
+          )}
+
+          {/* Table section */}
+          <div className="flex-1 min-h-0 border rounded-md overflow-hidden">
+            {!appliedFilters ? (
+              <div className="h-full flex items-center justify-center text-muted-foreground">
+                Click Apply Filter
+              </div>
+            ) : sampleQuery.isLoading ? (
+              <div className="h-full flex items-center justify-center text-muted-foreground">
+                Loading...
+              </div>
+            ) : sampledPages.length === 0 ? (
+              <div className="h-full flex items-center justify-center text-muted-foreground">
+                No pages match the filter
+              </div>
+            ) : (
+              <div className="h-full overflow-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow className="text-xs">
+                      <TableHead>ID</TableHead>
+                      <TableHead>Status</TableHead>
+                      <TableHead>Created</TableHead>
+                      <TableHead className="max-w-[200px]">URL</TableHead>
+                      <TableHead className="text-right">Data items</TableHead>
+                      <TableHead className="text-right">Tokens used</TableHead>
+                      <TableHead className="text-right w-[140px]">
+                        Actions
+                      </TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody className="text-xs">
+                    {sampledPages.map((page) => (
+                      <TableRow key={page.id}>
+                        <TableCell>{page.id}</TableCell>
+                        <TableCell>{page.status}</TableCell>
+                        <TableCell>{concisePrintDate(page.createdAt)}</TableCell>
+                        <TableCell className="max-w-[200px] truncate" title={page.url}>
+                          {page.url}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          {page.dataItemCount ?? 0}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          {formatThousands(page.tokenSum)}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          <div className="flex gap-1 justify-end">
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-7 w-7"
+                              title="Open catalogue URL in new tab"
+                              onClick={() =>
+                                window.open(
+                                  recipeUrl
+                                    ? resolveCrawlPageUrl(page.url, recipeUrl)
+                                    : page.url,
+                                  "_blank",
+                                  "noopener,noreferrer"
+                                )
+                              }
+                            >
+                              <ExternalLinkIcon className="h-3.5 w-3.5" />
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-7 w-7"
+                              title="Show extracted data"
+                              asChild
+                            >
+                              <a
+                                href={`/extractions/${extractionId}/steps/${page.crawlStepId}/items/${page.id}?tabName=data`}
+                                target="_blank"
+                                rel="noreferrer"
+                              >
+                                <FileJson className="h-3.5 w-3.5" />
+                              </a>
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-7 w-7"
+                              title="Show simplified content"
+                              asChild
+                            >
+                              <a
+                                href={`/extractions/${extractionId}/steps/${page.crawlStepId}/items/${page.id}?tabName=simplified_content`}
+                                target="_blank"
+                                rel="noreferrer"
+                              >
+                                <FileTextIcon className="h-3.5 w-3.5" />
+                              </a>
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-7 w-7"
+                              title="Show operation logs"
+                              asChild
+                            >
+                              <a
+                                href={`/extractions/${extractionId}/steps/${page.crawlStepId}/items/${page.id}?tabName=operation_logs`}
+                                target="_blank"
+                                rel="noreferrer"
+                              >
+                                <ScrollTextIcon className="h-3.5 w-3.5" />
+                              </a>
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/app/extractions/detail.tsx
+++ b/client/src/components/app/extractions/detail.tsx
@@ -38,12 +38,13 @@ import {
   resolveCrawlPageUrl,
   trpc,
 } from "@/utils";
-import { CookingPot, LibraryBig, List } from "lucide-react";
+import { CookingPot, LibraryBig, List, Pipette } from "lucide-react";
 import { useState } from "react";
 import { Bar, BarChart, XAxis, YAxis } from "recharts";
 import { Link, useLocation, useParams } from "wouter";
 import { displayRecipeDetails } from "../recipes/util";
 import AuditLogModal from "./AuditLogModal";
+import SampleModal from "./SampleModal";
 import { displayStepType } from "./utils";
 
 function displayStepParent(steps: CrawlStep[], parentId: number) {
@@ -139,6 +140,7 @@ export default function ExtractionDetail() {
   const [lockedCancel, setLockedCancel] = useState(true);
   const [lockedDelete, setLockDelete] = useState(true);
   const [auditLogModalOpen, setAuditLogModalOpen] = useState(false);
+  const [sampleModalOpen, setSampleModalOpen] = useState(false);
   const { toast } = useToast();
   const [, navigate] = useLocation();
   const query = trpc.extractions.detail.useQuery(
@@ -898,8 +900,16 @@ export default function ExtractionDetail() {
           ) : null}
         </div>
         <Card className="mt-4">
-          <CardHeader>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0">
             <CardTitle>Extraction Steps</CardTitle>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setSampleModalOpen(true)}
+            >
+              <Pipette className="w-3.5 h-3.5 mr-2" />
+              Sample
+            </Button>
           </CardHeader>
           <CardContent>
             <Tabs defaultValue="table">
@@ -986,6 +996,13 @@ export default function ExtractionDetail() {
         extractionId={extractionIdNum}
         open={auditLogModalOpen}
         onOpenChange={setAuditLogModalOpen}
+      />
+      <SampleModal
+        extractionId={extractionIdNum}
+        extractionStatus={extraction.status}
+        open={sampleModalOpen}
+        onOpenChange={setSampleModalOpen}
+        recipeUrl={extraction.recipe?.url}
       />
     </>
   );

--- a/client/src/components/app/extractions/page.tsx
+++ b/client/src/components/app/extractions/page.tsx
@@ -18,12 +18,26 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { concisePrintDate, prettyPrintDate, resolveCrawlPageUrl, trpc } from "@/utils";
 import { ExternalLink } from "lucide-react";
-import { useState } from "react";
-import { useParams } from "wouter";
+import { useEffect, useState } from "react";
+import { useLocation, useParams, useSearch } from "wouter";
 import { base64Img } from "./utils";
+
+const DEFAULT_TAB = "data";
+
+const VALID_TAB_VALUES = [
+  "data",
+  "raw_content",
+  "screenshot",
+  "simplified_content",
+  "operation_logs",
+];
 
 export default function CrawlPageDetail() {
   const { extractionId, stepId, crawlPageId } = useParams();
+  const [, navigate] = useLocation();
+  const search = useSearch();
+  const basePath = "~" + new URL(window.location.href).pathname;
+
   const crawlPageQuery = trpc.extractions.crawlPageDetail.useQuery(
     { crawlPageId: parseInt(crawlPageId || "") },
     { enabled: !!crawlPageId }
@@ -40,7 +54,22 @@ export default function CrawlPageDetail() {
         (typeof simulateExtractionQuery)["mutateAsync"]
       > | null>
     >(null);
-  if (!crawlPageQuery.data) {
+
+  const item = crawlPageQuery.data;
+
+  useEffect(() => {
+    const sp = new URLSearchParams(search || "");
+    const tabName = sp.get("tabName");
+    const shouldRedirect =
+      !tabName || !VALID_TAB_VALUES.includes(tabName || "");
+
+    if (shouldRedirect) {
+      sp.set("tabName", DEFAULT_TAB);
+      navigate(`${basePath}?${sp.toString()}`, { replace: true });
+    }
+  }, [basePath, navigate, search]);
+
+  if (!item) {
     return null;
   }
 
@@ -52,8 +81,6 @@ export default function CrawlPageDetail() {
       setSimulatedExtractedData(simulatedData);
     }
   };
-
-  const item = crawlPageQuery.data;
 
   const breadCrumbs = [
     { label: "Extractions", href: "/" },
@@ -123,8 +150,6 @@ export default function CrawlPageDetail() {
     </TabsContent>,
   ];
 
-  const defaultTab = "data";
-
   if (item.markdownContent) {
     tabTriggers.push(
       <TabsTrigger key="simplified_content" value="simplified_content">Simplified Content</TabsTrigger>
@@ -190,6 +215,18 @@ export default function CrawlPageDetail() {
     tabTriggers.splice(1, 0, <TabsTrigger key="screenshot" value="screenshot">Screenshot</TabsTrigger>);
     tabContents.splice(1, 0, <TabsContent key="screenshot" value="screenshot">{screenshot}</TabsContent>);
   }
+
+  const tabNameFromUrl = new URLSearchParams(search || "").get("tabName");
+  if (tabNameFromUrl && !VALID_TAB_VALUES.includes(tabNameFromUrl)) {
+    return null;
+  }
+  const currentTab = tabNameFromUrl ?? DEFAULT_TAB;
+
+  const onTabChange = (value: string) => {
+    const sp = new URLSearchParams(search || "");
+    sp.set("tabName", value);
+    navigate(`${basePath}?${sp.toString()}`);
+  };
 
   const formattedSimulatedData = simulatedExtractedData?.data
     ? JSON.stringify(simulatedExtractedData?.data, null, 2)
@@ -259,7 +296,7 @@ export default function CrawlPageDetail() {
         )}
       </div>
 
-      <Tabs defaultValue={defaultTab}>
+      <Tabs value={currentTab} onValueChange={onTabChange}>
         <TabsList className="w-full mb-4">{tabTriggers}</TabsList>
         <div className="border border-dashed p-4 text-xs overflow-auto">
           {tabContents}

--- a/client/src/components/app/profile/index.tsx
+++ b/client/src/components/app/profile/index.tsx
@@ -4,6 +4,7 @@ import {
   CardContent,
   CardDescription,
   CardHeader,
+  CardTitle,
 } from "@/components/ui/card";
 import {
   Form,
@@ -14,12 +15,16 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { trpc } from "@/utils";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { EmailNotificationPreference, trpc } from "@/utils";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useContext, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
 import { useToast } from "@/components/ui/use-toast";
+import UserContext from "@/userContext";
 
 const FormSchema = z
   .object({
@@ -36,7 +41,18 @@ const FormSchema = z
     }
   });
 
+const emailNotificationPreferenceSchema = z.nativeEnum(
+  EmailNotificationPreference
+);
+
 export default function MyProfile() {
+  const { user } = useContext(UserContext);
+  const userId = user?.id as number | undefined;
+  const detailQuery = trpc.users.detail.useQuery(
+    { id: userId! },
+    { enabled: userId != null }
+  );
+  const patchPrefs = trpc.users.patchUserPreferences.useMutation();
   const redefPassword = trpc.users.redefinePassword.useMutation();
   const form = useForm<z.infer<typeof FormSchema>>({
     resolver: zodResolver(FormSchema),
@@ -46,6 +62,25 @@ export default function MyProfile() {
     },
   });
   const { toast } = useToast();
+
+  const savedNotificationPref =
+    detailQuery.data?.userPreferences?.email?.notifications ??
+    EmailNotificationPreference.ALWAYS;
+
+  const [draftNotificationPref, setDraftNotificationPref] =
+    useState<EmailNotificationPreference>(EmailNotificationPreference.ALWAYS);
+
+  useEffect(() => {
+    if (detailQuery.data) {
+      setDraftNotificationPref(
+        detailQuery.data.userPreferences?.email?.notifications ??
+          EmailNotificationPreference.ALWAYS
+      );
+    }
+  }, [detailQuery.data]);
+
+  const notificationPrefsDirty =
+    draftNotificationPref !== savedNotificationPref;
 
   async function onSubmit(data: z.infer<typeof FormSchema>) {
     await redefPassword.mutateAsync({ password: data.password });
@@ -60,66 +95,150 @@ export default function MyProfile() {
     <>
       <h1 className="text-lg font-semibold md:text-2xl">My Profile</h1>
       <div>
-        <Form {...form}>
-          <form
-            onSubmit={form.handleSubmit(onSubmit)}
-            className="w-full space-y-6"
-          >
-            <div className="grid gap-2 md:grid-cols-[1fr_250px] lg:grid-cols-2 lg:gap-4">
-              <Card>
-                <CardHeader>
-                  <CardDescription>Redefine my password</CardDescription>
-                </CardHeader>
-                <CardContent className="grid gap-4">
-                  <div className="grid gap-2">
-                    <FormField
-                      control={form.control}
-                      name="password"
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormLabel>New Password</FormLabel>
-                          <FormControl>
-                            <Input
-                              placeholder="Your password"
-                              type="password"
-                              {...field}
-                            />
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
+        <div className="w-full space-y-6">
+          <div className="grid gap-2 md:grid-cols-[1fr_250px] lg:grid-cols-2 lg:gap-4">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg">Email notifications</CardTitle>
+                <CardDescription>
+                  These emails cover finished extractions and recipe configuration
+                  detection. Notify for my extractions limits mail to runs you
+                  started and detection you triggered; choose Notify me always to
+                  receive every notification from the app.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="grid gap-4">
+                <RadioGroup
+                  value={draftNotificationPref}
+                  onValueChange={(value) => {
+                    const parsed =
+                      emailNotificationPreferenceSchema.safeParse(value);
+                    if (parsed.success) {
+                      setDraftNotificationPref(parsed.data);
+                    }
+                  }}
+                  disabled={
+                    detailQuery.isLoading ||
+                    detailQuery.isFetching ||
+                    patchPrefs.isLoading
+                  }
+                  className="grid gap-3"
+                >
+                  <div className="flex items-center space-x-2">
+                    <RadioGroupItem
+                      value={EmailNotificationPreference.ALWAYS}
+                      id="email-notify-always"
                     />
+                    <Label htmlFor="email-notify-always" className="font-normal">
+                      Notify me always
+                    </Label>
                   </div>
-                  <div className="grid gap-2">
-                    <FormField
-                      control={form.control}
-                      name="passwordConfirmation"
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormLabel>New Password Confirmation</FormLabel>
-                          <FormControl>
-                            <Input
-                              placeholder="Confirm the password"
-                              type="password"
-                              {...field}
-                            />
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
+                  <div className="flex items-center space-x-2">
+                    <RadioGroupItem
+                      value={EmailNotificationPreference.MINE}
+                      id="email-notify-mine"
                     />
+                    <Label htmlFor="email-notify-mine" className="font-normal">
+                      Notify for my extractions
+                    </Label>
                   </div>
-                </CardContent>
-              </Card>
-            </div>
-            <Button
-              type="submit"
-              disabled={redefPassword.isLoading ? true : undefined}
-            >
-              Update password
-            </Button>
-          </form>
-        </Form>
+                  <div className="flex items-center space-x-2">
+                    <RadioGroupItem
+                      value={EmailNotificationPreference.OFF}
+                      id="email-notify-off"
+                    />
+                    <Label htmlFor="email-notify-off" className="font-normal">
+                      Off
+                    </Label>
+                  </div>
+                </RadioGroup>
+                <Button
+                  type="button"
+                  className="w-[150px]"
+                  disabled={
+                    !notificationPrefsDirty ||
+                    detailQuery.isLoading ||
+                    patchPrefs.isLoading
+                  }
+                  onClick={async () => {
+                    await patchPrefs.mutateAsync({
+                      email: {
+                        notifications: draftNotificationPref,
+                      },
+                    });
+                    await detailQuery.refetch();
+                    toast({
+                      title: "Preferences saved",
+                      description:
+                        "Your email notification settings were updated.",
+                    });
+                  }}
+                >
+                  Save
+                </Button>
+              </CardContent>
+            </Card>
+            <Form {...form}>
+              <form onSubmit={form.handleSubmit(onSubmit)}>
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="text-lg">Change password</CardTitle>
+                    <CardDescription>
+                      Set a new password for your account.
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="grid gap-4">
+                    <div className="grid gap-2">
+                      <FormField
+                        control={form.control}
+                        name="password"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>New Password</FormLabel>
+                            <FormControl>
+                              <Input
+                                placeholder="Your password"
+                                type="password"
+                                {...field}
+                              />
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                    </div>
+                    <div className="grid gap-2">
+                      <FormField
+                        control={form.control}
+                        name="passwordConfirmation"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>New Password Confirmation</FormLabel>
+                            <FormControl>
+                              <Input
+                                placeholder="Confirm the password"
+                                type="password"
+                                {...field}
+                              />
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                    </div>
+                    <Button
+                      type="submit"
+                      className="w-[150px]"
+                      disabled={redefPassword.isLoading ? true : undefined}
+                    >
+                      Update password
+                    </Button>
+                  </CardContent>
+                </Card>
+              </form>
+            </Form>
+          </div>
+        </div>
       </div>
     </>
   );

--- a/client/src/components/app/recipes/ExpandableRecipeSection.tsx
+++ b/client/src/components/app/recipes/ExpandableRecipeSection.tsx
@@ -1,0 +1,53 @@
+import { cn } from "@/utils";
+import type { ReactNode } from "react";
+
+export type ExpandableRecipeSectionProps = {
+  /** When true, `children` are shown below the header row. */
+  expanded: boolean;
+  /** Checkbox control (typically wrapped in `FormControl`). Omit for static sections. */
+  checkbox?: ReactNode;
+  /** Label beside the checkbox, or a section title when there is no checkbox. */
+  label?: ReactNode;
+  /** Body below the header; only mounted when `expanded` is true. */
+  children?: ReactNode;
+  className?: string;
+  /** Classes for the body region (e.g. `space-y-3 pl-6`). */
+  contentClassName?: string;
+};
+
+/**
+ * Card-style layout for recipe configuration: optional checkbox + label row,
+ * then fields. For always-on groups, omit `checkbox`, set `expanded` to true,
+ * and optionally omit `label` to only wrap `children` in the card.
+ */
+export function ExpandableRecipeSection({
+  expanded,
+  checkbox,
+  label,
+  children,
+  className,
+  contentClassName,
+}: ExpandableRecipeSectionProps) {
+  const hasHeader = checkbox != null || label != null;
+
+  return (
+    <div
+      className={cn(
+        "space-y-4 rounded-lg border bg-background p-4 transition-colors hover:bg-muted/50",
+        className
+      )}
+    >
+      {hasHeader && (
+        <div className="flex flex-row items-start space-x-3 space-y-0">
+          {checkbox}
+          {label != null && (
+            <div className="min-w-0 flex-1 space-y-1 leading-none">{label}</div>
+          )}
+        </div>
+      )}
+      {expanded && children != null && (
+        <div className={cn(contentClassName)}>{children}</div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/app/recipes/PageSetupSection.tsx
+++ b/client/src/components/app/recipes/PageSetupSection.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/ui/tooltip";
 import { ChevronDown, ChevronUp, HelpCircle, Trash2 } from "lucide-react";
 import { PageSetupStep } from "../../../../../common/types";
+import { ExpandableRecipeSection } from "./ExpandableRecipeSection";
 
 interface PageSetupSectionProps {
   basePath: string;
@@ -37,7 +38,6 @@ export function PageSetupSection({
   const stepsFieldName = `${basePath}.pageSetup.steps` as const;
 
   const pageSetup = useWatch({ control, name: pageSetupPath });
-  const enabled = pageSetup?.enabled ?? false;
 
   const { fields, append, remove, move } = useFieldArray({
     control,
@@ -49,28 +49,31 @@ export function PageSetupSection({
   };
 
   return (
-    <div className="space-y-4 rounded-lg border p-4">
-      <FormField
-        control={control}
-        name={`${basePath}.pageSetup.enabled`}
-        render={({ field }) => (
-          <FormItem className="flex flex-row items-start space-x-3 space-y-0">
-            <FormControl>
-              <Checkbox
-                checked={field.value ?? false}
-                onBlur={field.onBlur}
-                ref={field.ref}
-                name={field.name}
-                onCheckedChange={(checked) => {
-                  const next = checked === true;
-                  setPageSetup({
-                    enabled: next,
-                    steps: pageSetup?.steps ?? [],
-                  });
-                }}
-              />
-            </FormControl>
-            <div className="space-y-1 leading-none">
+    <FormField
+      control={control}
+      name={`${basePath}.pageSetup.enabled`}
+      render={({ field }) => (
+        <FormItem className="space-y-0">
+          <ExpandableRecipeSection
+            expanded={field.value ?? false}
+            checkbox={
+              <FormControl>
+                <Checkbox
+                  checked={field.value ?? false}
+                  onBlur={field.onBlur}
+                  ref={field.ref}
+                  name={field.name}
+                  onCheckedChange={(checked) => {
+                    const next = checked === true;
+                    setPageSetup({
+                      enabled: next,
+                      steps: pageSetup?.steps ?? [],
+                    });
+                  }}
+                />
+              </FormControl>
+            }
+            label={
               <FormLabel className="flex items-center gap-1.5">
                 Page actions
                 <Tooltip>
@@ -96,146 +99,143 @@ export function PageSetupSection({
                   </TooltipContent>
                 </Tooltip>
               </FormLabel>
+            }
+            contentClassName="space-y-3 pl-6"
+          >
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-sm text-muted-foreground">Add step:</span>
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={() => append({ type: "click", selector: "" })}
+              >
+                Click
+              </Button>
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={() => append({ type: "wait", seconds: 1 })}
+              >
+                Wait
+              </Button>
             </div>
-          </FormItem>
-        )}
-      />
 
-      {enabled && (
-        <div className="space-y-3 pl-6">
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="text-sm text-muted-foreground">Add step:</span>
-            <Button
-              type="button"
-              variant="secondary"
-              size="sm"
-              onClick={() => append({ type: "click", selector: "" })}
-            >
-              Click
-            </Button>
-            <Button
-              type="button"
-              variant="secondary"
-              size="sm"
-              onClick={() => append({ type: "wait", seconds: 1 })}
-            >
-              Wait
-            </Button>
-          </div>
-
-          {fields.length === 0 ? (
-            <p className="text-sm text-muted-foreground">
-              No steps yet. Add a click or wait step above.
-            </p>
-          ) : (
-            <ul className="space-y-3">
-              {fields.map((fieldItem, index) => {
-                const row = fieldItem as PageSetupStep & { id: string };
-                const step: PageSetupStep =
-                  pageSetup?.steps?.[index] ?? {
-                    type: row.type,
-                    ...(row.type === "click"
-                      ? { selector: row.selector }
-                      : { seconds: row.seconds }),
-                  };
-                return (
-                <li
-                  key={fieldItem.id}
-                  className="flex flex-col gap-2 rounded-md border bg-muted/30 p-3 sm:flex-row sm:items-start"
-                >
-                  <div className="min-w-0 flex-1 space-y-2">
-                    {step.type === "click" && (
-                      <FormField
-                        control={control}
-                        name={`${basePath}.pageSetup.steps.${index}.selector`}
-                        render={({ field: f }) => (
-                          <FormItem>
-                            <FormLabel className="text-xs">
-                              Step {index + 1} — Element selector
-                            </FormLabel>
-                            <FormControl>
-                              <Input
-                                placeholder="CSS selector"
-                                {...f}
-                                value={f.value ?? ""}
-                              />
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
+            {fields.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No steps yet. Add a click or wait step above.
+              </p>
+            ) : (
+              <ul className="space-y-3">
+                {fields.map((fieldItem, index) => {
+                  const row = fieldItem as PageSetupStep & { id: string };
+                  const step: PageSetupStep =
+                    pageSetup?.steps?.[index] ?? {
+                      type: row.type,
+                      ...(row.type === "click"
+                        ? { selector: row.selector }
+                        : { seconds: row.seconds }),
+                    };
+                  return (
+                    <li
+                      key={fieldItem.id}
+                      className="flex flex-col gap-2 rounded-md border bg-muted/30 p-3 sm:flex-row sm:items-start"
+                    >
+                      <div className="min-w-0 flex-1 space-y-2">
+                        {step.type === "click" && (
+                          <FormField
+                            control={control}
+                            name={`${basePath}.pageSetup.steps.${index}.selector`}
+                            render={({ field: f }) => (
+                              <FormItem>
+                                <FormLabel className="text-xs">
+                                  Step {index + 1} — Element selector
+                                </FormLabel>
+                                <FormControl>
+                                  <Input
+                                    placeholder="CSS selector"
+                                    {...f}
+                                    value={f.value ?? ""}
+                                  />
+                                </FormControl>
+                                <FormMessage />
+                              </FormItem>
+                            )}
+                          />
                         )}
-                      />
-                    )}
-                    {step.type === "wait" && (
-                      <FormField
-                        control={control}
-                        name={`${basePath}.pageSetup.steps.${index}.seconds`}
-                        render={({ field: f }) => (
-                          <FormItem>
-                            <FormLabel className="text-xs">
-                              Step {index + 1} — Wait (seconds)
-                            </FormLabel>
-                            <FormControl>
-                              <Input
-                                type="number"
-                                min={1}
-                                max={600}
-                                {...f}
-                                onChange={(e) => {
-                                  const v = e.target.value
-                                    ? parseFloat(e.target.value)
-                                    : 1;
-                                  f.onChange(Number.isFinite(v) ? v : 1);
-                                }}
-                                value={f.value ?? ""}
-                              />
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
+                        {step.type === "wait" && (
+                          <FormField
+                            control={control}
+                            name={`${basePath}.pageSetup.steps.${index}.seconds`}
+                            render={({ field: f }) => (
+                              <FormItem>
+                                <FormLabel className="text-xs">
+                                  Step {index + 1} — Wait (seconds)
+                                </FormLabel>
+                                <FormControl>
+                                  <Input
+                                    type="number"
+                                    min={1}
+                                    max={600}
+                                    {...f}
+                                    onChange={(e) => {
+                                      const v = e.target.value
+                                        ? parseFloat(e.target.value)
+                                        : 1;
+                                      f.onChange(Number.isFinite(v) ? v : 1);
+                                    }}
+                                    value={f.value ?? ""}
+                                  />
+                                </FormControl>
+                                <FormMessage />
+                              </FormItem>
+                            )}
+                          />
                         )}
-                      />
-                    )}
-                  </div>
-                  <div className="flex shrink-0 gap-1 self-end sm:self-start">
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      className="h-8 w-8"
-                      disabled={index === 0}
-                      onClick={() => move(index, index - 1)}
-                      aria-label="Move step up"
-                    >
-                      <ChevronUp className="h-4 w-4" />
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      className="h-8 w-8"
-                      disabled={index >= fields.length - 1}
-                      onClick={() => move(index, index + 1)}
-                      aria-label="Move step down"
-                    >
-                      <ChevronDown className="h-4 w-4" />
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      className="h-8 w-8 text-destructive"
-                      onClick={() => remove(index)}
-                      aria-label="Remove step"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  </div>
-                </li>
-              );
-              })}
-            </ul>
-          )}
-        </div>
+                      </div>
+                      <div className="flex shrink-0 gap-1 self-end sm:self-start">
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="icon"
+                          className="h-8 w-8"
+                          disabled={index === 0}
+                          onClick={() => move(index, index - 1)}
+                          aria-label="Move step up"
+                        >
+                          <ChevronUp className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="icon"
+                          className="h-8 w-8"
+                          disabled={index >= fields.length - 1}
+                          onClick={() => move(index, index + 1)}
+                          aria-label="Move step down"
+                        >
+                          <ChevronDown className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="icon"
+                          className="h-8 w-8 text-destructive"
+                          onClick={() => remove(index)}
+                          aria-label="Remove step"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </ExpandableRecipeSection>
+        </FormItem>
       )}
-    </div>
+    />
   );
 }

--- a/client/src/components/app/recipes/PageSetupSection.tsx
+++ b/client/src/components/app/recipes/PageSetupSection.tsx
@@ -1,0 +1,241 @@
+import {
+  Control,
+  UseFormSetValue,
+  useFieldArray,
+  useWatch,
+} from "react-hook-form";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { ChevronDown, ChevronUp, HelpCircle, Trash2 } from "lucide-react";
+import { PageSetupStep } from "../../../../../common/types";
+
+interface PageSetupSectionProps {
+  basePath: string;
+  control: Control<any>;
+  setValue: UseFormSetValue<any>;
+}
+
+export function PageSetupSection({
+  basePath,
+  control,
+  setValue,
+}: PageSetupSectionProps) {
+  const pageSetupPath = `${basePath}.pageSetup` as const;
+  const stepsFieldName = `${basePath}.pageSetup.steps` as const;
+
+  const pageSetup = useWatch({ control, name: pageSetupPath });
+  const enabled = pageSetup?.enabled ?? false;
+
+  const { fields, append, remove, move } = useFieldArray({
+    control,
+    name: stepsFieldName,
+  });
+
+  const setPageSetup = (next: { enabled: boolean; steps: PageSetupStep[] }) => {
+    setValue(pageSetupPath, next, { shouldDirty: true });
+  };
+
+  return (
+    <div className="space-y-4 rounded-lg border p-4">
+      <FormField
+        control={control}
+        name={`${basePath}.pageSetup.enabled`}
+        render={({ field }) => (
+          <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+            <FormControl>
+              <Checkbox
+                checked={field.value ?? false}
+                onBlur={field.onBlur}
+                ref={field.ref}
+                name={field.name}
+                onCheckedChange={(checked) => {
+                  const next = checked === true;
+                  setPageSetup({
+                    enabled: next,
+                    steps: pageSetup?.steps ?? [],
+                  });
+                }}
+              />
+            </FormControl>
+            <div className="space-y-1 leading-none">
+              <FormLabel className="flex items-center gap-1.5">
+                Page actions
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      className="inline-flex shrink-0 rounded-full text-muted-foreground outline-offset-2 hover:text-foreground focus-visible:outline focus-visible:ring-2 focus-visible:ring-ring"
+                      aria-label="What are page actions?"
+                    >
+                      <HelpCircle className="h-4 w-4 cursor-help" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm text-left" side="top">
+                    <p>
+                      Page actions can be defined to set the page in a specific
+                      state before xTRA performs its actions on the page,
+                      depending on page type. This is useful for certain
+                      catalogues that have a dynamic nature. For example,
+                      catalogues that display course content but do not use
+                      regular page links choosing to use user events instead
+                      such as clicks or scrolls.
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
+              </FormLabel>
+            </div>
+          </FormItem>
+        )}
+      />
+
+      {enabled && (
+        <div className="space-y-3 pl-6">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-sm text-muted-foreground">Add step:</span>
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={() => append({ type: "click", selector: "" })}
+            >
+              Click
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={() => append({ type: "wait", seconds: 1 })}
+            >
+              Wait
+            </Button>
+          </div>
+
+          {fields.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No steps yet. Add a click or wait step above.
+            </p>
+          ) : (
+            <ul className="space-y-3">
+              {fields.map((fieldItem, index) => {
+                const row = fieldItem as PageSetupStep & { id: string };
+                const step: PageSetupStep =
+                  pageSetup?.steps?.[index] ?? {
+                    type: row.type,
+                    ...(row.type === "click"
+                      ? { selector: row.selector }
+                      : { seconds: row.seconds }),
+                  };
+                return (
+                <li
+                  key={fieldItem.id}
+                  className="flex flex-col gap-2 rounded-md border bg-muted/30 p-3 sm:flex-row sm:items-start"
+                >
+                  <div className="min-w-0 flex-1 space-y-2">
+                    {step.type === "click" && (
+                      <FormField
+                        control={control}
+                        name={`${basePath}.pageSetup.steps.${index}.selector`}
+                        render={({ field: f }) => (
+                          <FormItem>
+                            <FormLabel className="text-xs">
+                              Step {index + 1} — Element selector
+                            </FormLabel>
+                            <FormControl>
+                              <Input
+                                placeholder="CSS selector"
+                                {...f}
+                                value={f.value ?? ""}
+                              />
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                    )}
+                    {step.type === "wait" && (
+                      <FormField
+                        control={control}
+                        name={`${basePath}.pageSetup.steps.${index}.seconds`}
+                        render={({ field: f }) => (
+                          <FormItem>
+                            <FormLabel className="text-xs">
+                              Step {index + 1} — Wait (seconds)
+                            </FormLabel>
+                            <FormControl>
+                              <Input
+                                type="number"
+                                min={1}
+                                max={600}
+                                {...f}
+                                onChange={(e) => {
+                                  const v = e.target.value
+                                    ? parseFloat(e.target.value)
+                                    : 1;
+                                  f.onChange(Number.isFinite(v) ? v : 1);
+                                }}
+                                value={f.value ?? ""}
+                              />
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                    )}
+                  </div>
+                  <div className="flex shrink-0 gap-1 self-end sm:self-start">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="icon"
+                      className="h-8 w-8"
+                      disabled={index === 0}
+                      onClick={() => move(index, index - 1)}
+                      aria-label="Move step up"
+                    >
+                      <ChevronUp className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="icon"
+                      className="h-8 w-8"
+                      disabled={index >= fields.length - 1}
+                      onClick={() => move(index, index + 1)}
+                      aria-label="Move step down"
+                    >
+                      <ChevronDown className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="icon"
+                      className="h-8 w-8 text-destructive"
+                      onClick={() => remove(index)}
+                      aria-label="Remove step"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </li>
+              );
+              })}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/app/recipes/RecipeConfigurationEditor.tsx
+++ b/client/src/components/app/recipes/RecipeConfigurationEditor.tsx
@@ -11,6 +11,7 @@ import { Input } from "@/components/ui/input";
 import { useToast } from "@/components/ui/use-toast";
 import { CatalogueType } from "../../../../../common/types";
 import { trpc } from "@/utils";
+import { ExpandableRecipeSection } from "./ExpandableRecipeSection";
 import { RecipeLevel, FormRecipeConfiguration } from "./RecipeLevel";
 
 type RecipeFormData = {
@@ -113,31 +114,33 @@ export function RecipeConfigurationEditor({
 
   return (
     <div className="space-y-4">
-      <FormField
-        control={control}
-        name="configuration.pageLoadWaitTime"
-        render={({ field }) => (
-          <FormItem>
-            <FormLabel>Page Load Wait Time (seconds)</FormLabel>
-            <FormControl>
-              <Input
-                type="number"
-                placeholder="0"
-                {...field}
-                onChange={(e) => {
-                  const value = e.target.value ? parseInt(e.target.value) : undefined;
-                  field.onChange(value);
-                }}
-                value={(field.value ?? "") as string | number}
-              />
-            </FormControl>
-            <FormDescription>
-              How long to wait (in seconds) for the page to fully load after opening. This is useful for pages that dynamically load content. Leave empty or 0 for no additional wait.
-            </FormDescription>
-            <FormMessage />
-          </FormItem>
-        )}
-      />
+      <ExpandableRecipeSection expanded contentClassName="space-y-2">
+        <FormField
+          control={control}
+          name="configuration.pageLoadWaitTime"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Page Load Wait Time (seconds)</FormLabel>
+              <FormControl>
+                <Input
+                  type="number"
+                  placeholder="0"
+                  {...field}
+                  onChange={(e) => {
+                    const value = e.target.value ? parseInt(e.target.value) : undefined;
+                    field.onChange(value);
+                  }}
+                  value={(field.value ?? "") as string | number}
+                />
+              </FormControl>
+              <FormDescription>
+                How long to wait (in seconds) for the page to fully load after opening. This is useful for pages that dynamically load content. Leave empty or 0 for no additional wait.
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </ExpandableRecipeSection>
       <RecipeLevel
         path="configuration"
         control={control}

--- a/client/src/components/app/recipes/RecipeLevel.tsx
+++ b/client/src/components/app/recipes/RecipeLevel.tsx
@@ -24,13 +24,15 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { HelpCircle, Loader2 } from "lucide-react";
+import { CornerDownRight, HelpCircle, Loader2 } from "lucide-react";
 import {
   PageSetupConfig,
   PageType,
   PaginationConfiguration,
   UrlPatternType,
 } from "../../../../../common/types";
+import { cn } from "@/utils";
+import { ExpandableRecipeSection } from "./ExpandableRecipeSection";
 import { PageSetupSection } from "./PageSetupSection";
 
 export type FormRecipeConfiguration = {
@@ -79,8 +81,15 @@ export function RecipeLevel({
   const [isDetectingUrlRegexp, setIsDetectingUrlRegexp] = useState(false);
   const [isDetectingPagination, setIsDetectingPagination] = useState(false);
   const [tooltipOpen, setTooltipOpen] = useState<{ [key: string]: boolean }>({});
+  const [contentSelectorUiExpanded, setContentSelectorUiExpanded] = useState(false);
 
   const rootUrl = form.watch("url");
+
+  const contentSelectorHasValue = Boolean(
+    (config?.contentSelector ?? "").toString().trim()
+  );
+  const contentSelectorSectionExpanded =
+    contentSelectorHasValue || contentSelectorUiExpanded;
 
   const currentConfig = form.getValues(path as any) as FormRecipeConfiguration;
   const parts = path.split(".");
@@ -107,109 +116,158 @@ export function RecipeLevel({
     }
   }, [path, form]);
 
+  const recipeLevelDepth = path.split(".links").length - 1;
+  const levelTitle = `Level ${recipeLevelDepth + 1}`;
+  const levelHeading = (
+    <h3 className="text-lg font-semibold leading-tight tracking-tight">
+      {levelTitle}
+    </h3>
+  );
+
   return (
     <TooltipProvider>
-      <div className="space-y-4 border-l-2 pl-4 mt-4">
-        <FormField
-          control={control}
-          name={`${path}.pageType` as any}
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Page Type</FormLabel>
-              <Select
-                onValueChange={(value) => {
-                  const currentConfig = form.getValues(
-                    path as any
-                  ) as FormRecipeConfiguration;
-                  const links =
-                    PageType.DETAIL_LINKS == value
-                      ? {
-                          pageType: PageType.DETAIL,
-                          pageSetup: { enabled: false, steps: [] },
-                        }
-                      : currentConfig?.links;
-                  (form.setValue as any)(path, {
-                    ...currentConfig,
-                    pageType: value as PageType,
-                    ...(value !== PageType.DETAIL && {
-                      linkRegexp: currentConfig?.linkRegexp || "",
-                      pagination: currentConfig?.pagination,
-                      links: links,
-                    }),
-                  });
-                  field.onChange(value);
-                }}
-                value={field.value}
-              >
-                <FormControl>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select a page type" />
-                  </SelectTrigger>
-                </FormControl>
-                <SelectContent>
-                  {Object.values(PageType).map((type) => (
-                    <SelectItem key={type} value={type}>
-                      {type}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        <FormField
-          control={control}
-          name={`${path}.contentSelector`}
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel className="flex items-center gap-2">
-                Content Element Selector
-                <Tooltip
-                  open={tooltipOpen[`${path}-contentSelector`] || false}
-                  onOpenChange={(open) =>
-                    setTooltipOpen((prev) => ({
-                      ...prev,
-                      [`${path}-contentSelector`]: open,
-                    }))
-                  }
+      <div className={cn("mt-4", recipeLevelDepth > 0 && "pl-6")}>
+        <div className="space-y-4">
+          <div className="flex items-center gap-3">
+            <CornerDownRight
+              className="h-5 w-5 shrink-0 text-muted-foreground"
+              aria-hidden
+            />
+            {levelHeading}
+          </div>
+          <div className="min-w-0 space-y-4 pl-8">
+            <ExpandableRecipeSection expanded contentClassName="space-y-2">
+          <FormField
+            control={control}
+            name={`${path}.pageType` as any}
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Page Type</FormLabel>
+                <Select
+                  onValueChange={(value) => {
+                    const currentConfig = form.getValues(
+                      path as any
+                    ) as FormRecipeConfiguration;
+                    const links =
+                      PageType.DETAIL_LINKS == value
+                        ? {
+                            pageType: PageType.DETAIL,
+                            pageSetup: { enabled: false, steps: [] },
+                          }
+                        : currentConfig?.links;
+                    (form.setValue as any)(path, {
+                      ...currentConfig,
+                      pageType: value as PageType,
+                      ...(value !== PageType.DETAIL && {
+                        linkRegexp: currentConfig?.linkRegexp || "",
+                        pagination: currentConfig?.pagination,
+                        links: links,
+                      }),
+                    });
+                    field.onChange(value);
+                  }}
+                  value={field.value}
                 >
-                  <TooltipTrigger asChild>
-                    <HelpCircle
-                      className="h-4 w-4 text-muted-foreground cursor-help"
-                      onClick={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        setTooltipOpen((prev) => ({
-                          ...prev,
-                          [`${path}-contentSelector`]: !prev[`${path}-contentSelector`],
-                        }));
-                      }}
-                    />
-                  </TooltipTrigger>
-                  <TooltipContent className="max-w-xs">
-                    <p>
-                      The HTML element selector (aka CSS selector) that xTRA will focus on, ignoring
-                      the other page elements. This is useful for when pages display
-                      a lot of irrelevant content which makes extractions more expensive
-                      and take longer to complete.
-                      The selector can be obtained from
-                      the browser Developer Tools while navigating the page.
-                    </p>
-                  </TooltipContent>
-                </Tooltip>
-              </FormLabel>
-              <FormControl>
-                <Input placeholder="e.g. main.content" {...field} />
-              </FormControl>
-              <FormDescription>
-                Optional. When set, only this element is used as page content.
-              </FormDescription>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select a page type" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {Object.values(PageType).map((type) => (
+                      <SelectItem key={type} value={type}>
+                        {type}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </ExpandableRecipeSection>
+
+        <ExpandableRecipeSection
+          expanded={contentSelectorSectionExpanded}
+          checkbox={
+            <FormControl>
+              <Checkbox
+                checked={contentSelectorSectionExpanded}
+                onCheckedChange={(checked) => {
+                  if (checked) {
+                    setContentSelectorUiExpanded(true);
+                  } else {
+                    setContentSelectorUiExpanded(false);
+                    if (contentSelectorHasValue) {
+                      form.setValue(
+                        `${path}.contentSelector` as Path<any>,
+                        undefined,
+                        { shouldValidate: false }
+                      );
+                    }
+                  }
+                }}
+              />
+            </FormControl>
+          }
+          label={
+            <FormLabel className="!mt-0 flex items-center gap-2">
+              Content Element Selector
+              <Tooltip
+                open={tooltipOpen[`${path}-contentSelector`] || false}
+                onOpenChange={(open) =>
+                  setTooltipOpen((prev) => ({
+                    ...prev,
+                    [`${path}-contentSelector`]: open,
+                  }))
+                }
+              >
+                <TooltipTrigger asChild>
+                  <HelpCircle
+                    className="h-4 w-4 text-muted-foreground cursor-help"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      setTooltipOpen((prev) => ({
+                        ...prev,
+                        [`${path}-contentSelector`]:
+                          !prev[`${path}-contentSelector`],
+                      }));
+                    }}
+                  />
+                </TooltipTrigger>
+                <TooltipContent className="max-w-xs">
+                  <p>
+                    The HTML element selector (aka CSS selector) that xTRA will focus on, ignoring
+                    the other page elements. This is useful for when pages display
+                    a lot of irrelevant content which makes extractions more expensive
+                    and take longer to complete.
+                    The selector can be obtained from
+                    the browser Developer Tools while navigating the page.
+                  </p>
+                </TooltipContent>
+              </Tooltip>
+            </FormLabel>
+          }
+          contentClassName="space-y-2 pl-6"
+        >
+          <FormField
+            control={control}
+            name={`${path}.contentSelector`}
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="sr-only">Content Element Selector</FormLabel>
+                <FormControl>
+                  <Input placeholder="e.g. main.content" {...field} />
+                </FormControl>
+                <FormDescription>
+                  Optional. When set, only this element is used as page content.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </ExpandableRecipeSection>
 
         {config?.pageSetup && (
           <PageSetupSection
@@ -221,59 +279,75 @@ export function RecipeLevel({
 
         {config?.pageType && config.pageType !== PageType.DETAIL && (
           <>
-            <FormItem className="flex flex-row items-start space-x-3 space-y-0">
-              <FormControl>
-                <Checkbox
-                  checked={config?.clickSelector !== undefined}
-                  onCheckedChange={(checked) => {
-                    if (checked) {
-                      // When checked, initialize clickSelector with "body" and set default limit
-                      form.setValue(
-                        `${path}.clickSelector` as Path<any>,
-                        "body",
-                        { shouldValidate: false }
-                      );
-                      const clickOptionsPath =
-                        `${path}.clickOptions` as Path<any>;
-                      const currentClickOptions =
-                        form.getValues(clickOptionsPath);
-                      if (!currentClickOptions?.limit) {
+            <ExpandableRecipeSection
+              expanded={config?.clickSelector !== undefined}
+              checkbox={
+                <FormControl>
+                  <Checkbox
+                    checked={config?.clickSelector !== undefined}
+                    onCheckedChange={(checked) => {
+                      if (checked) {
+                        // When checked, initialize clickSelector with "body" and set default limit
                         form.setValue(
-                          clickOptionsPath as Path<any>,
-                          { limit: 300 },
+                          `${path}.clickSelector` as Path<any>,
+                          "body",
+                          { shouldValidate: false }
+                        );
+                        const clickOptionsPath =
+                          `${path}.clickOptions` as Path<any>;
+                        const currentClickOptions =
+                          form.getValues(clickOptionsPath);
+                        if (!currentClickOptions?.limit) {
+                          form.setValue(
+                            clickOptionsPath as Path<any>,
+                            { limit: 300 },
+                            { shouldValidate: false }
+                          );
+                        }
+                      } else {
+                        // When unchecked, clear clickSelector and clickOptions
+                        form.setValue(
+                          `${path}.clickSelector` as Path<any>,
+                          undefined,
+                          { shouldValidate: false }
+                        );
+                        form.setValue(
+                          `${path}.clickOptions` as Path<any>,
+                          undefined,
                           { shouldValidate: false }
                         );
                       }
-                    } else {
-                      // When unchecked, clear clickSelector and clickOptions
-                      form.setValue(
-                        `${path}.clickSelector` as Path<any>,
-                        undefined,
-                        { shouldValidate: false }
-                      );
-                      form.setValue(
-                        `${path}.clickOptions` as Path<any>,
-                        undefined,
-                        { shouldValidate: false }
-                      );
-                    }
-                  }}
-                />
-              </FormControl>
-              <div className="space-y-1 leading-none">
-                <FormLabel>Dynamic catalogue</FormLabel>
-                <FormDescription>
-                  Enable dynamic link discovery by simulating clicks on the
-                  elements on the page. This is needed for catalogues that do
-                  not use classic page navigation and are more dynamic in
-                  nature.
-                </FormDescription>
-              </div>
-            </FormItem>
-
-            {config?.clickSelector !== undefined && (
-              <>
-                <FormField
+                    }}
+                  />
+                </FormControl>
+              }
+              label={
+                <FormLabel className="flex items-center gap-1.5">
+                  Dynamic catalogue
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        className="inline-flex shrink-0 rounded-full text-muted-foreground outline-offset-2 hover:text-foreground focus-visible:outline focus-visible:ring-2 focus-visible:ring-ring"
+                        aria-label="What is a dynamic catalogue?"
+                      >
+                        <HelpCircle className="h-4 w-4 cursor-help" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent className="max-w-sm text-left" side="top">
+                      <p>
+                        Enable dynamic link discovery by simulating clicks on
+                        the elements on the page. This is needed for catalogues
+                        that do not use classic page navigation and are more
+                        dynamic in nature.
+                      </p>
+                    </TooltipContent>
+                  </Tooltip>
+                </FormLabel>
+              }
+              contentClassName="space-y-4"
+            >
+              <FormField
                   control={control}
                   name={`${path}.clickSelector`}
                   render={({ field }) => (
@@ -420,166 +494,36 @@ export function RecipeLevel({
                     )}
                   />
                 </div>
-              </>
-            )}
+            </ExpandableRecipeSection>
 
-            <FormField
-              control={control}
-              name={`${path}.linkRegexp`}
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Link RegExp</FormLabel>
-                  <div className="flex space-x-2">
-                    <FormControl>
-                      <Input {...field} />
-                    </FormControl>
-                    <Button
-                      type="button"
-                      onClick={async () => {
-                        setIsDetectingUrlRegexp(true);
-                        try {
-                          await onDetectUrlRegexp(
-                            rootUrl,
-                            { parents: parentsConfig, current: currentConfig },
-                            path
-                          );
-                        } finally {
-                          setIsDetectingUrlRegexp(false);
-                        }
-                      }}
-                      disabled={!canDetectUrlRegexp}
-                    >
-                      {isDetectingUrlRegexp ? (
-                        <>
-                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                          Detecting...
-                        </>
-                      ) : (
-                        "Detect"
-                      )}
-                    </Button>
-                  </div>
-                  {config.sampleUrls?.length &&
-                    config.sampleUrls.length > 0 && (
-                      <div className="mt-2">
-                        <p className="text-sm font-medium">Sample matches:</p>
-                        <ul className="text-sm text-muted-foreground mt-1 space-y-1 max-h-32 overflow-y-auto">
-                          {config.sampleUrls.map((url, index) => (
-                            <li key={index} className="truncate">
-                              {url}
-                            </li>
-                          ))}
-                        </ul>
-                      </div>
-                    )}
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={control}
-              name={`${path}.exactLinkPatternMatch`}
-              render={({ field }) => (
-                <FormItem className="flex flex-row items-start space-x-2 space-y-0">
-                  <FormControl>
-                    <Checkbox
-                      checked={field.value ?? config?.exactLinkPatternMatch ?? false}
-                      onCheckedChange={field.onChange}
-                    />
-                  </FormControl>
-                  <div className="leading-none">
-                    <FormLabel className="flex items-center gap-1 space-x-0 space-y-0">
-                      Use exact Regex match in URL subpages.
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <HelpCircle className="h-4 w-4 text-muted-foreground cursor-help" />
-                        </TooltipTrigger>
-                        <TooltipContent className="max-w-[550px] break-words">
-                          <p className="mb-2">
-                            This controls how xTRA uses links in a page to
-                            enqueue sub-pages for crawling & extraction.
-
-                            When enabled, xTRA will only use 
-                            the sub-segment that exactly matches the link
-                            pattern. So for example, if the link pattern is
-                            <span className="font-mono mx-1">course\/([A-Za-z0-9]+)</span> and the URL is 
-                            <span className="font-mono mx-1">/2025-2026/course/acb</span> then the page enqueued will be 
-                            <span className="font-mono mx-1">/course/acb</span> instead of <span className="font-mono mx-1">/2025-2026/course/acb</span> which
-                            is the default behavior without this flag.
-                          </p>
-                          <p className="mb-2">
-                            This is needed when catalogues use links that are
-                            not correctly resolved in relation to their parent page.
-                            For example, The Antelope Valley College uses links such
-                            as <span className="font-mono">/2025-2026/course/acb</span> in its courses index page
-                            but the catalogue index page already contains the 
-                            <span className="font-mono">2025-2026</span> segment leading to URLs being
-                            formed to <span className="font-mono">/2025-2026/2025-2026/course/acb</span> instead of 
-                            <span className="font-mono">/2025-2026/course/acb</span>.
-                            Browsers handle this correctly but
-                            NodeJS URL built-in helper keeps the <span className="font-mono">2025-2026</span> duplicate segment.
-                          </p>
-                          <p>
-                            <b>Recommended to keep it disabled unless absolutely necessary.</b>
-                          </p>
-                        </TooltipContent>
-                      </Tooltip>
-                    </FormLabel>
-                  </div>
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={control}
-              name={`${path}.pagination`}
-              render={({ field }) => (
-                <FormItem>
-                  <div className="flex items-center space-x-2">
-                    <FormControl>
-                      <Checkbox
-                        checked={!!field.value}
-                        onCheckedChange={(checked) => {
-                          if (checked) {
-                            (form.setValue as any)(`${path}.pagination`, {
-                              urlPatternType: UrlPatternType.page_num,
-                              urlPattern: "",
-                              totalPages: 1,
-                            });
-                          } else {
-                            (form.setValue as any)(
-                              `${path}.pagination`,
-                              undefined
-                            );
-                          }
-                        }}
-                      />
-                    </FormControl>
-                    <FormLabel className="!mt-0">Has Pagination</FormLabel>
-                  </div>
-                  {field.value && (
-                    <div className="mt-2 space-y-4">
+            <ExpandableRecipeSection expanded contentClassName="space-y-2">
+              <FormField
+                control={control}
+                name={`${path}.linkRegexp`}
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Link RegExp</FormLabel>
+                    <div className="flex space-x-2">
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
                       <Button
                         type="button"
                         onClick={async () => {
-                          setIsDetectingPagination(true);
+                          setIsDetectingUrlRegexp(true);
                           try {
-                            await onDetectPagination(
+                            await onDetectUrlRegexp(
                               rootUrl,
-                              {
-                                parents: parentsConfig,
-                                current: currentConfig,
-                              },
+                              { parents: parentsConfig, current: currentConfig },
                               path
                             );
                           } finally {
-                            setIsDetectingPagination(false);
+                            setIsDetectingUrlRegexp(false);
                           }
                         }}
-                        disabled={isDetectingPagination}
+                        disabled={!canDetectUrlRegexp}
                       >
-                        {isDetectingPagination ? (
+                        {isDetectingUrlRegexp ? (
                           <>
                             <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                             Detecting...
@@ -588,74 +532,210 @@ export function RecipeLevel({
                           "Detect"
                         )}
                       </Button>
-                      <div className="space-y-2">
-                        <FormField
-                          control={control}
-                          name={`${path}.pagination.urlPatternType`}
-                          render={({ field }) => (
-                            <FormItem>
-                              <FormLabel>Pattern Type</FormLabel>
-                              <Select
-                                onValueChange={field.onChange}
-                                value={field.value}
-                                disabled={isDetectingPagination}
-                              >
-                                <FormControl>
-                                  <SelectTrigger>
-                                    <SelectValue placeholder="Select a pattern type" />
-                                  </SelectTrigger>
-                                </FormControl>
-                                <SelectContent>
-                                  {Object.values(UrlPatternType).map((type) => (
-                                    <SelectItem key={type} value={type}>
-                                      {type}
-                                    </SelectItem>
-                                  ))}
-                                </SelectContent>
-                              </Select>
-                              <FormMessage />
-                            </FormItem>
-                          )}
-                        />
-                        <FormField
-                          control={control}
-                          name={`${path}.pagination.urlPattern`}
-                          render={({ field }) => (
-                            <FormItem>
-                              <FormLabel>URL Pattern</FormLabel>
-                              <FormControl>
-                                <Input
-                                  {...field}
-                                  disabled={isDetectingPagination}
-                                />
-                              </FormControl>
-                              <FormMessage />
-                            </FormItem>
-                          )}
-                        />
-                        <FormField
-                          control={control}
-                          name={`${path}.pagination.totalPages`}
-                          render={({ field }) => (
-                            <FormItem>
-                              <FormLabel>Total Pages</FormLabel>
-                              <FormControl>
-                                <Input
-                                  type="number"
-                                  {...field}
-                                  disabled={isDetectingPagination}
-                                  onChange={(e) =>
-                                    field.onChange(parseInt(e.target.value))
-                                  }
-                                />
-                              </FormControl>
-                              <FormMessage />
-                            </FormItem>
-                          )}
-                        />
-                      </div>
                     </div>
-                  )}
+                    {config.sampleUrls?.length &&
+                      config.sampleUrls.length > 0 && (
+                        <div className="mt-2">
+                          <p className="text-sm font-medium">Sample matches:</p>
+                          <ul className="text-sm text-muted-foreground mt-1 space-y-1 max-h-32 overflow-y-auto">
+                            {config.sampleUrls.map((url, index) => (
+                              <li key={index} className="truncate">
+                                {url}
+                              </li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </ExpandableRecipeSection>
+
+            <ExpandableRecipeSection expanded contentClassName="space-y-2">
+              <FormField
+                control={control}
+                name={`${path}.exactLinkPatternMatch`}
+                render={({ field }) => (
+                  <FormItem className="flex flex-row items-start space-x-2 space-y-0">
+                    <FormControl>
+                      <Checkbox
+                        checked={field.value ?? config?.exactLinkPatternMatch ?? false}
+                        onCheckedChange={field.onChange}
+                      />
+                    </FormControl>
+                    <div className="leading-none">
+                      <FormLabel className="flex items-center gap-1 space-x-0 space-y-0">
+                        Use exact Regex match in URL subpages.
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <HelpCircle className="h-4 w-4 text-muted-foreground cursor-help" />
+                          </TooltipTrigger>
+                          <TooltipContent className="max-w-[550px] break-words">
+                            <p className="mb-2">
+                              This controls how xTRA uses links in a page to
+                              enqueue sub-pages for crawling & extraction.
+
+                              When enabled, xTRA will only use 
+                              the sub-segment that exactly matches the link
+                              pattern. So for example, if the link pattern is
+                              <span className="font-mono mx-1">course\/([A-Za-z0-9]+)</span> and the URL is 
+                              <span className="font-mono mx-1">/2025-2026/course/acb</span> then the page enqueued will be 
+                              <span className="font-mono mx-1">/course/acb</span> instead of <span className="font-mono mx-1">/2025-2026/course/acb</span> which
+                              is the default behavior without this flag.
+                            </p>
+                            <p className="mb-2">
+                              This is needed when catalogues use links that are
+                              not correctly resolved in relation to their parent page.
+                              For example, The Antelope Valley College uses links such
+                              as <span className="font-mono">/2025-2026/course/acb</span> in its courses index page
+                              but the catalogue index page already contains the 
+                              <span className="font-mono">2025-2026</span> segment leading to URLs being
+                              formed to <span className="font-mono">/2025-2026/2025-2026/course/acb</span> instead of 
+                              <span className="font-mono">/2025-2026/course/acb</span>.
+                              Browsers handle this correctly but
+                              NodeJS URL built-in helper keeps the <span className="font-mono">2025-2026</span> duplicate segment.
+                            </p>
+                            <p>
+                              <b>Recommended to keep it disabled unless absolutely necessary.</b>
+                            </p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </FormLabel>
+                    </div>
+                  </FormItem>
+                )}
+              />
+            </ExpandableRecipeSection>
+
+            <FormField
+              control={control}
+              name={`${path}.pagination`}
+              render={({ field }) => (
+                <FormItem className="space-y-0">
+                  <ExpandableRecipeSection
+                    expanded={!!field.value}
+                    checkbox={
+                      <FormControl>
+                        <Checkbox
+                          checked={!!field.value}
+                          onCheckedChange={(checked) => {
+                            if (checked) {
+                              (form.setValue as any)(`${path}.pagination`, {
+                                urlPatternType: UrlPatternType.page_num,
+                                urlPattern: "",
+                                totalPages: 1,
+                              });
+                            } else {
+                              (form.setValue as any)(
+                                `${path}.pagination`,
+                                undefined
+                              );
+                            }
+                          }}
+                        />
+                      </FormControl>
+                    }
+                    label={
+                      <FormLabel className="!mt-0">Has Pagination</FormLabel>
+                    }
+                    contentClassName="space-y-4"
+                  >
+                    <Button
+                      type="button"
+                      onClick={async () => {
+                        setIsDetectingPagination(true);
+                        try {
+                          await onDetectPagination(
+                            rootUrl,
+                            {
+                              parents: parentsConfig,
+                              current: currentConfig,
+                            },
+                            path
+                          );
+                        } finally {
+                          setIsDetectingPagination(false);
+                        }
+                      }}
+                      disabled={isDetectingPagination}
+                    >
+                      {isDetectingPagination ? (
+                        <>
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          Detecting...
+                        </>
+                      ) : (
+                        "Detect"
+                      )}
+                    </Button>
+                    <div className="space-y-2">
+                      <FormField
+                        control={control}
+                        name={`${path}.pagination.urlPatternType`}
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>Pattern Type</FormLabel>
+                            <Select
+                              onValueChange={field.onChange}
+                              value={field.value}
+                              disabled={isDetectingPagination}
+                            >
+                              <FormControl>
+                                <SelectTrigger>
+                                  <SelectValue placeholder="Select a pattern type" />
+                                </SelectTrigger>
+                              </FormControl>
+                              <SelectContent>
+                                {Object.values(UrlPatternType).map((type) => (
+                                  <SelectItem key={type} value={type}>
+                                    {type}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                      <FormField
+                        control={control}
+                        name={`${path}.pagination.urlPattern`}
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>URL Pattern</FormLabel>
+                            <FormControl>
+                              <Input
+                                {...field}
+                                disabled={isDetectingPagination}
+                              />
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                      <FormField
+                        control={control}
+                        name={`${path}.pagination.totalPages`}
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>Total Pages</FormLabel>
+                            <FormControl>
+                              <Input
+                                type="number"
+                                {...field}
+                                disabled={isDetectingPagination}
+                                onChange={(e) =>
+                                  field.onChange(parseInt(e.target.value))
+                                }
+                              />
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                    </div>
+                  </ExpandableRecipeSection>
                   <FormMessage />
                 </FormItem>
               )}
@@ -663,7 +743,7 @@ export function RecipeLevel({
           </>
         )}
 
-        <div className="flex space-x-2">
+        <ExpandableRecipeSection expanded contentClassName="flex flex-wrap gap-2">
           {config?.pageType !== PageType.DETAIL && (
             <Button
               type="button"
@@ -684,7 +764,7 @@ export function RecipeLevel({
           >
             Remove Level
           </Button>
-        </div>
+        </ExpandableRecipeSection>
 
         {config?.links && (
           <RecipeLevel
@@ -694,6 +774,8 @@ export function RecipeLevel({
             onDetectPagination={onDetectPagination}
           />
         )}
+          </div>
+        </div>
       </div>
     </TooltipProvider>
   );

--- a/client/src/components/app/recipes/RecipeLevel.tsx
+++ b/client/src/components/app/recipes/RecipeLevel.tsx
@@ -1,5 +1,5 @@
 import { useFormContext, Path } from "react-hook-form";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -25,7 +25,13 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { HelpCircle, Loader2 } from "lucide-react";
-import { PageType, PaginationConfiguration, UrlPatternType } from "../../../../../common/types";
+import {
+  PageSetupConfig,
+  PageType,
+  PaginationConfiguration,
+  UrlPatternType,
+} from "../../../../../common/types";
+import { PageSetupSection } from "./PageSetupSection";
 
 export type FormRecipeConfiguration = {
   pageType: PageType;
@@ -38,6 +44,7 @@ export type FormRecipeConfiguration = {
   pageLoadWaitTime?: number;
   exactLinkPatternMatch?: boolean;
   contentSelector?: string;
+  pageSetup?: PageSetupConfig;
 };
 
 interface RecipeLevelProps {
@@ -90,6 +97,16 @@ export function RecipeLevel({
       parentsConfig.length === 0 ||
       parentsConfig[parentsConfig.length - 1]?.sampleUrls?.length);
 
+  useEffect(() => {
+    const cfg = form.getValues(path as any) as FormRecipeConfiguration | undefined;
+    if (cfg && cfg.pageSetup === undefined) {
+      form.setValue(`${path}.pageSetup` as any, {
+        enabled: false,
+        steps: [],
+      });
+    }
+  }, [path, form]);
+
   return (
     <TooltipProvider>
       <div className="space-y-4 border-l-2 pl-4 mt-4">
@@ -106,7 +123,10 @@ export function RecipeLevel({
                   ) as FormRecipeConfiguration;
                   const links =
                     PageType.DETAIL_LINKS == value
-                      ? { pageType: PageType.DETAIL }
+                      ? {
+                          pageType: PageType.DETAIL,
+                          pageSetup: { enabled: false, steps: [] },
+                        }
                       : currentConfig?.links;
                   (form.setValue as any)(path, {
                     ...currentConfig,
@@ -190,6 +210,14 @@ export function RecipeLevel({
             </FormItem>
           )}
         />
+
+        {config?.pageSetup && (
+          <PageSetupSection
+            basePath={path}
+            control={control}
+            setValue={form.setValue}
+          />
+        )}
 
         {config?.pageType && config.pageType !== PageType.DETAIL && (
           <>
@@ -642,6 +670,7 @@ export function RecipeLevel({
               onClick={() =>
                 (form.setValue as any)(`${path}.links`, {
                   pageType: PageType.DETAIL,
+                  pageSetup: { enabled: false, steps: [] },
                 })
               }
             >

--- a/client/src/components/app/recipes/TestLinkRegex.tsx
+++ b/client/src/components/app/recipes/TestLinkRegex.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { Loader2, Copy } from "lucide-react";
 import { trpc } from "@/utils";
 import { useToast } from "@/components/ui/use-toast";
+import { PageSetupConfig } from "../../../../../common/types";
 
 type TestResult = { regexp: string; urls: string[]; markdownContent?: string };
 
@@ -64,6 +65,7 @@ export default function TestLinkRegex({
   clickOptions,
   exactLinkPatternMatch,
   pageLoadWaitTime,
+  pageSetup,
 }: {
   defaultUrl: string;
   defaultRegex?: string;
@@ -72,6 +74,7 @@ export default function TestLinkRegex({
   clickOptions?: { limit?: number; waitMs?: number };
   exactLinkPatternMatch?: boolean;
   pageLoadWaitTime?: number;
+  pageSetup?: PageSetupConfig;
 }) {
   const [url, setUrl] = useState(defaultUrl);
   const [regex, setRegex] = useState(defaultRegex || "");
@@ -113,6 +116,7 @@ export default function TestLinkRegex({
                 clickOptions?: { limit?: number; waitMs?: number };
                 exactLinkPatternMatch?: boolean;
                 pageLoadWaitTime?: number;
+                pageSetup?: PageSetupConfig;
               } = {
                 url,
               };
@@ -135,6 +139,10 @@ export default function TestLinkRegex({
               
               if (pageLoadWaitTime !== undefined) {
                 mutationData.pageLoadWaitTime = pageLoadWaitTime;
+              }
+
+              if (pageSetup !== undefined) {
+                mutationData.pageSetup = pageSetup;
               }
               
               testRecipeRegex.mutate(mutationData);
@@ -205,6 +213,7 @@ export default function TestLinkRegex({
                 clickOptions?: { limit?: number; waitMs?: number };
                 exactLinkPatternMatch?: boolean;
                 pageLoadWaitTime?: number;
+                pageSetup?: PageSetupConfig;
               } = {
                 url,
               };
@@ -227,6 +236,10 @@ export default function TestLinkRegex({
               
               if (pageLoadWaitTime !== undefined) {
                 mutationData.pageLoadWaitTime = pageLoadWaitTime;
+              }
+
+              if (pageSetup !== undefined) {
+                mutationData.pageSetup = pageSetup;
               }
               
               testRecipeRegex.mutate(mutationData);

--- a/client/src/components/app/recipes/create.tsx
+++ b/client/src/components/app/recipes/create.tsx
@@ -44,8 +44,21 @@ import {
   CatalogueType,
   PageType,
   PaginationConfiguration,
+  RecipeConfiguration,
   UrlPatternType,
 } from "../../../../../common/types";
+
+function withDefaultPageSetupAtEachLevel(
+  cfg: RecipeConfiguration
+): RecipeConfiguration {
+  return {
+    ...cfg,
+    pageSetup: cfg.pageSetup ?? { enabled: false, steps: [] },
+    links: cfg.links
+      ? withDefaultPageSetupAtEachLevel(cfg.links)
+      : undefined,
+  };
+}
 import {
   Table,
   TableBody,
@@ -74,6 +87,40 @@ const PaginationSchema = z.object({
   totalPages: z.number().positive(),
 }) as z.ZodType<PaginationConfiguration>;
 
+const PageSetupStepInputSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("click"), selector: z.string() }),
+  z.object({ type: z.literal("wait"), seconds: z.number() }),
+]);
+
+const PageSetupConfigSchema = z
+  .object({
+    enabled: z.boolean(),
+    steps: z.array(PageSetupStepInputSchema),
+  })
+  .superRefine((data, ctx) => {
+    if (!data.enabled) return;
+
+    data.steps.forEach((step, i) => {
+      if (step.type === "click") {
+        if (!step.selector.trim()) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "Selector is required",
+            path: ["steps", i, "selector"],
+          });
+        }
+      } else if (step.type === "wait") {
+        if (!Number.isFinite(step.seconds) || step.seconds <= 0 || step.seconds > 600) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "Wait seconds must be between 0 and 600",
+            path: ["steps", i, "seconds"],
+          });
+        }
+      }
+    });
+  });
+
 const RecipeConfigurationSchema: z.ZodType<FormRecipeConfiguration> = z.object({
   pageType: z.nativeEnum(PageType),
   linkRegexp: z.string().optional(),
@@ -89,6 +136,7 @@ const RecipeConfigurationSchema: z.ZodType<FormRecipeConfiguration> = z.object({
   pageLoadWaitTime: z.number().optional().default(0),
   exactLinkPatternMatch: z.boolean().optional(),
   contentSelector: z.string().optional(),
+  pageSetup: PageSetupConfigSchema.optional(),
 }).refine(
   (data) => {
     // If clickSelector is defined (not undefined), it must be a non-empty string
@@ -176,7 +224,9 @@ export default function CreateRecipe() {
       form.reset({
         url: catalogueQuery.data.url,
         manualConfig: true,
-        configuration: templateQuery.data.configuration as any,
+        configuration: withDefaultPageSetupAtEachLevel(
+          templateQuery.data.configuration as RecipeConfiguration
+        ),
         acknowledgedSkipRobotsTxt: templateQuery.data.acknowledgedSkipRobotsTxt || false,
         creationMode: "template" as const,
         name: templateQuery.data.name || undefined,
@@ -197,12 +247,14 @@ export default function CreateRecipe() {
   }, [catalogueQuery.data, templateQuery.data, selectedTemplateId]);
 
   const creationMode = form.watch("creationMode");
+  const configuration = form.watch("configuration");
 
   useEffect(() => {
     if (creationMode === "manual" || creationMode === "template") {
       if (!form.getValues("configuration")) {
         form.setValue("configuration", {
           pageType: PageType.DETAIL,
+          pageSetup: { enabled: false, steps: [] },
         });
       }
       form.setValue("manualConfig", true);
@@ -280,8 +332,6 @@ export default function CreateRecipe() {
     { label: "Catalogues", href: "/" },
     { label: catalogueQuery.data.name, href: `/${catalogueId}` },
   ];
-
-  const configuration = form.watch("configuration");
 
   async function onDetectPagination(
     // @ts-ignore
@@ -447,6 +497,7 @@ export default function CreateRecipe() {
                                 if (!form.getValues("configuration")) {
                                   form.setValue("configuration", {
                                     pageType: PageType.DETAIL,
+                                    pageSetup: { enabled: false, steps: [] },
                                   });
                                 }
                                 form.setValue("manualConfig", true);
@@ -678,6 +729,7 @@ export default function CreateRecipe() {
                       clickOptions={configuration?.clickOptions || undefined}
                       exactLinkPatternMatch={configuration?.exactLinkPatternMatch}
                       pageLoadWaitTime={configuration?.pageLoadWaitTime}
+                      pageSetup={configuration?.pageSetup}
                     />
                   </CardContent>
                 </Card>

--- a/client/src/components/app/recipes/create.tsx
+++ b/client/src/components/app/recipes/create.tsx
@@ -68,6 +68,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import TestLinkRegex from "./TestLinkRegex";
+import { ExpandableRecipeSection } from "./ExpandableRecipeSection";
 import { RecipeLevel, FormRecipeConfiguration } from "./RecipeLevel";
 
 function debounce<T extends (...args: any[]) => any>(
@@ -687,31 +688,33 @@ export default function CreateRecipe() {
                     <CardDescription>Recipe Configuration</CardDescription>
                   </CardHeader>
                   <CardContent className="space-y-4">
-                    <FormField
-                      control={form.control}
-                      name="configuration.pageLoadWaitTime"
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormLabel>Page Load Wait Time (seconds)</FormLabel>
-                          <FormControl>
-                            <Input
-                              type="number"
-                              placeholder="0"
-                              {...field}
-                              onChange={(e) => {
-                                const value = e.target.value ? parseInt(e.target.value) : undefined;
-                                field.onChange(value);
-                              }}
-                              value={field.value ?? ""}
-                            />
-                          </FormControl>
-                          <FormDescription>
-                            How long to wait (in seconds) for the page to fully load after opening. This is useful for pages that dynamically load content. Leave empty or 0 for no additional wait.
-                          </FormDescription>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
+                    <ExpandableRecipeSection expanded contentClassName="space-y-2">
+                      <FormField
+                        control={form.control}
+                        name="configuration.pageLoadWaitTime"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>Page Load Wait Time (seconds)</FormLabel>
+                            <FormControl>
+                              <Input
+                                type="number"
+                                placeholder="0"
+                                {...field}
+                                onChange={(e) => {
+                                  const value = e.target.value ? parseInt(e.target.value) : undefined;
+                                  field.onChange(value);
+                                }}
+                                value={field.value ?? ""}
+                              />
+                            </FormControl>
+                            <FormDescription>
+                              How long to wait (in seconds) for the page to fully load after opening. This is useful for pages that dynamically load content. Leave empty or 0 for no additional wait.
+                            </FormDescription>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                    </ExpandableRecipeSection>
                     {configuration && (
                       <RecipeLevel
                         path="configuration"

--- a/client/src/components/app/recipes/edit.tsx
+++ b/client/src/components/app/recipes/edit.tsx
@@ -53,13 +53,65 @@ import { Link } from "wouter";
 import { displayRecipeDetails } from "./util";
 import TestLinkRegex from "./TestLinkRegex";
 import { RecipeConfigurationEditor } from "./RecipeConfigurationEditor";
-import { CatalogueType, PageType, PaginationConfiguration, UrlPatternType } from "../../../../../common/types";
+import {
+  CatalogueType,
+  PageType,
+  PaginationConfiguration,
+  RecipeConfiguration,
+  UrlPatternType,
+} from "../../../../../common/types";
+
+/** Ensures each nested recipe level can bind page setup in the UI. */
+function withDefaultPageSetupAtEachLevel(
+  cfg: RecipeConfiguration
+): RecipeConfiguration {
+  return {
+    ...cfg,
+    pageSetup: cfg.pageSetup ?? { enabled: false, steps: [] },
+    links: cfg.links
+      ? withDefaultPageSetupAtEachLevel(cfg.links)
+      : undefined,
+  };
+}
 
 const PaginationSchema = z.object({
   urlPatternType: z.nativeEnum(UrlPatternType),
   urlPattern: z.string(),
   totalPages: z.number().positive(),
 }) as z.ZodType<PaginationConfiguration>;
+
+const PageSetupStepInputSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("click"), selector: z.string() }),
+  z.object({ type: z.literal("wait"), seconds: z.number() }),
+]);
+
+const PageSetupConfigSchema = z
+  .object({
+    enabled: z.boolean(),
+    steps: z.array(PageSetupStepInputSchema),
+  })
+  .superRefine((data, ctx) => {
+    if (!data.enabled) return;
+    data.steps.forEach((step, i) => {
+      if (step.type === "click") {
+        if (!step.selector.trim()) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "Selector is required",
+            path: ["steps", i, "selector"],
+          });
+        }
+      } else if (step.type === "wait") {
+        if (!Number.isFinite(step.seconds) || step.seconds <= 0 || step.seconds > 600) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "Wait seconds must be between 0 and 600",
+            path: ["steps", i, "seconds"],
+          });
+        }
+      }
+    });
+  });
 
 const RecipeConfigurationSchema: z.ZodType<any> = z.object({
   pageType: z.nativeEnum(PageType),
@@ -69,6 +121,7 @@ const RecipeConfigurationSchema: z.ZodType<any> = z.object({
   pageLoadWaitTime: z.number().optional().default(0),
   exactLinkPatternMatch: z.boolean().optional(),
   contentSelector: z.string().optional(),
+  pageSetup: PageSetupConfigSchema.optional(),
 });
 
 const FormSchema = z.object({
@@ -160,6 +213,11 @@ export default function EditRecipe() {
       ...recipeQuery.data,
       name: recipeQuery.data.name ?? undefined,
       description: recipeQuery.data.description ?? undefined,
+      configuration: recipeQuery.data.configuration
+        ? withDefaultPageSetupAtEachLevel(
+            recipeQuery.data.configuration as RecipeConfiguration
+          )
+        : undefined,
     });
     
     // Update JSON text when recipe data loads
@@ -434,6 +492,7 @@ export default function EditRecipe() {
                   clickOptions={getFirstLevelClickOptions(recipe)}
                   exactLinkPatternMatch={getFirstLevelExactLinkPatternMatch(recipe)}
                   pageLoadWaitTime={recipe.configuration?.pageLoadWaitTime}
+                  pageSetup={recipe.configuration?.pageSetup}
                 />
               )}
               {recipe.status == RecipeDetectionStatus.WAITING ? (

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -30,35 +30,12 @@ export type CrawlPage = ItemType<
 type DatasetItemsResponse = Exclude<RouterOutput["datasets"]["items"], null>;
 export type DatasetItem = ItemType<DatasetItemsResponse["items"]["results"]>;
 
-export enum ExtractionStatus {
-  WAITING = "WAITING",
-  IN_PROGRESS = "IN_PROGRESS",
-  COMPLETE = "COMPLETE",
-  STALE = "STALE",
-  CANCELLED = "CANCELLED",
-}
-
-export enum PageStatus {
-  WAITING = "WAITING",
-  IN_PROGRESS = "IN_PROGRESS",
-  DOWNLOADED = "DOWNLOADED",
-  SUCCESS = "SUCCESS",
-  EXTRACTED_NO_DATA = "EXTRACTED_NO_DATA",
-  ERROR = "ERROR",
-}
-
-export enum RecipeDetectionStatus {
-  WAITING = "WAITING",
-  IN_PROGRESS = "IN_PROGRESS",
-  SUCCESS = "SUCCESS",
-  ERROR = "ERROR",
-}
-
-export enum Step {
-  FETCH_ROOT = "FETCH_ROOT",
-  FETCH_PAGINATED = "FETCH_PAGINATED",
-  FETCH_LINKS = "FETCH_LINKS",
-}
+export {
+  ExtractionStatus,
+  PageStatus,
+  RecipeDetectionStatus,
+  Step,
+} from "../../common/types";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -31,6 +31,7 @@ type DatasetItemsResponse = Exclude<RouterOutput["datasets"]["items"], null>;
 export type DatasetItem = ItemType<DatasetItemsResponse["items"]["results"]>;
 
 export {
+  EmailNotificationPreference,
   ExtractionStatus,
   PageStatus,
   RecipeDetectionStatus,

--- a/common/catalogueTypes.ts
+++ b/common/catalogueTypes.ts
@@ -353,7 +353,8 @@ export const catalogueTypes: Record<CatalogueType, CatalogueTypeDefinition> = {
     presencePrompt:
       "Look at the given markdown page and check if there exists a list of skills in a dedicated section. " +
       "We are looking for a list in a dedicated section, do not consider paragraphs or long descriptions. " +
-      "Do not confuse courses with skills. We are looking for skills attained after taking the course described in the page.",
+      "Do not confuse courses with skills. We are looking for skills attained after taking the course described in the page." +
+      "Example of headers listing the items are 'Learning outcomes', 'Course objectives', 'Competencies', etc.",
     desiredOutput:
       "We are looking for a list of skills that are gained after taking the course described in the page. " +
       "If found, take each item exactly as it is in the page and return them. Skip everything else, just the skill list." +
@@ -371,10 +372,18 @@ export const catalogueTypes: Record<CatalogueType, CatalogueTypeDefinition> = {
           "The name of the encompassing or overarching skill or competency or learning program or course that will lead " +
           "to obtaining the skill or competency or learning outcome. " +
           "Usually this value is the same for the entire list but should be set " +
-          "according to the hierarchy structure of the page. This is usually shorter. " +
+          "according to the hierarchy structure of the page. This is usually shorter. No course codes should be included. (ex. ACCT 101)" +
           "Sometimes, this might contain descriptive language about the skill - we should only keep the " +
           'name of the skill and trim phrases such as "competency" or "learning outcome".' +
           "This field should be in title case. If it contains roman numerals, they use use uppercase.",
+        required: false,
+      },
+      competency_category: {
+        description:
+          "Some pages contain competency under outcomes and course objectives, we need to distinguish between the two. " +
+          "If the competency is under outcomes, set this field to 'outcomes'. " +
+          "Otherwise, set this field to 'course_objectives'. " +
+          "If it's not clear, set this field to 'unknown'.",
         required: false,
       },
       language: {
@@ -393,10 +402,14 @@ export const catalogueTypes: Record<CatalogueType, CatalogueTypeDefinition> = {
             properties: {
               text: { type: "string" },
               competency_framework: { type: "string" },
+              competency_category: {
+                type: "string",
+                enum: ["outcomes", "course_objectives", "unknown"],
+              },
               language: { type: "string" },
             },
             additionalProperties: false,
-            required: ["competency_framework", "text", "language"],
+            required: ["competency_framework", "text", "language", "competency_category"],
           },
         },
       },

--- a/common/types.ts
+++ b/common/types.ts
@@ -162,6 +162,7 @@ export interface CompetencyStructuredData {
   text: string;
   competency_framework: string;
   language?: string;
+  competency_category?: "outcomes" | "course_objectives" | "unknown";
 }
 
 export type TextInclusion<T> = {

--- a/common/types.ts
+++ b/common/types.ts
@@ -218,3 +218,26 @@ export interface ClickDiscoveryOptions {
   limit?: number;
   waitMs?: number;
 }
+
+export enum EmailNotificationPreference {
+  ALWAYS = "always",
+  MINE = "mine",
+  OFF = "off",
+}
+
+export interface UserEmailPreferences {
+  /** Default: ALWAYS (legacy / no stored preference). */
+  notifications?: EmailNotificationPreference;
+}
+
+export interface UserPreferences {
+  email?: UserEmailPreferences;
+}
+
+export function defaultUserPreferences(): UserPreferences {
+  return {
+    email: {
+      notifications: EmailNotificationPreference.ALWAYS,
+    },
+  };
+}

--- a/common/types.ts
+++ b/common/types.ts
@@ -30,6 +30,16 @@ export interface PaginationConfiguration {
   totalPages: number;
 }
 
+/** Ordered actions after navigation; extend the union for new step kinds. */
+export type PageSetupStep =
+  | { type: "click"; selector: string }
+  | { type: "wait"; seconds: number };
+
+export interface PageSetupConfig {
+  enabled: boolean;
+  steps: PageSetupStep[];
+}
+
 export interface RecipeConfiguration<
   ConfigType extends ApiProvider = ApiProvider,
 > {
@@ -43,6 +53,7 @@ export interface RecipeConfiguration<
   apiConfig?: ApiConfig[ConfigType];
   pageLoadWaitTime?: number;
   contentSelector?: string;
+  pageSetup?: PageSetupConfig;
 
   /**
    * When true, the links gathered from the page

--- a/common/types.ts
+++ b/common/types.ts
@@ -1,3 +1,5 @@
+import { toTitleCase } from "./utils";
+
 export enum CatalogueType {
   COURSES = "COURSES",
   LEARNING_PROGRAMS = "LEARNING_PROGRAMS",
@@ -111,6 +113,13 @@ export enum PageStatus {
   EXTRACTED_NO_DATA = "EXTRACTED_NO_DATA",
   ERROR = "ERROR",
 }
+
+export const UIPageStatus: { value: PageStatus; label: string }[] = (
+  Object.values(PageStatus) as PageStatus[]
+).map((value) => ({
+  value,
+  label: toTitleCase(String(value).replace(/_/g, " ")),
+}));
 
 export enum RecipeDetectionStatus {
   WAITING = "WAITING",

--- a/common/utils.ts
+++ b/common/utils.ts
@@ -1,0 +1,6 @@
+export function toTitleCase(str: string): string {
+  return str
+    .split(" ")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(" ");
+}

--- a/server/migrations/0019_funny_starhawk.sql
+++ b/server/migrations/0019_funny_starhawk.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users" ADD COLUMN "user_preferences" jsonb;

--- a/server/migrations/meta/0019_snapshot.json
+++ b/server/migrations/meta/0019_snapshot.json
@@ -1,0 +1,1428 @@
+{
+  "id": "5cc4527a-6555-49a4-a7a8-55e6329436b9",
+  "prevId": "e0e92807-7294-4d13-8eeb-3ee3929c24ef",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.catalogues": {
+      "name": "catalogues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "catalogue_type": {
+          "name": "catalogue_type",
+          "type": "catalogue_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COURSES'"
+        },
+        "institution_id": {
+          "name": "institution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "catalogues_institution_id_institutions_id_fk": {
+          "name": "catalogues_institution_id_institutions_id_fk",
+          "tableFrom": "catalogues",
+          "tableTo": "institutions",
+          "columnsFrom": [
+            "institution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "catalogues_url_catalogue_type_unique": {
+          "name": "catalogues_url_catalogue_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url",
+            "catalogue_type"
+          ]
+        }
+      }
+    },
+    "public.crawl_pages": {
+      "name": "crawl_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "extraction_id": {
+          "name": "extraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crawl_step_id": {
+          "name": "crawl_step_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step": {
+          "name": "step",
+          "type": "step",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "page_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'WAITING'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshot": {
+          "name": "screenshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetch_failure_reason": {
+          "name": "fetch_failure_reason",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_type": {
+          "name": "page_type",
+          "type": "page_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_extraction_started_at": {
+          "name": "data_extraction_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crawl_pages_extraction_idx": {
+          "name": "crawl_pages_extraction_idx",
+          "columns": [
+            {
+              "expression": "extraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crawl_pages_status_idx": {
+          "name": "crawl_pages_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crawl_pages_data_type_idx": {
+          "name": "crawl_pages_data_type_idx",
+          "columns": [
+            {
+              "expression": "page_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crawl_pages_step_idx": {
+          "name": "crawl_pages_step_idx",
+          "columns": [
+            {
+              "expression": "crawl_step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crawl_pages_extraction_id_extractions_id_fk": {
+          "name": "crawl_pages_extraction_id_extractions_id_fk",
+          "tableFrom": "crawl_pages",
+          "tableTo": "extractions",
+          "columnsFrom": [
+            "extraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crawl_pages_crawl_step_id_crawl_steps_id_fk": {
+          "name": "crawl_pages_crawl_step_id_crawl_steps_id_fk",
+          "tableFrom": "crawl_pages",
+          "tableTo": "crawl_steps",
+          "columnsFrom": [
+            "crawl_step_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "crawl_pages_extraction_id_url_step_unique": {
+          "name": "crawl_pages_extraction_id_url_step_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "extraction_id",
+            "url",
+            "step"
+          ]
+        }
+      }
+    },
+    "public.crawl_steps": {
+      "name": "crawl_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "extraction_id": {
+          "name": "extraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step": {
+          "name": "step",
+          "type": "step",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_step_id": {
+          "name": "parent_step_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crawl_steps_extraction_idx": {
+          "name": "crawl_steps_extraction_idx",
+          "columns": [
+            {
+              "expression": "extraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crawl_steps_parent_step_idx": {
+          "name": "crawl_steps_parent_step_idx",
+          "columns": [
+            {
+              "expression": "parent_step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crawl_steps_extraction_id_extractions_id_fk": {
+          "name": "crawl_steps_extraction_id_extractions_id_fk",
+          "tableFrom": "crawl_steps",
+          "tableTo": "extractions",
+          "columnsFrom": [
+            "extraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crawl_steps_parent_step_id_crawl_steps_id_fk": {
+          "name": "crawl_steps_parent_step_id_crawl_steps_id_fk",
+          "tableFrom": "crawl_steps",
+          "tableTo": "crawl_steps",
+          "columnsFrom": [
+            "parent_step_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.data_items": {
+      "name": "data_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crawl_page_id": {
+          "name": "crawl_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "structured_data": {
+          "name": "structured_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_inclusion": {
+          "name": "text_inclusion",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_items_dataset_idx": {
+          "name": "data_items_dataset_idx",
+          "columns": [
+            {
+              "expression": "dataset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "data_items_crawl_page_idx": {
+          "name": "data_items_crawl_page_idx",
+          "columns": [
+            {
+              "expression": "crawl_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "data_items_dataset_id_datasets_id_fk": {
+          "name": "data_items_dataset_id_datasets_id_fk",
+          "tableFrom": "data_items",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "data_items_crawl_page_id_crawl_pages_id_fk": {
+          "name": "data_items_crawl_page_id_crawl_pages_id_fk",
+          "tableFrom": "data_items",
+          "tableTo": "crawl_pages",
+          "columnsFrom": [
+            "crawl_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.datasets": {
+      "name": "datasets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "catalogue_id": {
+          "name": "catalogue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extraction_id": {
+          "name": "extraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "datasets_catalogue_idx": {
+          "name": "datasets_catalogue_idx",
+          "columns": [
+            {
+              "expression": "catalogue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "datasets_extraction_idx": {
+          "name": "datasets_extraction_idx",
+          "columns": [
+            {
+              "expression": "extraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "datasets_catalogue_id_catalogues_id_fk": {
+          "name": "datasets_catalogue_id_catalogues_id_fk",
+          "tableFrom": "datasets",
+          "tableTo": "catalogues",
+          "columnsFrom": [
+            "catalogue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "datasets_extraction_id_extractions_id_fk": {
+          "name": "datasets_extraction_id_extractions_id_fk",
+          "tableFrom": "datasets",
+          "tableTo": "extractions",
+          "columnsFrom": [
+            "extraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.extraction_logs": {
+      "name": "extraction_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "extraction_id": {
+          "name": "extraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crawl_page_id": {
+          "name": "crawl_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log": {
+          "name": "log",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "log_level": {
+          "name": "log_level",
+          "type": "log_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INFO'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "extraction_logs_extraction_idx": {
+          "name": "extraction_logs_extraction_idx",
+          "columns": [
+            {
+              "expression": "extraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "extraction_logs_crawl_page_idx": {
+          "name": "extraction_logs_crawl_page_idx",
+          "columns": [
+            {
+              "expression": "crawl_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "extraction_logs_extraction_id_extractions_id_fk": {
+          "name": "extraction_logs_extraction_id_extractions_id_fk",
+          "tableFrom": "extraction_logs",
+          "tableTo": "extractions",
+          "columnsFrom": [
+            "extraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "extraction_logs_crawl_page_id_crawl_pages_id_fk": {
+          "name": "extraction_logs_crawl_page_id_crawl_pages_id_fk",
+          "tableFrom": "extraction_logs",
+          "tableTo": "crawl_pages",
+          "columnsFrom": [
+            "crawl_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.extractions": {
+      "name": "extractions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "provider_model",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_stats": {
+          "name": "completion_stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "extraction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'WAITING'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "extractions_recipe_idx": {
+          "name": "extractions_recipe_idx",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "extractions_recipe_id_recipes_id_fk": {
+          "name": "extractions_recipe_id_recipes_id_fk",
+          "tableFrom": "extractions",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.extractions_audit_log": {
+      "name": "extractions_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "extraction_id": {
+          "name": "extraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(180)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "extractions_audit_log_extraction_idx": {
+          "name": "extractions_audit_log_extraction_idx",
+          "columns": [
+            {
+              "expression": "extraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "extractions_audit_log_user_idx": {
+          "name": "extractions_audit_log_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "extractions_audit_log_extraction_id_extractions_id_fk": {
+          "name": "extractions_audit_log_extraction_id_extractions_id_fk",
+          "tableFrom": "extractions_audit_log",
+          "tableTo": "extractions",
+          "columnsFrom": [
+            "extraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "extractions_audit_log_user_id_users_id_fk": {
+          "name": "extractions_audit_log_user_id_users_id_fk",
+          "tableFrom": "extractions_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.institutions": {
+      "name": "institutions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domains": {
+          "name": "domains",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "institutions_name_unique": {
+          "name": "institutions_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.model_api_calls": {
+      "name": "model_api_calls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "extraction_id": {
+          "name": "extraction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crawl_page_id": {
+          "name": "crawl_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "provider_model",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "call_site": {
+          "name": "call_site",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_token_count": {
+          "name": "input_token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_token_count": {
+          "name": "output_token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "model_api_calls_extraction_idx": {
+          "name": "model_api_calls_extraction_idx",
+          "columns": [
+            {
+              "expression": "extraction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "model_api_calls_crawl_page_idx": {
+          "name": "model_api_calls_crawl_page_idx",
+          "columns": [
+            {
+              "expression": "crawl_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "model_api_calls_datasaet_idx": {
+          "name": "model_api_calls_datasaet_idx",
+          "columns": [
+            {
+              "expression": "dataset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_api_calls_extraction_id_extractions_id_fk": {
+          "name": "model_api_calls_extraction_id_extractions_id_fk",
+          "tableFrom": "model_api_calls",
+          "tableTo": "extractions",
+          "columnsFrom": [
+            "extraction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_api_calls_crawl_page_id_crawl_pages_id_fk": {
+          "name": "model_api_calls_crawl_page_id_crawl_pages_id_fk",
+          "tableFrom": "model_api_calls",
+          "tableTo": "crawl_pages",
+          "columnsFrom": [
+            "crawl_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_api_calls_dataset_id_datasets_id_fk": {
+          "name": "model_api_calls_dataset_id_datasets_id_fk",
+          "tableFrom": "model_api_calls",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.recipes": {
+      "name": "recipes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_template": {
+          "name": "is_template",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "catalogue_id": {
+          "name": "catalogue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "detection_failure_reason": {
+          "name": "detection_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "recipe_detection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'WAITING'"
+        },
+        "robots_txt": {
+          "name": "robots_txt",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acknowledged_skip_robots_txt": {
+          "name": "acknowledged_skip_robots_txt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recipes_catalogue_idx": {
+          "name": "recipes_catalogue_idx",
+          "columns": [
+            {
+              "expression": "catalogue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recipes_template_idx": {
+          "name": "recipes_template_idx",
+          "columns": [
+            {
+              "expression": "is_template",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "catalogue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipes_catalogue_id_catalogues_id_fk": {
+          "name": "recipes_catalogue_id_catalogues_id_fk",
+          "tableFrom": "recipes",
+          "tableTo": "catalogues",
+          "columnsFrom": [
+            "catalogue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_encrypted": {
+          "name": "is_encrypted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "encrypted_preview": {
+          "name": "encrypted_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "settings_key_unique": {
+          "name": "settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      }
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_preferences": {
+          "name": "user_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "public.catalogue_type": {
+      "name": "catalogue_type",
+      "schema": "public",
+      "values": [
+        "COURSES",
+        "LEARNING_PROGRAMS",
+        "COMPETENCIES",
+        "CREDENTIALS"
+      ]
+    },
+    "public.extraction_status": {
+      "name": "extraction_status",
+      "schema": "public",
+      "values": [
+        "WAITING",
+        "IN_PROGRESS",
+        "COMPLETE",
+        "STALE",
+        "CANCELLED"
+      ]
+    },
+    "public.log_level": {
+      "name": "log_level",
+      "schema": "public",
+      "values": [
+        "INFO",
+        "ERROR"
+      ]
+    },
+    "public.page_status": {
+      "name": "page_status",
+      "schema": "public",
+      "values": [
+        "WAITING",
+        "IN_PROGRESS",
+        "DOWNLOADED",
+        "SUCCESS",
+        "EXTRACTED_NO_DATA",
+        "ERROR"
+      ]
+    },
+    "public.page_type": {
+      "name": "page_type",
+      "schema": "public",
+      "values": [
+        "DETAIL",
+        "CATEGORY_LINKS",
+        "DETAIL_LINKS",
+        "API_REQUEST",
+        "EXPLORATORY"
+      ]
+    },
+    "public.provider": {
+      "name": "provider",
+      "schema": "public",
+      "values": [
+        "openai"
+      ]
+    },
+    "public.provider_model": {
+      "name": "provider_model",
+      "schema": "public",
+      "values": [
+        "gpt-4o",
+        "gpt-4.1",
+        "o3-mini",
+        "o4-mini",
+        "gpt-5",
+        "gpt-5-nano",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.4-nano"
+      ]
+    },
+    "public.recipe_detection_status": {
+      "name": "recipe_detection_status",
+      "schema": "public",
+      "values": [
+        "WAITING",
+        "IN_PROGRESS",
+        "SUCCESS",
+        "ERROR"
+      ]
+    },
+    "public.step": {
+      "name": "step",
+      "schema": "public",
+      "values": [
+        "FETCH_ROOT",
+        "FETCH_PAGINATED",
+        "FETCH_LINKS",
+        "FETCH_VIA_API"
+      ]
+    },
+    "public.url_pattern_type": {
+      "name": "url_pattern_type",
+      "schema": "public",
+      "values": [
+        "page_num",
+        "offset"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/migrations/meta/_journal.json
+++ b/server/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1773774697355,
       "tag": "0018_bitter_tyrannus",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1774706058290,
+      "tag": "0019_funny_starhawk",
+      "breakpoints": true
     }
   ]
 }

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -1028,24 +1028,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@14.1.4':
     resolution: {integrity: sha512-l/kMG+z6MB+fKA9KdtyprkTQ1ihlJcBh66cf0HvqGP+rXBbOXX0dpJatjZbHeunvEHoBBS69GYQG5ry78JMy3g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@14.1.4':
     resolution: {integrity: sha512-BapIFZ3ZRnvQ1uWbmqEGJuPT9cgLwvKtxhK/L2t4QYO7l+/DxXuIGjvp1x8rvfa/x1FFSsipERZK70pewbtJtw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@14.1.4':
     resolution: {integrity: sha512-mqVxTwk4XuBl49qn2A5UmzFImoL1iLm0KQQwtdRJRKl21ylQwwGCxJtIYo2rbfkZHoSKlh/YgztY0qH3wG1xIg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@14.1.4':
     resolution: {integrity: sha512-xzxF4ErcumXjO2Pvg/wVGrtr9QQJLk3IyQX1ddAC/fi6/5jZCZ9xpuL9Tzc4KPWMFq8GGWFVDMshZOdHGdkvag==}
@@ -1572,46 +1576,55 @@ packages:
     resolution: {integrity: sha512-10ICosOwYChROdQoQo589N5idQIisxjaFE/PAnX2i0Zr84mY0k9zul1ArH0rnJ/fpgiqfu13TFZR5A5YJLOYZA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.24.4':
     resolution: {integrity: sha512-ySAfWs69LYC7QhRDZNKqNhz2UKN8LDfbKSMAEtoEI0jitwfAG2iZwVqGACJT+kfYvvz3/JgsLlcBP+WWoKCLcw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.24.4':
     resolution: {integrity: sha512-uHYJ0HNOI6pGEeZ/5mgm5arNVTI0nLlmrbdph+pGXpC9tFHFDQmDMOEqkmUObRfosJqpU8RliYoGz06qSdtcjg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.24.4':
     resolution: {integrity: sha512-38yiWLemQf7aLHDgTg85fh3hW9stJ0Muk7+s6tIkSUOMmi4Xbv5pH/5Bofnsb6spIwD5FJiR+jg71f0CH5OzoA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.24.4':
     resolution: {integrity: sha512-q73XUPnkwt9ZNF2xRS4fvneSuaHw2BXuV5rI4cw0fWYVIWIBeDZX7c7FWhFQPNTnE24172K30I+dViWRVD9TwA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.24.4':
     resolution: {integrity: sha512-Aie/TbmQi6UXokJqDZdmTJuZBCU3QBDA8oTKRGtd4ABi/nHgXICulfg1KI6n9/koDsiDbvHAiQO3YAUNa/7BCw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.24.4':
     resolution: {integrity: sha512-P8MPErVO/y8ohWSP9JY7lLQ8+YMHfTI4bAdtCi3pC2hTeqFJco2jYspzOzTUB8hwUWIIu1xwOrJE11nP+0JFAQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.24.4':
     resolution: {integrity: sha512-K03TljaaoPK5FOyNMZAAEmhlyO49LaE4qCsr0lYHUKyb6QacTNF9pnfPpXnFlFD3TXuFbFbz7tJ51FujUXkXYA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.24.4':
     resolution: {integrity: sha512-VJYl4xSl/wqG2D5xTYncVWW+26ICV4wubwN9Gs5NrqhJtayikwCXzPL8GDsLnaLU3WwhQ8W02IinYSFJfyo34Q==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.24.4':
     resolution: {integrity: sha512-ku2GvtPwQfCqoPFIJCqZ8o7bJcj+Y54cZSr43hHca6jLwAiCbZdBUOrqE6y29QFajNAzzpIOwsckaTFmN6/8TA==}
@@ -1657,24 +1670,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.3.101':
     resolution: {integrity: sha512-OGjYG3H4BMOTnJWJyBIovCez6KiHF30zMIu4+lGJTCrxRI2fAjGLml3PEXj8tC3FMcud7U2WUn6TdG0/te2k6g==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.3.101':
     resolution: {integrity: sha512-/kBMcoF12PRO/lwa8Z7w4YyiKDcXQEiLvM+S3G9EvkoKYGgkkz4Q6PSNhF5rwg/E3+Hq5/9D2R+6nrkF287ihg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.3.101':
     resolution: {integrity: sha512-kDN8lm4Eew0u1p+h1l3JzoeGgZPQ05qDE0czngnjmfpsH2sOZxVj1hdiCwS5lArpy7ktaLu5JdRnx70MkUzhXw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.3.101':
     resolution: {integrity: sha512-9Wn8TTLWwJKw63K/S+jjrZb9yoJfJwCE2RV5vPCCWmlMf3U1AXj5XuWOLUX+Rp2sGKau7wZKsvywhheWm+qndQ==}

--- a/server/pnpm-workspace.yaml
+++ b/server/pnpm-workspace.yaml
@@ -7,3 +7,5 @@ allowBuilds:
   puppeteer: true
   rebrowser-puppeteer: true
   sodium-native: true
+
+packages: []

--- a/server/pnpm-workspace.yaml
+++ b/server/pnpm-workspace.yaml
@@ -1,0 +1,9 @@
+allowBuilds:
+  '@swc/core': true
+  argon2: true
+  better-sqlite3: true
+  esbuild: true
+  msgpackr-extract: true
+  puppeteer: true
+  rebrowser-puppeteer: true
+  sodium-native: true

--- a/server/src/csv.ts
+++ b/server/src/csv.ts
@@ -105,6 +105,17 @@ function getLearningProgramRow(
 
 type Framework = { name: string; id: string };
 
+const COMPETENCY_CATEGORY_MAP: Record<string, string> = {
+  outcomes: "Course Level Student Learning Outcome(s)",
+  course_objectives: "Course Objectives",
+};
+
+function formatCompetencyCategory(
+  value: string | null | undefined
+): string {
+  return COMPETENCY_CATEGORY_MAP[value ?? ""] || "Unknown";
+}
+
 function getCompetencyRow(
   item: Awaited<ReturnType<typeof findDataItems>>["items"][number],
   textVerificationAverage: number,
@@ -143,6 +154,7 @@ function getCompetencyRow(
       text: entityData.text,
       language: entityData.language,
       competency_framework: framework.id,
+      competency_category: entityData.competency_category,
     },
     { textVerificationAverage, textVerificationDetails },
     framework
@@ -177,6 +189,9 @@ function makeCompetencyRow(
     "ceasn:inLanguage": language,
     "ceasn:publisher": "",
     "ceasn:isPartOf": isPartOf,
+    ...(parent && {
+      "Competency Category": formatCompetencyCategory(entity.competency_category),
+    }),
   };
 
   return result;

--- a/server/src/data/extractions.ts
+++ b/server/src/data/extractions.ts
@@ -73,6 +73,24 @@ export async function createExtractionAuditLog(
   return result[0];
 }
 
+export async function findExtractionStartUserId(
+  extractionId: number
+): Promise<number | null> {
+  const result = await db
+    .select({ userId: extractionsAuditLog.userId })
+    .from(extractionsAuditLog)
+    .where(
+      and(
+        eq(extractionsAuditLog.extractionId, extractionId),
+        eq(extractionsAuditLog.action, "START"),
+        isNotNull(extractionsAuditLog.userId)
+      )
+    )
+    .orderBy(asc(extractionsAuditLog.createdAt))
+    .limit(1);
+  return result[0]?.userId ?? null;
+}
+
 export async function findLastAuditLogEntry(extractionId: number) {
   const result = await db
     .select({

--- a/server/src/data/extractions.ts
+++ b/server/src/data/extractions.ts
@@ -831,8 +831,7 @@ export async function createModelApiCallLog(
   callSite: string,
   inputTokenCount: number,
   outputTokenCount: number,
-  datasetId?: number,
-  crawlPageId?: number
+  options?: { datasetId?: number; crawlPageId?: number }
 ) {
   const result = await db
     .insert(modelApiCalls)
@@ -843,8 +842,8 @@ export async function createModelApiCallLog(
       callSite,
       input_token_count: inputTokenCount,
       output_token_count: outputTokenCount,
-      datasetId,
-      crawlPageId,
+      datasetId: options?.datasetId,
+      crawlPageId: options?.crawlPageId,
     })
     .returning();
   return result[0];
@@ -923,7 +922,7 @@ export async function findFailedAndNoDataPageIds(crawlStepId: number) {
       )
     )
     .groupBy(crawlPages.id)
-    .having(sql`count(${dataItems.id}) = 0`);
+    .having(eq(count(dataItems.id), 0));
 
   return [...new Set(failedIds.concat(noDataIds).map((p) => p.id))];
 }
@@ -931,3 +930,10 @@ export async function findFailedAndNoDataPageIds(crawlStepId: number) {
 export async function destroyExtraction(id: number) {
   return db.delete(extractions).where(eq(extractions.id, id));
 }
+
+export {
+  findSampledPagesForExtraction,
+  type SamplePagesOptions,
+  type SampleSortOption,
+  type SampledPageRow,
+} from "./extractionsSample";

--- a/server/src/data/extractionsSample.ts
+++ b/server/src/data/extractionsSample.ts
@@ -1,0 +1,161 @@
+/**
+ * Sample pages query for extractions. Uses raw SQL to ensure correct column
+ * aliases (camelCase), data status filtering, and minimal data selection.
+ * All filtering, aggregation, and sampling is done in the database.
+ */
+import { sql } from "drizzle-orm";
+import { PageStatus } from "../../../common/types";
+import db from ".";
+
+export type SampleSortOption =
+  | "random"
+  | "most_expensive"
+  | "most_data_items"
+  | "least_data_items";
+
+const VALID_STATUSES = new Set<string>(Object.values(PageStatus));
+const VALID_SORT: SampleSortOption[] = [
+  "random",
+  "most_expensive",
+  "most_data_items",
+  "least_data_items",
+];
+
+export interface SamplePagesOptions {
+  extractionId: number;
+  sampleSizePercent: number;
+  dataStatus: ("present" | "absent")[];
+  statuses: PageStatus[];
+  sortBy: SampleSortOption;
+}
+
+export interface SampledPageRow {
+  id: number;
+  extractionId: number;
+  crawlStepId: number;
+  url: string;
+  status: string;
+  createdAt: Date;
+  dataItemCount: number;
+  tokenSum: number;
+}
+
+/**
+ * Fetches a sampled subset of crawl pages for an extraction.
+ * 
+ * ```markdown
+ * **SQL Injection safety**: Numerical parameters are validated using Zod,
+ * if calling this function from outside, make sure to validate the input.
+ * ```
+ */
+export async function findSampledPagesForExtraction(
+  opts: SamplePagesOptions
+): Promise<SampledPageRow[]> {
+  const statuses = (opts.statuses as string[]).filter((s) => VALID_STATUSES.has(s));
+  if (statuses.length === 0) {
+    return [];
+  }
+
+  const sortBy = VALID_SORT.includes(opts.sortBy) ? opts.sortBy : "random";
+
+  const hasPresent = opts.dataStatus.includes("present");
+  const hasAbsent = opts.dataStatus.includes("absent");
+  const dataStatusFilter =
+    (hasPresent && hasAbsent) || (!hasPresent && !hasAbsent)
+      ? undefined
+      : hasPresent && !hasAbsent
+        ? "present"
+        : "absent";
+
+  const noDataStatusFilter = dataStatusFilter === undefined;
+  const filterPresent = dataStatusFilter === "present";
+  const filterAbsent = dataStatusFilter === "absent";
+
+  const statusInClause = sql.join(
+    statuses.map((s) => sql`${s}`),
+    sql`, `
+  );
+
+  /* 
+  SQL Injection safety:
+  Interpolated parameters are safe to use with Drizzle `sql` function.
+  From docs (https://orm.drizzle.team/docs/sql):
+    Additionally, any dynamic parameters such as ${id} will be mapped to the $1 placeholder, 
+    and the corresponding values will be moved to an array of values that are passed separately to the database. 
+    This approach effectively prevents any potential SQL Injection vulnerabilities.
+  */
+  const result = await db.execute(sql`
+    WITH latest_dataset AS (
+      SELECT id FROM datasets
+      WHERE extraction_id = ${opts.extractionId}
+      ORDER BY created_at DESC
+      LIMIT 1
+    ),
+    base AS (
+      SELECT
+        cp.id,
+        cp.extraction_id AS "extractionId",
+        cp.crawl_step_id AS "crawlStepId",
+        cp.url,
+        cp.status,
+        cp.created_at AS "createdAt",
+        COALESCE((
+          SELECT COUNT(*)::integer
+          FROM data_items di
+          WHERE di.crawl_page_id = cp.id
+            AND di.dataset_id = (SELECT id FROM latest_dataset)
+        ), 0) AS "dataItemCount",
+        COALESCE((
+          SELECT SUM(mac.input_token_count + mac.output_token_count)::integer
+          FROM model_api_calls mac
+          WHERE mac.crawl_page_id = cp.id
+        ), 0) AS "tokenSum"
+      FROM crawl_pages cp
+      WHERE cp.extraction_id = ${opts.extractionId}
+        AND cp.status IN (${statusInClause})
+        AND (
+          ${noDataStatusFilter}
+          OR (${filterPresent} AND COALESCE((
+            SELECT COUNT(*)::integer FROM data_items di
+            WHERE di.crawl_page_id = cp.id
+              AND di.dataset_id = (SELECT id FROM latest_dataset)
+          ), 0) > 0)
+          OR (${filterAbsent} AND COALESCE((
+            SELECT COUNT(*)::integer FROM data_items di
+            WHERE di.crawl_page_id = cp.id
+              AND di.dataset_id = (SELECT id FROM latest_dataset)
+          ), 0) = 0)
+        )
+    ),
+    with_total AS (
+      SELECT *, COUNT(*) OVER () AS total FROM base
+    ),
+    numbered AS (
+      SELECT *,
+        ROW_NUMBER() OVER (
+          ORDER BY
+            CASE WHEN ${sortBy} = 'random' THEN random() END,
+            CASE WHEN ${sortBy} = 'most_expensive' THEN "tokenSum" END DESC NULLS LAST,
+            CASE WHEN ${sortBy} = 'most_data_items' THEN "dataItemCount" END DESC NULLS LAST,
+            CASE WHEN ${sortBy} = 'least_data_items' THEN "dataItemCount" END ASC NULLS LAST
+        ) AS rn
+      FROM with_total
+    ),
+    limited AS (
+      SELECT id, "extractionId", "crawlStepId", url, status, "createdAt",
+             "dataItemCount", "tokenSum"
+      FROM numbered
+      WHERE total = 0 OR rn <= GREATEST(0, CEIL(total * ${opts.sampleSizePercent}::float / 100)::integer)
+    )
+    SELECT id, "extractionId", "crawlStepId", url, status, "createdAt",
+           "dataItemCount", "tokenSum"
+    FROM limited
+    ORDER BY
+      CASE WHEN ${sortBy} = 'random' THEN random() END,
+      CASE WHEN ${sortBy} = 'most_expensive' THEN "tokenSum" END DESC NULLS LAST,
+      CASE WHEN ${sortBy} = 'most_data_items' THEN "dataItemCount" END DESC NULLS LAST,
+      CASE WHEN ${sortBy} = 'least_data_items' THEN "dataItemCount" END ASC NULLS LAST
+  `);
+
+  return (result.rows ?? []) as unknown as SampledPageRow[];
+}

--- a/server/src/data/schema.ts
+++ b/server/src/data/schema.ts
@@ -36,6 +36,7 @@ import {
   RecipeDetectionStatus,
   Step,
   TextInclusion,
+  UserPreferences,
 } from "../../../common/types";
 import { RobotsTxt } from "../extraction/robotsParser";
 import getLogger from "../logging";
@@ -562,6 +563,7 @@ const users = pgTable("users", {
   email: text("email").notNull().unique(),
   password: text("password").notNull(),
   createdAt: timestamp("created_at").notNull().defaultNow(),
+  userPreferences: jsonb("user_preferences").$type<UserPreferences | null>(),
 });
 
 const extractionsAuditLog = pgTable(

--- a/server/src/data/schema.ts
+++ b/server/src/data/schema.ts
@@ -332,6 +332,9 @@ const modelApiCalls = pgTable(
     extractionId: integer("extraction_id").references(() => extractions.id, {
       onDelete: "cascade",
     }),
+    crawlPageId: integer("crawl_page_id").references(() => crawlPages.id, {
+      onDelete: "cascade",
+    }),
     provider: providerEnum("provider").notNull(),
     model: providerModelEnum("model").notNull(),
     callSite: text("call_site").notNull(),
@@ -341,14 +344,11 @@ const modelApiCalls = pgTable(
     datasetId: integer("dataset_id").references(() => datasets.id, {
       onDelete: "cascade"
     }),
-    crawlPageId: integer("crawl_page_id").references(() => crawlPages.id, {
-      onDelete: "cascade",
-    }),
   },
   (t) => ({
     extractionIdx: index("model_api_calls_extraction_idx").on(t.extractionId),
-    datasetIdx: index("model_api_calls_datasaet_idx").on(t.datasetId),
     crawlPageIdx: index("model_api_calls_crawl_page_idx").on(t.crawlPageId),
+    datasetIdx: index("model_api_calls_datasaet_idx").on(t.datasetId),
   })
 );
 
@@ -357,13 +357,13 @@ const modelApiCallsRelations = relations(modelApiCalls, ({ one }) => ({
     fields: [modelApiCalls.extractionId],
     references: [extractions.id],
   }),
-  dataset: one(datasets, {
-    fields: [modelApiCalls.datasetId],
-    references: [datasets.id]
-  }),
   crawlPage: one(crawlPages, {
     fields: [modelApiCalls.crawlPageId],
     references: [crawlPages.id],
+  }),
+  dataset: one(datasets, {
+    fields: [modelApiCalls.datasetId],
+    references: [datasets.id]
   }),
 }));
 
@@ -480,6 +480,7 @@ const crawlPageRelations = relations(crawlPages, ({ one, many }) => ({
   }),
   dataItems: many(dataItems),
   extractionLogs: many(extractionLogs),
+  modelApiCalls: many(modelApiCalls),
 }));
 
 const datasets = pgTable(

--- a/server/src/data/users.ts
+++ b/server/src/data/users.ts
@@ -1,5 +1,10 @@
 import { hash } from "argon2";
 import { eq } from "drizzle-orm";
+import { merge } from "lodash";
+import {
+  defaultUserPreferences,
+  UserPreferences,
+} from "../../../common/types";
 import db from "../data";
 import { users } from "./schema";
 
@@ -48,6 +53,7 @@ export async function findAllUsers() {
   return db.query.users.findMany({
     columns: {
       password: false,
+      userPreferences: false,
     },
     orderBy: (u) => u.createdAt,
   });
@@ -88,4 +94,35 @@ export async function resetUserPassword(id: number, password: string) {
     .where(eq(users.id, id))
     .returning();
   return { ...result[0], password: undefined };
+}
+
+export type UserPreferencesPatch = Partial<
+  Pick<UserPreferences, "email">
+> & {
+  email?: Partial<NonNullable<UserPreferences["email"]>>;
+};
+
+export async function patchUserPreferences(
+  userId: number,
+  patch: UserPreferencesPatch
+) {
+  const row = await db.query.users.findFirst({
+    columns: { userPreferences: true },
+    where: (users, { eq }) => eq(users.id, userId),
+  });
+  if (!row) {
+    return null;
+  }
+  const current: UserPreferences = merge(
+    {},
+    defaultUserPreferences(),
+    row.userPreferences ?? {}
+  );
+  const next: UserPreferences = merge({}, current, patch);
+  await db
+    .update(users)
+    .set({ userPreferences: next })
+    .where(eq(users.id, userId));
+
+  return next;
 }

--- a/server/src/email.tsx
+++ b/server/src/email.tsx
@@ -1,7 +1,19 @@
 import { renderAsync } from "@react-email/components";
 import nodemailer from "nodemailer";
-import { getAllEmailAddresses } from "./data/users";
+import QueryStream from "pg-query-stream";
+import db, { pool } from "./data";
+import { users } from "./data/schema";
 import { Email } from "./emails";
+import getLogger from "./logging";
+import {
+  NotificationRecipientContext,
+  NotificationUserRow,
+  shouldSendNotificationEmail,
+} from "./notifications";
+
+const logger = getLogger("email");
+
+const NOTIFICATION_BATCH_SIZE = 50;
 
 let transporter: nodemailer.Transporter;
 
@@ -37,7 +49,7 @@ async function getMailer() {
 async function sendMail(to: string[], subject: string, html: string) {
   const mailer = await getMailer();
   const params = {
-    from: "CTDL xTRA <do-not-reply.ctdl-xtra@credentialengineregistry.org>",
+    from: process.env.SMTP_FROM || "CTDL xTRA <do-not-reply.ctdl-xtra@credentialengineregistry.org>",
     to,
     subject,
     html,
@@ -45,13 +57,66 @@ async function sendMail(to: string[], subject: string, html: string) {
   return await mailer.sendMail(params);
 }
 
+function normalizeUserStreamRow(
+  raw: Record<string, unknown>
+): NotificationUserRow {
+  const id = raw.id;
+  const email = raw.email;
+  const prefsRaw = raw.userPreferences ?? raw.user_preferences;
+  if (typeof id !== "number" || typeof email !== "string") {
+    throw new Error("Invalid user row from notification stream");
+  }
+  return {
+    id,
+    email,
+    userPreferences: prefsRaw ?? null,
+  };
+}
+
 export async function sendEmailToAll<T>(
   EmailComponent: Email<T>,
   props: T & {},
-  subject?: string
+  subject?: string,
+  notificationCtx?: NotificationRecipientContext
 ) {
   const emailHtml = await renderAsync(<EmailComponent {...props} />);
-  const addresses = await getAllEmailAddresses();
+  const ctx: NotificationRecipientContext = notificationCtx ?? {
+    triggeredByUserId: null,
+  };
   subject = subject || EmailComponent.DefaultSubject || "";
-  return await sendMail(addresses, subject, emailHtml);
+
+  const query = db
+    .select({
+      id: users.id,
+      email: users.email,
+      userPreferences: users.userPreferences,
+    })
+    .from(users);
+
+  const { sql: rawSql, params } = query.toSQL();
+
+  const client = await pool.connect();
+  try {
+    const queryStream = new QueryStream(rawSql, params, {
+      batchSize: NOTIFICATION_BATCH_SIZE,
+    });
+    const stream = client.query(queryStream);
+
+    for await (const raw of stream as AsyncIterable<Record<string, unknown>>) {
+      const user = normalizeUserStreamRow(raw);
+
+      if (!user.email) {
+        logger.error({ userId: user.id }, "User email is missing");
+        continue;
+      }
+
+      if (shouldSendNotificationEmail(user, ctx)) {
+        sendMail([user.email], subject, emailHtml).catch((err) => {
+          logger.error({ err, userId: user.id }, "Notification email send failed");
+        });
+      }
+    }
+  } finally {
+    client.release();
+  }
 }

--- a/server/src/extraction/browser.ts
+++ b/server/src/extraction/browser.ts
@@ -10,11 +10,14 @@ import { findSetting } from "../data/settings";
 import getLogger from "../logging";
 import { SimplifiedMarkdown } from "../types";
 import { httpCodeToMessage, isProxyError, resolveAbsoluteUrl } from "../utils";
+import { PageSetupConfig } from "../../../common/types";
+import { applyPageSetupSteps } from "./pageSetup";
 import { detectCatalogueType } from "./llm/detectCatalogueType";
 
 export interface BrowserTaskInput {
   url: string;
   pageLoadWaitTime?: number;
+  pageSetup?: PageSetupConfig;
 }
 
 export interface BrowserTaskResult {
@@ -110,7 +113,7 @@ export async function getCluster(proxyUrl?: string) {
     }
 
     page.setDefaultTimeout(PAGE_TIMEOUT);
-    const { url, pageLoadWaitTime } = data;
+    const { url, pageLoadWaitTime, pageSetup } = data;
     let response: HTTPResponse | null = null;
 
     response = await page.goto(url, {
@@ -121,7 +124,9 @@ export async function getCluster(proxyUrl?: string) {
     if (!response) {
       throw new Error(`Failed to load page ${url}, no response received.`);
     }
-    
+
+    await applyPageSetupSteps(page, url, pageSetup);
+
     // Wait for the specified time if provided
     if (pageLoadWaitTime && pageLoadWaitTime > 0) {
       logger.info(`Waiting ${pageLoadWaitTime} seconds for page scripts to complete at ${url}`);
@@ -226,6 +231,8 @@ export interface FetchBrowserPageOptions {
   skipProxy?: boolean;
   /** Seconds to wait after page load for scripts to complete before capturing content. */
   pageLoadWaitTime?: number;
+  /** After navigation, optional ordered click/wait steps (root recipe config). */
+  pageSetup?: PageSetupConfig;
   /** Base URL used to resolve relative URLs. */
   baseUrl?: string;
 

--- a/server/src/extraction/dynamicLinkDiscovery.ts
+++ b/server/src/extraction/dynamicLinkDiscovery.ts
@@ -1,7 +1,9 @@
 import { addExtra, VanillaPuppeteer } from "puppeteer-extra";
 import StealthPlugin from "puppeteer-extra-plugin-stealth";
 import rebrowserPuppeteer, { ElementHandle, KnownDevices } from "rebrowser-puppeteer";
+import { PageSetupConfig } from "../../../common/types";
 import { BrowserFetchError, findProxies } from "./browser";
+import { applyPageSetupSteps } from "./pageSetup";
 import getLogger from "../logging";
 import { readFileSync } from "fs";
 import { isProxyError } from "../utils";
@@ -27,6 +29,8 @@ export interface DiscoverDynamicLinksOptions {
   selector?: string;
   /** Options for the click discovery process (limit, wait timeout). */
   clickOptions?: ClickDiscoveryOptions;
+  /** Root recipe page setup (after load, before waiting for the click container). */
+  pageSetup?: PageSetupConfig;
 }
 
 type Browser = Awaited<ReturnType<typeof puppeteer.launch>>;
@@ -146,6 +150,7 @@ export async function navigateWithProxy(
  * @param options.rootUrl - Root URL to navigate to and discover links from
  * @param options.selector - CSS selector for the container of clickable elements (defaults to "body")
  * @param options.clickOptions - Options for the click discovery process (limit, wait timeout)
+ * @param options.pageSetup - Optional root recipe page setup (runs after load, before the click container selector)
  */
 export async function discoverDynamicLinks(
   options: DiscoverDynamicLinksOptions
@@ -230,7 +235,7 @@ async function runDiscoveryWithProxy(
   options: DiscoverDynamicLinksOptions,
   proxyUrl?: string
 ): Promise<string[]> {
-  const { rootUrl, selector, clickOptions = {} } = options;
+  const { rootUrl, selector, clickOptions = {}, pageSetup } = options;
   const pageMaxWaitMs = Number.isFinite(clickOptions.waitMs) && clickOptions.waitMs! > 0
     ? clickOptions.waitMs!
     : 30 * 1000;
@@ -240,16 +245,19 @@ async function runDiscoveryWithProxy(
   const rootOrigin = new URL(rootUrl).origin;
   const state: PageListenerState = { blockedError: null, urls: [] };
 
+  const afterRootNavigation = async (webpage: Page) => {
+    if (state.blockedError) throw state.blockedError;
+    await webpage.waitForNetworkIdle({ idleTime: 1000, timeout: pageMaxWaitMs });
+    await applyPageSetupSteps(webpage, rootUrl, pageSetup);
+    if (selector) {
+      await webpage.waitForSelector(selector, { timeout: pageMaxWaitMs });
+    }
+  };
+
   try {
     const navResult = await navigateWithProxy(rootUrl, proxyUrl, {
       beforeNavigation: (p) => attachPageListeners(p, rootOrigin, state),
-      loadCompletedCallback: async (webpage) => {
-        if (state.blockedError) throw state.blockedError;
-        await webpage.waitForNetworkIdle({ idleTime: 1000, timeout: pageMaxWaitMs });
-        if (selector) {
-          await webpage.waitForSelector(selector, { timeout: pageMaxWaitMs });
-        }
-      },
+      loadCompletedCallback: afterRootNavigation,
     });
     page = navResult.page;
     browser = navResult.browser;
@@ -259,6 +267,8 @@ async function runDiscoveryWithProxy(
     await page.setRequestInterception(true);
     attachRequestInterception(page, state);
 
+    // Repeat settle + selector wait after interception attaches: navigation callbacks
+    // already ran before interception, and blocking navigations can change network/ DOM timing.
     await page.waitForNetworkIdle({ idleTime: 1000, timeout: pageMaxWaitMs });
     if (selector) {
       await page.waitForSelector(selector, { timeout: pageMaxWaitMs });
@@ -321,6 +331,8 @@ async function runDiscoveryWithProxy(
         });
         await page.waitForNetworkIdle({ idleTime: 500, timeout: pageMaxWaitMs }).catch(() => {});
 
+        await applyPageSetupSteps(page, rootUrl, pageSetup);
+
         if (selector) {
           try {
             await page.waitForSelector(selector, { timeout: pageMaxWaitMs });
@@ -337,6 +349,7 @@ async function runDiscoveryWithProxy(
           await browser?.close();
           const navResult = await navigateWithProxy(rootUrl, proxyUrl, {
             beforeNavigation: (p) => attachPageListeners(p, rootOrigin, state),
+            loadCompletedCallback: afterRootNavigation,
           });
           page = navResult.page;
           browser = navResult.browser;
@@ -346,10 +359,6 @@ async function runDiscoveryWithProxy(
           await page.setRequestInterception(true);
           attachRequestInterception(page, state);
 
-          await page.waitForNetworkIdle({ idleTime: 1000, timeout: pageMaxWaitMs });
-          if (selector) {
-            await page.waitForSelector(selector, { timeout: pageMaxWaitMs });
-          }
           await scrollAndSettle(page, pageMaxWaitMs);
         }
 

--- a/server/src/extraction/llm/detectUrlRegexp.ts
+++ b/server/src/extraction/llm/detectUrlRegexp.ts
@@ -39,7 +39,7 @@ export function createUrlExtractor(regexp: RegExp) {
           const matches = markdownUrl.match(regexp);
           
           if (matches) {
-            return matches[0];
+            return `.${matches[0]}`;
           }
         } else {
           return markdownUrl;

--- a/server/src/extraction/llm/determinePresenceOfEntity.ts
+++ b/server/src/extraction/llm/determinePresenceOfEntity.ts
@@ -84,6 +84,7 @@ ${MD_END}
     logApiCall: options?.logApiCalls
       ? {
           extractionId: options.logApiCalls.extractionId,
+          datasetId: options.logApiCalls.datasetId,
           crawlPageId: options.logApiCalls.crawlPageId,
           callSite: "determinePresenceOfEntity",
         }

--- a/server/src/extraction/llm/exploreAdditionalPages.ts
+++ b/server/src/extraction/llm/exploreAdditionalPages.ts
@@ -79,6 +79,7 @@ ${MD_END}
     logApiCall: options?.logApiCalls
       ? {
           extractionId: options.logApiCalls.extractionId,
+          datasetId: options.logApiCalls.datasetId,
           crawlPageId: options.logApiCalls.crawlPageId,
           callSite: "exploreAdditionalPages",
         }

--- a/server/src/extraction/llm/extractEntityData.ts
+++ b/server/src/extraction/llm/extractEntityData.ts
@@ -276,11 +276,11 @@ ${basePrompt}
       model,
       logApiCall: options?.logApiCalls
         ? {
-            extractionId: options.logApiCalls.extractionId,
-            datasetId: options.logApiCalls.datasetId,
-            crawlPageId: options.logApiCalls.crawlPageId,
-            callSite: "extractEntityData",
-          }
+          extractionId: options.logApiCalls.extractionId,
+          datasetId: options.logApiCalls.datasetId,
+          crawlPageId: options.logApiCalls.crawlPageId,
+          callSite: "extractEntityData",
+        }
         : undefined,
     });
 
@@ -311,11 +311,11 @@ ${basePrompt}
       requiredParameters: ["items"],
       logApiCall: options?.logApiCalls
         ? {
-            extractionId: options.logApiCalls.extractionId,
-            datasetId: options.logApiCalls.datasetId,
-            crawlPageId: options.logApiCalls.crawlPageId,
-            callSite: "extractEntityData",
-          }
+          extractionId: options.logApiCalls.extractionId,
+          datasetId: options.logApiCalls.datasetId,
+          crawlPageId: options.logApiCalls.crawlPageId,
+          callSite: "extractEntityData",
+        }
         : undefined,
     };
 

--- a/server/src/extraction/pageSetup.ts
+++ b/server/src/extraction/pageSetup.ts
@@ -1,0 +1,83 @@
+import { PageSetupConfig, PageSetupStep } from "../../../common/types";
+
+/**
+ * Minimal page surface for running setup steps (Puppeteer Page or compatible).
+ */
+export type PageSetupPage = {
+  waitForSelector(selector: string, options?: { timeout?: number }): Promise<unknown>;
+  click(selector: string, options?: { delay?: number }): Promise<void>;
+};
+
+/** Per–step-type handlers keyed by `PageSetupStep["type"]` for static correlation. */
+export type PageSetupStepHandlers = {
+  [K in PageSetupStep["type"]]: (
+    page: PageSetupPage,
+    step: Extract<PageSetupStep, { type: K }>
+  ) => Promise<void>;
+};
+
+const Steps = {
+  click: async (page, step) => {
+    const selector = step.selector?.trim();
+    if (!selector) {
+      throw new Error(
+        `Click step selector is empty/falsey. Please check the recipe configuration.`
+      );
+    }
+    await page.waitForSelector(selector);
+    await page.click(selector);
+  },
+  wait: async (_page, step) => {
+    const sec = step.seconds;
+    if (!Number.isFinite(sec) || sec <= 0) {
+      throw new Error(
+        `Wait step seconds is invalid/falsey. Please check the recipe configuration.`
+      );
+    }
+    await new Promise((r) => setTimeout(r, sec * 1000));
+  },
+} satisfies PageSetupStepHandlers;
+
+async function runPageSetupStep(page: PageSetupPage, step: PageSetupStep): Promise<void> {
+  switch (step.type) {
+    case "click":
+      await Steps.click(page, step);
+      return;
+    case "wait":
+      await Steps.wait(page, step);
+      return;
+    default: {
+      const unhandledStep = (step as unknown as { type: string })?.type;
+      throw new Error(`Unknown step type: ${String(unhandledStep)}`);
+    }
+  }
+}
+
+/**
+ * Runs recipe page setup steps in order. Safe to call after any navigation
+ * or whenever the page should be brought into a known state before further
+ * automation (e.g. cookie banners, waits).
+ *
+ * No-ops when `pageSetup` is missing, disabled, or has no steps.
+ */
+export async function applyPageSetupSteps(
+  page: PageSetupPage,
+  urlForLogging: string,
+  pageSetup: PageSetupConfig | undefined
+): Promise<void> {
+  if (!pageSetup?.enabled || !pageSetup.steps?.length) {
+    return;
+  }
+
+  for (const [index, step] of pageSetup.steps.entries()) {
+    try {
+      await runPageSetupStep(page, step);
+    } catch (error) {
+      const wrapped = new Error(
+        `Error applying page setup step ${index + 1} (step type: ${step.type}) for page ${urlForLogging}`
+      );
+      (wrapped as Error & { cause?: unknown }).cause = error;
+      throw wrapped;
+    }
+  }
+}

--- a/server/src/extraction/resumeExtraction.ts
+++ b/server/src/extraction/resumeExtraction.ts
@@ -3,7 +3,6 @@ import { findLatestDataset } from "../data/datasets";
 import {
   createExtractionAuditLog,
   createExtractionLog,
-  findApiExtractionRootPage,
   findExtractionById,
   findInProgressPagesWithoutJobs,
   findPagesNeedingExtractData,
@@ -16,7 +15,6 @@ import {
   getPageIdsWithExistingJobs,
   Queues,
   REPEAT_UPDATE_COMPLETION_EVERY_MS,
-  submitJob,
   submitJobs,
   submitRepeatableJob,
 } from "../workers";

--- a/server/src/extraction/submitRecipeDetection.ts
+++ b/server/src/extraction/submitRecipeDetection.ts
@@ -9,7 +9,11 @@ import { detectPageType } from "./llm/detectPageType";
 
 const logger = getLogger("extraction.submitRecipeDetection");
 
-export async function submitRecipeDetection(url: string, catalogueId: number) {
+export async function submitRecipeDetection(
+  url: string,
+  catalogueId: number,
+  triggeredByUserId?: number | null
+) {
   const { content, screenshot } = await fetchBrowserPage({ url });
   const markdownContent = await simplifiedMarkdown(content);
   logger.info(`Downloaded ${url}.`);
@@ -42,7 +46,7 @@ export async function submitRecipeDetection(url: string, catalogueId: number) {
   const id = result.id;
   await submitJob(
     Queues.DetectConfiguration,
-    { recipeId: id },
+    { recipeId: id, triggeredByUserId: triggeredByUserId ?? null },
     `detectConfiguration.${id}`
   );
   return {

--- a/server/src/notifications.ts
+++ b/server/src/notifications.ts
@@ -1,0 +1,43 @@
+import {
+  defaultUserPreferences,
+  EmailNotificationPreference,
+  UserPreferences,
+} from "../../common/types";
+import { merge } from "lodash";
+
+export interface NotificationRecipientContext {
+  triggeredByUserId: number | null;
+}
+
+export type NotificationUserRow = {
+  id: number;
+  email: string;
+  userPreferences: unknown | null;
+};
+
+export function shouldSendNotificationEmail(
+  row: NotificationUserRow,
+  ctx: NotificationRecipientContext
+): boolean {
+  const preferences: UserPreferences = merge(
+    {},
+    defaultUserPreferences(),
+    row.userPreferences || {}
+  );
+  const notificationPreference = preferences.email?.notifications;
+  const isTriggeredByMe = row.id === ctx.triggeredByUserId;
+
+  if (notificationPreference === EmailNotificationPreference.OFF) {
+    return false;
+  }
+  if (notificationPreference === EmailNotificationPreference.ALWAYS) {
+    return true;
+  }
+  if (
+    notificationPreference === EmailNotificationPreference.MINE &&
+    isTriggeredByMe
+  ) {
+    return true;
+  }
+  return false;
+}

--- a/server/src/openai.ts
+++ b/server/src/openai.ts
@@ -99,6 +99,7 @@ export async function simpleToolCompletion<
   logApiCall?: {
     callSite: string;
     extractionId: number;
+    datasetId?: number;
     crawlPageId?: number;
   };
 }): Promise<{
@@ -195,8 +196,10 @@ export async function simpleToolCompletion<
         options.logApiCall.callSite,
         inputTokenCount,
         outputTokenCount,
-        undefined,
-        options.logApiCall.crawlPageId
+        {
+          datasetId: options.logApiCall.datasetId,
+          crawlPageId: options.logApiCall.crawlPageId,
+        }
       );
     }
 
@@ -326,8 +329,10 @@ export async function structuredCompletion<
         options.logApiCall.callSite,
         inputTokenCount,
         outputTokenCount,
-        options.logApiCall.datasetId,
-        options.logApiCall.crawlPageId
+        {
+          datasetId: options.logApiCall.datasetId,
+          crawlPageId: options.logApiCall.crawlPageId,
+        }
       );
     }
 

--- a/server/src/openai.ts
+++ b/server/src/openai.ts
@@ -68,11 +68,16 @@ export function estimateCost(
 }
 
 export async function findOpenAiApiKey() {
-  const apiKey = await findSetting<string>("OPENAI_API_KEY", true);
-  if (!apiKey) {
+  const envKey =
+    process.env.OPENAI_API_KEY?.trim()
+  if (envKey) {
+    return envKey;
+  }
+  const dbSetting = await findSetting<string>("OPENAI_API_KEY", true);
+  if (!dbSetting?.value) {
     throw new Error("OpenAI API Key not found");
   }
-  return apiKey.value;
+  return dbSetting.value;
 }
 
 export async function getOpenAi() {

--- a/server/src/routers/extractions.ts
+++ b/server/src/routers/extractions.ts
@@ -3,6 +3,7 @@ import { publicProcedure, router } from ".";
 import {
   CatalogueType,
   ExtractionStatus,
+  PageStatus,
   ProviderModel,
 } from "../../../common/types";
 import { AppError, AppErrors } from "../appErrors";
@@ -24,7 +25,9 @@ import {
   findPage,
   findPageForJob,
   findPagesPaginated,
+  findSampledPagesForExtraction,
   findStep,
+  getApiCallSummary,
   getExtractionCount,
   getLogCount,
   getPageCount,
@@ -130,17 +133,30 @@ export const extractionsRouter = router({
       })
     )
     .query(async (opts) => {
-      let result = await findExtractionForDetailPage(opts.input.id);
+      const result = await findExtractionForDetailPage(opts.input.id);
       if (!result) {
         throw new AppError("Extraction not found", AppErrors.NOT_FOUND);
       }
       const datasets = await findExtractionDatasets(opts.input.id);
       const lastAuditLog = await findLastAuditLogEntry(opts.input.id);
+
+      const apiSummary = await getApiCallSummary(opts.input.id);
+      const totalInputTokens = apiSummary.reduce(
+        (sum, s) => sum + Number(s.totalInputTokens ?? 0),
+        0
+      );
+      const totalOutputTokens = apiSummary.reduce(
+        (sum, s) => sum + Number(s.totalOutputTokens ?? 0),
+        0
+      );
+
       return {
         ...result,
         datasets,
         latestDataset: datasets[0],
         lastAuditLog,
+        totalInputTokens,
+        totalOutputTokens,
       };
     }),
   destroy: publicProcedure
@@ -307,6 +323,26 @@ export const extractionsRouter = router({
     )
     .query(async (opts) => {
       return findLogsByCrawlPageId(opts.input.crawlPageId);
+    }),
+  samplePages: publicProcedure
+    .input(
+      z.object({
+        extractionId: z.number().int().positive(),
+        sampleSizePercent: z.number().min(0).max(100),
+        dataStatus: z.array(z.enum(["present", "absent"])),
+        statuses: z.array(z.nativeEnum(PageStatus)),
+        sortBy: z.enum(["random", "most_expensive", "most_data_items", "least_data_items"]),
+        applyKey: z.number().optional(),
+      })
+    )
+    .query(async (opts) => {
+      return findSampledPagesForExtraction({
+        extractionId: opts.input.extractionId,
+        sampleSizePercent: opts.input.sampleSizePercent,
+        dataStatus: opts.input.dataStatus,
+        statuses: opts.input.statuses,
+        sortBy: opts.input.sortBy,
+      });
     }),
   simulateDataExtraction: publicProcedure
     .input(

--- a/server/src/routers/recipes.ts
+++ b/server/src/routers/recipes.ts
@@ -44,6 +44,45 @@ const ClickDiscoveryOptionsSchema = z.object({
   waitMs: z.number().int().nonnegative().max(60000).optional(),
 });
 
+const PageSetupStepInputSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("click"),
+    selector: z.string(),
+  }),
+  z.object({
+    type: z.literal("wait"),
+    seconds: z.number(),
+  }),
+]);
+
+const PageSetupConfigSchema = z
+  .object({
+    enabled: z.boolean(),
+    steps: z.array(PageSetupStepInputSchema),
+  })
+  .superRefine((data, ctx) => {
+    if (!data.enabled) return;
+    data.steps.forEach((step, i) => {
+      if (step.type === "click") {
+        if (!step.selector.trim()) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "Selector is required",
+            path: ["steps", i, "selector"],
+          });
+        }
+      } else if (step.type === "wait") {
+        if (!Number.isFinite(step.seconds) || step.seconds <= 0 || step.seconds > 600) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "Wait seconds must be between 1 and 600",
+            path: ["steps", i, "seconds"],
+          });
+        }
+      }
+    });
+  });
+
 const RecipeConfigurationSchema = z.object({
   pageType: z.nativeEnum(PageType),
   linkRegexp: z.string().optional(),
@@ -54,6 +93,7 @@ const RecipeConfigurationSchema = z.object({
   pageLoadWaitTime: z.number().optional().default(0),
   exactLinkPatternMatch: z.boolean().optional(),
   contentSelector: z.string().optional(),
+  pageSetup: PageSetupConfigSchema.optional(),
 });
 
 export const recipesRouter = router({
@@ -330,6 +370,7 @@ export const recipesRouter = router({
         clickOptions: ClickDiscoveryOptionsSchema.optional(),
         exactLinkPatternMatch: z.boolean().optional(),
         pageLoadWaitTime: z.number().optional(),
+        pageSetup: PageSetupConfigSchema.optional(),
       })
     )
     .mutation(async (opts) => {
@@ -345,6 +386,7 @@ export const recipesRouter = router({
             rootUrl: opts.input.url,
             selector: opts.input.clickSelector,
             clickOptions: opts.input.clickOptions,
+            pageSetup: opts.input.pageSetup,
           });
           
           // If regex is provided, filter the discovered URLs by the regex
@@ -367,6 +409,7 @@ export const recipesRouter = router({
             url: opts.input.url,
             skipProxy: false,
             pageLoadWaitTime: opts.input.pageLoadWaitTime,
+            pageSetup: opts.input.pageSetup,
           });
           markdownContent = await simplifiedMarkdown(content);
         } else {
@@ -378,6 +421,7 @@ export const recipesRouter = router({
             url: opts.input.url,
             skipProxy: false,
             pageLoadWaitTime: opts.input.pageLoadWaitTime,
+            pageSetup: opts.input.pageSetup,
           });
           markdownContent = await simplifiedMarkdown(content);
 

--- a/server/src/routers/recipes.ts
+++ b/server/src/routers/recipes.ts
@@ -268,18 +268,7 @@ export const recipesRouter = router({
       if (!recipe) {
         throw new AppError("Recipe not found", AppErrors.NOT_FOUND);
       }
-      
-      // Only trigger detection if URL changed, not if only configuration or isTemplate changed
-      const urlChanged = opts.input.update.url !== undefined && opts.input.update.url !== recipe.url;
-      
-      if (urlChanged) {
-        await submitJob(
-          Queues.DetectConfiguration,
-          { recipeId: recipe.id },
-          `detectConfiguration.${recipe.id}`
-        );
-      }
-      
+
       // Build update object with only provided fields
       const updateData: any = {};
       

--- a/server/src/routers/recipes.ts
+++ b/server/src/routers/recipes.ts
@@ -136,7 +136,8 @@ export const recipesRouter = router({
             logger.info(`No configuration provided. Starting recipe detection with background tasks (detect mode).`);
             const detection = await submitRecipeDetection(
               opts.input.url,
-              opts.input.catalogueId
+              opts.input.catalogueId,
+              opts.ctx.user?.id
             );
 
             // If detection was successful, update the recipe with robots.txt info, name, and description
@@ -182,7 +183,10 @@ export const recipesRouter = router({
       }
       await submitJob(
         Queues.DetectConfiguration,
-        { recipeId: opts.input.id },
+        {
+          recipeId: opts.input.id,
+          triggeredByUserId: opts.ctx.user?.id ?? null,
+        },
         `detectConfiguration.${recipe.id}`
       );
       return;

--- a/server/src/routers/users.ts
+++ b/server/src/routers/users.ts
@@ -1,4 +1,10 @@
 import { z } from "zod";
+import { merge } from "lodash";
+import {
+  defaultUserPreferences,
+  EmailNotificationPreference,
+  UserPreferences,
+} from "../../../common/types";
 import { publicProcedure, router } from ".";
 import { AppError, AppErrors } from "../appErrors";
 import {
@@ -7,6 +13,7 @@ import {
   findAllUsers,
   findUserById,
   generateStrongPassword,
+  patchUserPreferences as applyUserPreferencesPatch,
   resetUserPassword,
 } from "../data/users";
 
@@ -18,7 +25,18 @@ export const usersRouter = router({
       })
     )
     .query(async (opts) => {
-      return findUserById(opts.input.id);
+      const user = await findUserById(opts.input.id);
+      if (!user) {
+        return null;
+      }
+      return {
+        ...user,
+        userPreferences: merge(
+          {},
+          defaultUserPreferences(),
+          user.userPreferences || {}
+        ) as UserPreferences,
+      };
     }),
   list: publicProcedure.query(async (_opts) => {
     return findAllUsers();
@@ -84,5 +102,26 @@ export const usersRouter = router({
     )
     .mutation(async (opts) => {
       await resetUserPassword(opts.ctx.user!.id, opts.input.password);
+    }),
+  patchUserPreferences: publicProcedure
+    .input(
+      z.object({
+        email: z.object({
+          notifications: z.nativeEnum(EmailNotificationPreference),
+        }),
+      })
+    )
+    .mutation(async (opts) => {
+      const uid = opts.ctx.user?.id;
+      if (!uid) {
+        throw new AppError("Not authenticated", AppErrors.BAD_REQUEST);
+      }
+      const merged = await applyUserPreferencesPatch(uid, {
+        email: opts.input.email,
+      });
+      if (!merged) {
+        throw new AppError("User not found", AppErrors.NOT_FOUND);
+      }
+      return merged;
     }),
 });

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -90,6 +90,7 @@ server.register(async (instance) => {
             path: opts.path,
             type: opts.error.name,
             message: opts.error.message,
+            stack: opts.error.stack,
           },
           "Error in tRPC request"
         );

--- a/server/src/workers/detectConfiguration.ts
+++ b/server/src/workers/detectConfiguration.ts
@@ -38,7 +38,10 @@ export default createProcessor<
         recipeId: recipe.id,
         url: recipe.url,
       },
-      `Recipe configuration detection #${recipe.id} is complete`
+      `Recipe configuration detection #${recipe.id} is complete`,
+      {
+        triggeredByUserId: job.data.triggeredByUserId ?? null,
+      }
     );
   } catch (err: unknown) {
     let detectionFailureReason;
@@ -64,7 +67,10 @@ export default createProcessor<
           url: recipe.url,
           reason: detectionFailureReason,
         },
-        `Recipe configuration detection #${recipe.id} has failed`
+        `Recipe configuration detection #${recipe.id} has failed`,
+        {
+          triggeredByUserId: job.data.triggeredByUserId ?? null,
+        }
       );
     }
     throw err;

--- a/server/src/workers/fetchPage.ts
+++ b/server/src/workers/fetchPage.ts
@@ -106,13 +106,20 @@ async function enqueuePages(
     configuration.pagination!.urlPatternType
   );
 
-  if (!pageCount) {
+  const totalPages =
+    pageCount?.totalPages ?? configuration.pagination!.totalPages;
+  if (!Number.isFinite(totalPages) || totalPages < 1) {
     throw new Error("Couldn't determine page count for paginated page");
+  }
+  if (!pageCount) {
+    logger.info(
+      `Using recipe totalPages (${totalPages}) as fallback; LLM did not detect page count for ${crawlPage.url}`
+    );
   }
 
   const updatedPagination = {
     ...configuration.pagination!,
-    totalPages: pageCount.totalPages,
+    totalPages,
   };
 
   const pageUrls = constructPaginatedUrls(updatedPagination);

--- a/server/src/workers/fetchPage.ts
+++ b/server/src/workers/fetchPage.ts
@@ -166,6 +166,7 @@ export async function processLinks(
       rootUrl: crawlPage.url,
       selector: configuration.clickSelector,
       clickOptions: configuration.clickOptions,
+      pageSetup: configuration.pageSetup,
     });
     for (const url of discovered) {
       const page = await findPageByUrl(crawlPage.extractionId, url);
@@ -315,6 +316,7 @@ export const performJob = async (
       url: crawlPage.url,
       skipProxy: false,
       pageLoadWaitTime: rootConfiguration?.pageLoadWaitTime,
+      pageSetup: configuration.pageSetup,
       baseUrl,
     });
 

--- a/server/src/workers/index.ts
+++ b/server/src/workers/index.ts
@@ -149,6 +149,8 @@ export function startProcessor<T>(
 
 export interface DetectConfigurationJob {
   recipeId: number;
+  /** User who requested detection; omitted on older queued jobs. */
+  triggeredByUserId?: number | null;
 }
 
 export interface FetchPageJob {

--- a/server/src/workers/index.ts
+++ b/server/src/workers/index.ts
@@ -11,6 +11,7 @@ import {
 import { default as IORedis } from "ioredis";
 import { closeCluster } from "../extraction/browser";
 import getLogger from "../logging";
+import { inspect } from "node:util";
 
 const logger = getLogger("workers");
 const REDIS_URL = process.env.REDIS_URL || "redis://localhost:6379";
@@ -276,8 +277,11 @@ async function collectJobsForExtraction<T extends { extractionId: number; crawlP
       break;
     }
     for (const job of batch) {
-      if (job.data.extractionId === extractionId) {
+      if (job?.data?.extractionId === extractionId) {
         jobs.push({ data: job.data });
+      } else {
+        logger.info(`Skipping job ${job.id} for extraction ${extractionId} because it's not for the same extraction`);
+        logger.info(`Job data: \n${inspect(job.data)}`);
       }
     }
     start = end;

--- a/server/src/workers/updateExtractionCompletion.ts
+++ b/server/src/workers/updateExtractionCompletion.ts
@@ -21,6 +21,7 @@ import { findLatestDataset } from "../data/datasets";
 import {
   createExtractionAuditLog,
   findExtractionById,
+  findExtractionStartUserId,
   getApiCallSummary,
   getStepStats,
   updateExtraction,
@@ -160,6 +161,7 @@ async function afterExtractionComplete(
 ) {
   if (job) await removeSelf(job);
   if (job) {
+    const triggeredByUserId = await findExtractionStartUserId(extraction.id);
     await sendEmailToAll(
       ExtractionComplete,
       {
@@ -172,7 +174,8 @@ async function afterExtractionComplete(
         createdAt: extraction.createdAt.toISOString(),
         stale: extraction.status == ExtractionStatus.STALE,
       },
-      `Extraction #${extraction.id} has finished`
+      `Extraction #${extraction.id} has finished`,
+      { triggeredByUserId }
     );
   }
 }

--- a/server/tests/extractions/competencies/coastline.test.ts
+++ b/server/tests/extractions/competencies/coastline.test.ts
@@ -1,0 +1,130 @@
+import { describe, test, expect } from "vitest";
+import { extractCompetencies, EXTRACTION_TIMEOUT } from "../..";
+
+describe("Coastline College", { timeout: EXTRACTION_TIMEOUT }, () => {
+  describe("Coastline College", () => {
+    test("Accounting A101", async () => {
+      const extractions = await extractCompetencies(
+        "https://catalog.cccd.edu/courses/acct-a101/"
+      );
+
+      expect(extractions).toEqual([
+        {
+          "competency_category": "outcomes",
+          "competency_framework": "Financial Accounting",
+          "language": "en",
+          "text": "Demonstrate knowledge of an accounting cycle by performing appropriate accounting functions.",
+        },
+        {
+          "competency_category": "outcomes",
+          "competency_framework": "Financial Accounting",
+          "language": "en",
+          "text": "Demonstrate ability to prepare financial statements for a corporation.",
+        },
+        {
+          "competency_category": "outcomes",
+          "competency_framework": "Financial Accounting",
+          "language": "en",
+          "text": "Prepare accounting entries required for a service versus merchandising business.",
+        },
+        {
+          "competency_category": "course_objectives",
+          "competency_framework": "Financial Accounting",
+          "language": "en",
+          "text": "Explain the nature and purpose of generally accepted accounting principles (GAAP) and International Financial Reporting Standards (IFRS). Explain and apply the components of the conceptual framework for financial accounting and reporting, including the qualitative characteristics of accounting information, the assumptions underlying accounting, the basic principles of financial accounting, and the constraints and limitations on accounting information.",
+        },
+        {
+          "competency_category": "course_objectives",
+          "competency_framework": "Financial Accounting",
+          "language": "en",
+          "text": "Define and use accounting and business terminology.",
+        },
+        {
+          "competency_category": "course_objectives",
+          "competency_framework": "Financial Accounting",
+          "language": "en",
+          "text": "Explain what a system is and how an accounting system is designed to satisfy the needs of specific businesses and users; summarize the purpose of journals and ledgers.",
+        },
+        {
+          "competency_category": "course_objectives",
+          "competency_framework": "Financial Accounting",
+          "language": "en",
+          "text": "Apply transaction analysis, input transactions into the accounting system, process this input, and prepare and interpret the four basic financial statements.",
+        },
+        {
+          "competency_category": "course_objectives",
+          "competency_framework": "Financial Accounting",
+          "language": "en",
+          "text": "Distinguish between cash basis and accrual basis accounting and their impact on the financial statements, including the revenue recognition and matching principles.",
+        },
+        {
+          "competency_category": "course_objectives",
+          "competency_framework": "Financial Accounting",
+          "language": "en",
+          "text": "Identify and illustrate how the principles of internal control are used to manage and control the firm?s resources and minimize risk.",
+        },
+        {
+          "competency_category": "course_objectives",
+          "competency_framework": "Financial Accounting",
+          "language": "en",
+          "text": "Explain the content, form, and purpose of the basic financial statements (including footnotes) and the annual report, and how they satisfy the information needs of investors, creditors, and other users.",
+        },
+        {
+          "competency_category": "course_objectives",
+          "competency_framework": "Financial Accounting",
+          "language": "en",
+          "text": "Explain the nature of current assets and related issues, including the measurement and reporting of cash and cash equivalents, receivables and bad debts, and inventory and cost of goods sold.",
+        },
+        {
+          "competency_category": "course_objectives",
+          "competency_framework": "Financial Accounting",
+          "language": "en",
+          "text": "Explain the valuation and reporting of current liabilities, estimated liabilities, and other contingencies.",
+        },
+        {
+          "competency_category": "course_objectives",
+          "competency_framework": "Financial Accounting",
+          "language": "en",
+          "text": "Identify and illustrate issues relating to long-term asset acquisition, use, cost allocation, and disposal.",
+        },
+        {
+          "competency_category": "course_objectives",
+          "competency_framework": "Financial Accounting",
+          "language": "en",
+          "text": "Distinguish between capital and revenue expenditures.",
+        },
+        {
+          "competency_category": "course_objectives",
+          "competency_framework": "Financial Accounting",
+          "language": "en",
+          "text": "Identify and illustrate issues relating to long-term liabilities, including issuance, valuation, and retirement of debt;(including the time value of money).",
+        },
+        {
+          "competency_category": "course_objectives",
+          "competency_framework": "Financial Accounting",
+          "language": "en",
+          "text": "Identify and illustrate issues relating to stockholders? equity, including issuance, repurchase of capital stock, and dividends.",
+        },
+        {
+          "competency_category": "course_objectives",
+          "competency_framework": "Financial Accounting",
+          "language": "en",
+          "text": "Explain the importance of operating, investing and financing activities reported in the Statement of Cash Flows.",
+        },
+        {
+          "competency_category": "course_objectives",
+          "competency_framework": "Financial Accounting",
+          "language": "en",
+          "text": "Interpret company activity, profitability, liquidity and solvency through selection and application of appropriate financial analysis tools.",
+        },
+        {
+          "competency_category": "course_objectives",
+          "competency_framework": "Financial Accounting",
+          "language": "en",
+          "text": "Identify the ethical implications inherent in financial reporting and be able to apply strategies for addressing them.",
+        },
+
+      ]);
+    });
+  });
+});

--- a/worker.Dockerfile
+++ b/worker.Dockerfile
@@ -24,11 +24,12 @@ RUN npm install pm2 -g
 RUN npm install pnpm -g
 
 # Build the app
-COPY server/package.json server/pnpm-lock.yaml /build/app/server/
+COPY server/package.json server/pnpm-lock.yaml server/pnpm-workspace.yaml /build/app/server/
 RUN cd /build/app/server && pnpm install
 
 USER pptruser
 RUN /build/app/server/node_modules/.bin/rebrowser-puppeteer browsers install chrome
+RUN /build/app/server/node_modules/.bin/rebrowser-puppeteer browsers install chrome-headless-shell
 
 USER root
 COPY server/ /build/app/server


### PR DESCRIPTION
This is a big PR that syncs main to the preview branch - where we accumulated work for the past month or so. Opening individual PRs would be too time consuming so they will be addressed in this one instead. While we see many changes here, it is to be noted that these have been deployed and in use in xTRA for the said month with no major issues surfacing in usage.

The changes introduces are:
- **`3c4b0ce` — Fix extraction completion logic failing due to undefined job** — When the system checked whether an extraction was still running, it could crash if one of the background tasks had incomplete information. It now ignores those incomplete entries instead of failing.

- **`15aba20` — Fixes base URL missing from when trying to open source pages (#196)** — Links to “view the original page” sometimes pointed at the app itself instead of the real website, especially when the saved address was short (like a path only). Those links now use the catalogue’s real site address so they open the correct page in the browser.

- **`490b8c8` — Track model calls to the page for better statistics** — Usage of the AI assistant is now recorded per crawled page, not only for the run as a whole. That makes it easier to see which pages drove the most AI use and cost.

- **`f61a4fd` — Add recent OpenAI models** — Newer AI models from OpenAI (including smaller or cheaper variants) were added so they can be chosen where supported, with pricing kept in line for estimates.

- **`2cadbfd` — Add option to pick the model to be used with an extraction** — When you start an extraction, you can pick which AI model to use for that run. The choice is remembered for that extraction so behaviour stays consistent.

- **`c6e61c1` — Fix simplified content breaking page UI due to line length** — This commit has no actual file changes in Git—it only has a message. Nothing in the product was updated by this commit alone. If a layout fix was intended, it would need to live on another commit or be redone.

- **`aa512c3` — Add URL based state for the tab navigation of the crawl page detail screen** — On a single crawled page’s detail view, the tab you are on (data, screenshot, logs, and so on) is reflected in the browser address. You can bookmark or share that link, and refreshing the page keeps you on the same tab.

- **`70efc72` — Add sample tool to extractions** — You can ask for a sample of pages from an extraction—for example random pages, or pages that were especially expensive or had a lot (or little) extracted data—so you can spot-check quality without opening every page.

- **`c2f69c1` — Add CompetencyCategory field to competencies** — Competencies can carry a category (such as learning outcomes vs course objectives), and that shows up in exported spreadsheet data in a readable way. Separately, if an OpenAI key is set in the server environment, that key is preferred over one stored only in the database. Closes #192 

- **`187edc5` — Print stack for the tRPC query errors.** — When something goes wrong in the API, server logs now include more detailed troubleshooting information (a “stack trace”). Background workers also log a bit more clearly when a queued task does not belong to the extraction being inspected.

- **`9a4a06a` — Fix recipe starting auto detection on its own if URL changes** — Saving a recipe after changing its URL no longer automatically starts a new “detect configuration” run. You stay in control of when that analysis runs.

- **`7e51350` — Fix failure when page count is manually specified by the recipe but the LLM can't detect pages** — For sites with numbered pages, if you already told the recipe how many pages there are but the AI could not figure it out from the page, the run no longer fails—it falls back to the number you configured.

- **`6a6e76a` — Allow customizing E-mail notification preferences** — In your profile you can choose how much email you want: all notifications, only ones tied to your own actions, or none. The system respects that choice when sending recipe and extraction emails.

- **`48e3e18` — Add recipe page setup steps for post-load clicks and waits** — Recipes can include simple after-the-page-loads steps—like “click this button” or “wait N seconds”—so the browser can accept cookies, close popups, or let dynamic content load before the crawl continues.

- **`2f367a0` — Visually group recipe items & distance levels more** — The recipe editing screens were reorganised so related options sit together and are easier to scan—especially levels and distance settings—without changing what the product does behind the scenes.

- **`ade9095` — Execute PNPM build scripts & install Chrome Shell** — Packaged builds (for example Docker images) were updated so installs stay reliable and the headless browser used for scraping has the Chrome “shell” variant available, which helps automated browsing in containers.

- **`b9a43c1` — Fix URL page forming when using precise link pattern matching** — When you use a tight pattern to match links on a page, combined addresses are built correctly again so pagination and link following work as expected. Minor packaging settings were adjusted alongside that fix.