### PR TITLE
Add CTDL xTRA EKS infrastructure

### DIFF
--- a/.github/workflows/skooner-token.yml
+++ b/.github/workflows/skooner-token.yml
@@ -60,6 +60,13 @@ jobs:
         run: |
           aws eks update-kubeconfig --name "${{ env.EKS_CLUSTER }}" --region "${{ env.AWS_REGION }}"
 
+      - name: Mask sensitive inputs
+        if: ${{ inputs.whitelist_source_range != '' }}
+        env:
+          WHITELIST: ${{ inputs.whitelist_source_range }}
+        run: |
+          echo "::add-mask::${WHITELIST}"
+
       - name: Validate RBAC (dry-run)
         env:
           ROLE: ${{ inputs.role }}
@@ -131,7 +138,7 @@ jobs:
         env:
           WHITELIST: ${{ inputs.whitelist_source_range }}
         run: |
-          echo "Setting whitelist-source-range to: ${WHITELIST}"
+          echo "Setting whitelist-source-range"
           kubectl -n kube-system annotate ingress skooner-ingress \
             nginx.ingress.kubernetes.io/whitelist-source-range="${WHITELIST}" --overwrite
 
@@ -156,7 +163,7 @@ jobs:
           ACTOR: ${{ github.actor }}
           DURATION: ${{ inputs.duration }}
           ROLE: ${{ inputs.role }}
-          WHITELIST: ${{ inputs.whitelist_source_range }}
+          WHITELIST_CONFIGURED: ${{ inputs.whitelist_source_range != '' }}
           BINDING_KIND: ${{ steps.rbac.outputs.binding_kind }}
           BINDING_NS: ${{ steps.rbac.outputs.binding_namespace }}
           SA_NAME: ${{ env.SA_NAME }}
@@ -174,7 +181,7 @@ jobs:
             --arg duration "$DURATION" \
             --arg role "$ROLE" \
             --arg ns "$BINDING_NS" \
-            --arg wl "${WHITELIST:-}" \
+            --arg whitelist_configured "$WHITELIST_CONFIGURED" \
             --arg token "$TOKEN" \
             '
             {
@@ -189,7 +196,7 @@ jobs:
                   ]
                 },
                 { "type": "section", "fields": [
-                    {"type":"mrkdwn", "text": "*Whitelist:*\n\($wl)"}
+                    {"type":"mrkdwn", "text": "*Whitelist:*\n\(if $whitelist_configured == "true" then "configured" else "unchanged" end)"}
                   ]
                 },
                 { "type": "section", "text": { "type": "mrkdwn", "text": "*Token:*\n```\($token)```" } },

--- a/infra/terraform/.gitignore
+++ b/infra/terraform/.gitignore
@@ -1,0 +1,6 @@
+.terraform/
+*.tfstate
+*.tfstate.*
+tfplan
+crash.log
+crash.*.log

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,19 +1,102 @@
 # CTDL xTRA Infrastructure
 
-This directory follows the `ce-registry/infra` layout:
+This directory contains the infrastructure used to run CTDL xTRA on the
+`cer-api-prod` EKS cluster in `us-east-1`.
 
-- `envs/ctdl-xtra`: Terraform for AWS resources attached to the target EKS cluster in `us-east-1`.
-- `github-ci-oidc`: Terraform for the GitHub Actions IAM role used by the image build workflow.
-- `modules`: small reusable Terraform modules.
-- `k8s-manifests/ctdl-xtra`: Kubernetes manifests for the CTDL xTRA namespace and workloads.
+## Deployed AWS Resources
 
-The first target is a Cloud66-to-EKS migration with:
+The main stack is in `envs/ctdl-xtra` and uses the shared S3 backend:
 
-- dedicated namespace: `ctdl-xtra`
-- dedicated node group: `ctdl-xtra`
-- app deployment: `ctdl-xtra-web`
-- worker deployment: `ctdl-xtra-worker`
-- shared extraction storage: EFS mounted at `/app/storage`
-- secrets sourced from AWS Secrets Manager through External Secrets
+- bucket: `terraform-state-o1r8`
+- key: `ctdl-xtra/envs/ctdl-xtra/tfstate`
 
-Do not commit real Cloud66 secret values. Rotate the source credentials and update the `ctdl-xtra` secret directly in AWS Secrets Manager.
+It provisions:
+
+- An EKS managed node group named `ctdl-xtra`.
+  - Cluster: `cer-api-prod`
+  - Instance type: `m6i.large`
+  - Capacity: on-demand
+  - Scaling: min `1`, desired `1`, max `2`
+  - Label: `workload=ctdl-xtra`
+  - Taint: `workload=ctdl-xtra:NoSchedule`
+- ECR repositories:
+  - `ctdl-xtra-app`
+  - `ctdl-xtra-worker`
+- Secrets Manager secret:
+  - `ctdl-xtra`
+- EFS filesystem and mount targets for shared app storage.
+
+The stack discovers the existing EKS VPC, private subnets, node security groups,
+cluster, and node group IAM role from the existing `cer-api-prod` infrastructure.
+
+## GitHub Actions OIDC
+
+The `github-ci-oidc` stack provisions the GitHub Actions IAM role used by the
+image build workflow.
+
+It uses backend key:
+
+- `ctdl-xtra/github-ci-oidc/tfstate`
+
+The deployed role is:
+
+- `github-actions-ctdl-xtra`
+
+The role is trusted by GitHub OIDC for `CredentialEngine/ctdl-xtra` and can push
+images to the CTDL xTRA app and worker ECR repositories. Store its ARN in the
+repository secret `AWS_ROLE_ARN`.
+
+## Kubernetes Manifests
+
+Kubernetes resources live under `k8s-manifests/ctdl-xtra`.
+
+They define:
+
+- Namespace: `ctdl-xtra`
+- ServiceAccount: `ctdl-xtra`
+- ExternalSecret syncing from Secrets Manager secret `ctdl-xtra`
+- ConfigMap for non-secret runtime configuration
+- EFS-backed shared PVC: `ctdl-xtra-storage`
+- Redis StatefulSet, Service, and ConfigMap
+- Database migration Job
+- Web Deployment and Service
+- Worker Deployment
+- NGINX Ingress with cert-manager TLS
+
+The current public hostname is:
+
+- `ctdl-xtra.credentialengineregistry.org`
+
+The app and worker deployments are pinned to the CTDL node group through the
+`workload=ctdl-xtra` node selector and matching toleration.
+
+## Live Dependencies
+
+These resources are part of the current deployment but are not fully represented
+in this Terraform directory yet:
+
+- RDS clone: `aicrawler-ctdl-xtra`
+  - Created from the original `aicrawler` database
+  - Placed in the EKS VPC using DB subnet group `cer-api-app-db-subnet-group`
+  - Used by `DATABASE_URL` in Secrets Manager secret `ctdl-xtra`
+- RDS security group: `ctdl-xtra-rds`
+  - Allows PostgreSQL from EKS workloads
+- EKS managed add-on: `aws-efs-csi-driver`
+  - Required for the EFS-backed RWX PVC
+- Route53 CNAME:
+  - `ctdl-xtra.credentialengineregistry.org`
+  - Points to the NGINX ingress load balancer
+
+## Image Build Workflow
+
+The GitHub Actions workflow at `.github/workflows/build-images.yml` builds and
+pushes the app and worker images to ECR.
+
+It runs for matching changes on:
+
+- `main`
+- `preview`
+
+It also supports manual `workflow_dispatch`.
+
+The currently deployed workload uses the `preview` image tags.

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,0 +1,19 @@
+# CTDL xTRA Infrastructure
+
+This directory follows the `ce-registry/infra` layout:
+
+- `envs/ctdl-xtra`: Terraform for AWS resources attached to the target EKS cluster in `us-east-1`.
+- `github-ci-oidc`: Terraform for the GitHub Actions IAM role used by the image build workflow.
+- `modules`: small reusable Terraform modules.
+- `k8s-manifests/ctdl-xtra`: Kubernetes manifests for the CTDL xTRA namespace and workloads.
+
+The first target is a Cloud66-to-EKS migration with:
+
+- dedicated namespace: `ctdl-xtra`
+- dedicated node group: `ctdl-xtra`
+- app deployment: `ctdl-xtra-web`
+- worker deployment: `ctdl-xtra-worker`
+- shared extraction storage: EFS mounted at `/app/storage`
+- secrets sourced from AWS Secrets Manager through External Secrets
+
+Do not commit real Cloud66 secret values. Rotate the source credentials and update the `ctdl-xtra` secret directly in AWS Secrets Manager.

--- a/infra/terraform/envs/ctdl-xtra/.terraform.lock.hcl
+++ b/infra/terraform/envs/ctdl-xtra/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.50"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/terraform/envs/ctdl-xtra/backend.tf
+++ b/infra/terraform/envs/ctdl-xtra/backend.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.50"
+    }
+  }
+
+  backend "s3" {
+    bucket  = "terraform-state-o1r8"
+    key     = "ctdl-xtra/envs/ctdl-xtra/tfstate"
+    region  = "us-east-1"
+    encrypt = true
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}

--- a/infra/terraform/envs/ctdl-xtra/data.tf
+++ b/infra/terraform/envs/ctdl-xtra/data.tf
@@ -1,0 +1,36 @@
+data "aws_vpc" "main" {
+  tags = {
+    project = "cer-api"
+  }
+}
+
+data "aws_subnets" "private" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.main.id]
+  }
+
+  filter {
+    name   = "tag:Name"
+    values = ["app_vpc-private-*"]
+  }
+}
+
+data "aws_eks_cluster" "cluster" {
+  name = var.eks_cluster_name
+}
+
+data "aws_iam_role" "eks_nodegroup_role" {
+  name = var.eks_nodegroup_role_name
+}
+
+data "aws_security_groups" "eks_nodes" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.main.id]
+  }
+
+  tags = {
+    "kubernetes.io/cluster/${var.eks_cluster_name}" = "owned"
+  }
+}

--- a/infra/terraform/envs/ctdl-xtra/main.tf
+++ b/infra/terraform/envs/ctdl-xtra/main.tf
@@ -1,0 +1,38 @@
+locals {
+  project_name = "ctdl-xtra"
+  namespace    = "ctdl-xtra"
+
+  common_tags = {
+    project = local.project_name
+    cluster = var.eks_cluster_name
+  }
+}
+
+module "ecr" {
+  source = "../../modules/ecr"
+
+  repository_names = [
+    "${local.project_name}-app",
+    "${local.project_name}-worker",
+  ]
+  common_tags = local.common_tags
+}
+
+module "ctdl_xtra_secret" {
+  source = "../../modules/secrets"
+
+  secret_name   = local.project_name
+  description   = "CTDL xTRA application secrets"
+  secret_values = var.ctdl_xtra_secret_values
+  tags          = local.common_tags
+}
+
+module "efs" {
+  source = "../../modules/efs"
+
+  name                       = local.project_name
+  vpc_id                     = data.aws_vpc.main.id
+  subnet_ids                 = toset(data.aws_subnets.private.ids)
+  allowed_security_group_ids = toset(data.aws_security_groups.eks_nodes.ids)
+  common_tags                = local.common_tags
+}

--- a/infra/terraform/envs/ctdl-xtra/node-group.tf
+++ b/infra/terraform/envs/ctdl-xtra/node-group.tf
@@ -1,0 +1,45 @@
+resource "aws_eks_node_group" "ctdl_xtra" {
+  cluster_name    = data.aws_eks_cluster.cluster.name
+  node_group_name = "ctdl-xtra"
+  node_role_arn   = data.aws_iam_role.eks_nodegroup_role.arn
+  subnet_ids      = data.aws_subnets.private.ids
+
+  ami_type       = "AL2023_x86_64_STANDARD"
+  capacity_type  = "ON_DEMAND"
+  disk_size      = 50
+  instance_types = var.node_group_instance_types
+
+  scaling_config {
+    desired_size = var.node_group_desired_size
+    min_size     = var.node_group_min_size
+    max_size     = var.node_group_max_size
+  }
+
+  labels = {
+    workload = local.project_name
+  }
+
+  taint {
+    key    = "workload"
+    value  = local.project_name
+    effect = "NO_SCHEDULE"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      scaling_config[0].desired_size
+    ]
+  }
+
+  update_config {
+    max_unavailable = 1
+  }
+
+  tags = merge(
+    local.common_tags,
+    {
+      "k8s.io/cluster-autoscaler/${var.eks_cluster_name}" = "owned"
+      "k8s.io/cluster-autoscaler/enabled"                 = "true"
+    }
+  )
+}

--- a/infra/terraform/envs/ctdl-xtra/outputs.tf
+++ b/infra/terraform/envs/ctdl-xtra/outputs.tf
@@ -1,0 +1,19 @@
+output "ecr_repository_urls" {
+  description = "CTDL xTRA ECR repository URLs."
+  value       = module.ecr.repository_urls
+}
+
+output "secret_name" {
+  description = "Secrets Manager secret backing the ExternalSecret."
+  value       = module.ctdl_xtra_secret.secret_name
+}
+
+output "efs_file_system_id" {
+  description = "EFS file system ID for extraction storage."
+  value       = module.efs.file_system_id
+}
+
+output "efs_storage_access_point_id" {
+  description = "EFS access point ID for /app/storage."
+  value       = module.efs.storage_access_point_id
+}

--- a/infra/terraform/envs/ctdl-xtra/terraform.tfvars
+++ b/infra/terraform/envs/ctdl-xtra/terraform.tfvars
@@ -1,0 +1,9 @@
+eks_cluster_name        = "cer-api-prod"
+eks_nodegroup_role_name = "cer-api-prod-eks-nodegroup-role"
+
+node_group_min_size     = 1
+node_group_desired_size = 1
+node_group_max_size     = 2
+node_group_instance_types = [
+  "m6i.large",
+]

--- a/infra/terraform/envs/ctdl-xtra/variables.tf
+++ b/infra/terraform/envs/ctdl-xtra/variables.tf
@@ -1,0 +1,48 @@
+variable "eks_cluster_name" {
+  description = "Existing EKS cluster that will host CTDL xTRA."
+  type        = string
+}
+
+variable "eks_nodegroup_role_name" {
+  description = "Existing IAM role used by EKS managed node groups."
+  type        = string
+}
+
+variable "node_group_min_size" {
+  description = "Minimum size for the CTDL xTRA dedicated node group."
+  type        = number
+  default     = 1
+}
+
+variable "node_group_desired_size" {
+  description = "Desired size for the CTDL xTRA dedicated node group."
+  type        = number
+  default     = 2
+}
+
+variable "node_group_max_size" {
+  description = "Maximum size for the CTDL xTRA dedicated node group."
+  type        = number
+  default     = 4
+}
+
+variable "node_group_instance_types" {
+  description = "Instance types for Puppeteer-capable CTDL xTRA nodes."
+  type        = list(string)
+  default     = ["m6i.large"]
+}
+
+variable "ctdl_xtra_secret_values" {
+  description = "Initial app secret keys. Replace placeholders directly in Secrets Manager after creation."
+  type        = map(string)
+  sensitive   = true
+  default = {
+    AIRBRAKE_PROJECT_ID  = "CHANGE_ME"
+    AIRBRAKE_PROJECT_KEY = "CHANGE_ME"
+    COOKIE_KEY           = "CHANGE_ME"
+    DATABASE_URL         = "CHANGE_ME"
+    ENCRYPTION_KEY       = "CHANGE_ME"
+    SMTP_PASSWORD        = "CHANGE_ME"
+    SMTP_USER            = "CHANGE_ME"
+  }
+}

--- a/infra/terraform/github-ci-oidc/.terraform.lock.hcl
+++ b/infra/terraform/github-ci-oidc/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.50"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/terraform/github-ci-oidc/README.md
+++ b/infra/terraform/github-ci-oidc/README.md
@@ -1,0 +1,36 @@
+# GitHub Actions OIDC
+
+This creates the IAM role used by GitHub Actions to push CTDL xTRA images to ECR without static AWS keys.
+
+The trust policy is scoped to:
+
+```text
+repo:CredentialEngine/ctdl-xtra:*
+```
+
+Apply:
+
+```bash
+cd infra/terraform/github-ci-oidc
+terraform init
+terraform apply
+```
+
+Then add the `role_arn` output as the GitHub Actions repository secret:
+
+```text
+AWS_ROLE_ARN
+```
+
+The role can push only to:
+
+```text
+ctdl-xtra-app
+ctdl-xtra-worker
+```
+
+The account-level GitHub OIDC provider must already exist at:
+
+```text
+https://token.actions.githubusercontent.com
+```

--- a/infra/terraform/github-ci-oidc/main.tf
+++ b/infra/terraform/github-ci-oidc/main.tf
@@ -1,0 +1,132 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.50"
+    }
+  }
+
+  backend "s3" {
+    bucket  = "terraform-state-o1r8"
+    key     = "ctdl-xtra/github-ci-oidc/tfstate"
+    region  = "us-east-1"
+    encrypt = true
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+variable "aws_region" {
+  description = "AWS region for provider operations."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "github_org" {
+  description = "GitHub organization name."
+  type        = string
+  default     = "CredentialEngine"
+}
+
+variable "github_repo" {
+  description = "GitHub repository name."
+  type        = string
+  default     = "ctdl-xtra"
+}
+
+variable "role_name" {
+  description = "IAM role name for GitHub Actions OIDC."
+  type        = string
+  default     = "github-actions-ctdl-xtra"
+}
+
+variable "ecr_repository_names" {
+  description = "ECR repositories this role can push to."
+  type        = set(string)
+  default = [
+    "ctdl-xtra-app",
+    "ctdl-xtra-worker",
+  ]
+}
+
+variable "common_tags" {
+  description = "Common tags for all resources."
+  type        = map(string)
+  default = {
+    project = "ctdl-xtra"
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_openid_connect_provider" "github" {
+  url = "https://token.actions.githubusercontent.com"
+}
+
+resource "aws_iam_role" "github_actions" {
+  name = var.role_name
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = data.aws_iam_openid_connect_provider.github.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = "repo:${var.github_org}/${var.github_repo}:*"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = var.common_tags
+}
+
+resource "aws_iam_role_policy" "ecr_push" {
+  name = "ecr-push"
+  role = aws_iam_role.github_actions.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "ecr:GetAuthorizationToken"
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "ecr:InitiateLayerUpload",
+          "ecr:UploadLayerPart",
+          "ecr:CompleteLayerUpload",
+          "ecr:PutImage"
+        ]
+        Resource = [
+          for repository_name in var.ecr_repository_names :
+          "arn:aws:ecr:${var.aws_region}:${data.aws_caller_identity.current.account_id}:repository/${repository_name}"
+        ]
+      }
+    ]
+  })
+}
+
+output "role_arn" {
+  description = "IAM Role ARN for GitHub Actions. Store this as the AWS_ROLE_ARN repository secret."
+  value       = aws_iam_role.github_actions.arn
+}

--- a/infra/terraform/github-ci-oidc/main.tf
+++ b/infra/terraform/github-ci-oidc/main.tf
@@ -122,6 +122,13 @@ resource "aws_iam_role_policy" "ecr_push" {
           "arn:aws:ecr:${var.aws_region}:${data.aws_caller_identity.current.account_id}:repository/${repository_name}"
         ]
       }
+      {
+        Effect = "Allow"
+        Action = [
+          "eks:DescribeCluster"
+        ]
+        Resource = "arn:aws:eks:${var.aws_region}:${data.aws_caller_identity.current.account_id}:cluster/cer-api-prod"
+      }
     ]
   })
 }

--- a/infra/terraform/k8s-manifests/ctdl-xtra/cluster/namespace.yaml
+++ b/infra/terraform/k8s-manifests/ctdl-xtra/cluster/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ctdl-xtra
+  labels:
+    name: ctdl-xtra
+    workload: ctdl-xtra

--- a/infra/terraform/k8s-manifests/ctdl-xtra/ctdl-xtra/configmap.yaml
+++ b/infra/terraform/k8s-manifests/ctdl-xtra/ctdl-xtra/configmap.yaml
@@ -6,8 +6,8 @@ metadata:
 data:
   CLIENT_PATH: /app/public
   EXTRACTION_FILES_PATH: /app/storage
-  FRONTEND_URL: https://ctdl-xtra.credentialengine.org
+  FRONTEND_URL: https://ctdl-xtra.credentialengineregistry.org
   INSPECT_WORKERS: "1"
   PORT: "3000"
   REDIS_URL: redis://redis:6379
-  VITE_API_URL: https://ctdl-xtra.credentialengine.org
+  VITE_API_URL: https://ctdl-xtra.credentialengineregistry.org

--- a/infra/terraform/k8s-manifests/ctdl-xtra/ctdl-xtra/configmap.yaml
+++ b/infra/terraform/k8s-manifests/ctdl-xtra/ctdl-xtra/configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ctdl-xtra-config
+  namespace: ctdl-xtra
+data:
+  CLIENT_PATH: /app/public
+  EXTRACTION_FILES_PATH: /app/storage
+  FRONTEND_URL: https://ctdl-xtra.credentialengine.org
+  INSPECT_WORKERS: "1"
+  PORT: "3000"
+  REDIS_URL: redis://redis:6379
+  VITE_API_URL: https://ctdl-xtra.credentialengine.org

--- a/infra/terraform/k8s-manifests/ctdl-xtra/ctdl-xtra/db-migrate-job.yaml
+++ b/infra/terraform/k8s-manifests/ctdl-xtra/ctdl-xtra/db-migrate-job.yaml
@@ -1,0 +1,32 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ctdl-xtra-db-migrate
+  namespace: ctdl-xtra
+spec:
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        app: ctdl-xtra-db-migrate
+        workload: ctdl-xtra
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        workload: ctdl-xtra
+      tolerations:
+        - key: workload
+          operator: Equal
+          value: ctdl-xtra
+          effect: NoSchedule
+      serviceAccountName: ctdl-xtra
+      containers:
+        - name: migrate
+          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra-app:release
+          imagePullPolicy: Always
+          command: ["./node_modules/.bin/drizzle-kit", "migrate"]
+          envFrom:
+            - configMapRef:
+                name: ctdl-xtra-config
+            - secretRef:
+                name: ctdl-xtra-secrets

--- a/infra/terraform/k8s-manifests/ctdl-xtra/ctdl-xtra/deployment.yaml
+++ b/infra/terraform/k8s-manifests/ctdl-xtra/ctdl-xtra/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: ctdl-xtra-web
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: ctdl-xtra-web

--- a/infra/terraform/k8s-manifests/ctdl-xtra/ctdl-xtra/deployment.yaml
+++ b/infra/terraform/k8s-manifests/ctdl-xtra/ctdl-xtra/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ctdl-xtra-web
+  namespace: ctdl-xtra
+  labels:
+    app: ctdl-xtra-web
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: ctdl-xtra-web
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: ctdl-xtra-web
+        workload: ctdl-xtra
+    spec:
+      nodeSelector:
+        workload: ctdl-xtra
+      tolerations:
+        - key: workload
+          operator: Equal
+          value: ctdl-xtra
+          effect: NoSchedule
+      serviceAccountName: ctdl-xtra
+      containers:
+        - name: web
+          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra-app:release
+          imagePullPolicy: Always
+          command: ["pm2-runtime", "/app/dist/server/src/server.js"]
+          ports:
+            - containerPort: 3000
+          envFrom:
+            - configMapRef:
+                name: ctdl-xtra-config
+            - secretRef:
+                name: ctdl-xtra-secrets
+          readinessProbe:
+            httpGet:
+              path: /up
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /up
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "2Gi"
+            limits:
+              cpu: "2000m"
+              memory: "4Gi"
+          volumeMounts:
+            - name: extraction-storage
+              mountPath: /app/storage
+      volumes:
+        - name: extraction-storage
+          persistentVolumeClaim:
+            claimName: ctdl-xtra-storage

--- a/infra/terraform/k8s-manifests/ctdl-xtra/ctdl-xtra/externalsecret.yaml
+++ b/infra/terraform/k8s-manifests/ctdl-xtra/ctdl-xtra/externalsecret.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ctdl-xtra-secrets
+  namespace: ctdl-xtra
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: ctdl-xtra-secrets
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: ctdl-xtra

--- a/infra/terraform/k8s-manifests/ctdl-xtra/ctdl-xtra/ingress.yaml
+++ b/infra/terraform/k8s-manifests/ctdl-xtra/ctdl-xtra/ingress.yaml
@@ -9,10 +9,10 @@ spec:
   ingressClassName: nginx
   tls:
     - hosts:
-        - ctdl-xtra.credentialengine.org
+        - ctdl-xtra.credentialengineregistry.org
       secretName: ctdl-xtra-web-tls
   rules:
-    - host: ctdl-xtra.credentialengine.org
+    - host: ctdl-xtra.credentialengineregistry.org
       http:
         paths:
           - path: /

--- a/infra/terraform/k8s-manifests/ctdl-xtra/ctdl-xtra/ingress.yaml
+++ b/infra/terraform/k8s-manifests/ctdl-xtra/ctdl-xtra/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ctdl-xtra-web
+  namespace: ctdl-xtra
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - ctdl-xtra.credentialengine.org
+      secretName: ctdl-xtra-web-tls
+  rules:
+    - host: ctdl-xtra.credentialengine.org
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ctdl-xtra-web
+                port:
+                  number: 80

--- a/infra/terraform/k8s-manifests/ctdl-xtra/ctdl-xtra/service-account.yaml
+++ b/infra/terraform/k8s-manifests/ctdl-xtra/ctdl-xtra/service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ctdl-xtra
+  namespace: ctdl-xtra

--- a/infra/terraform/k8s-manifests/ctdl-xtra/ctdl-xtra/service.yaml
+++ b/infra/terraform/k8s-manifests/ctdl-xtra/ctdl-xtra/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ctdl-xtra-web
+  namespace: ctdl-xtra
+spec:
+  selector:
+    app: ctdl-xtra-web
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3000

--- a/infra/terraform/k8s-manifests/ctdl-xtra/ctdl-xtra/storage.yaml
+++ b/infra/terraform/k8s-manifests/ctdl-xtra/ctdl-xtra/storage.yaml
@@ -1,0 +1,25 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ctdl-xtra-efs
+provisioner: efs.csi.aws.com
+parameters:
+  provisioningMode: efs-ap
+  fileSystemId: fs-00d4b313d702350ad
+  directoryPerms: "0755"
+  gidRangeStart: "1000"
+  gidRangeEnd: "2000"
+  basePath: "/ctdl-xtra"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ctdl-xtra-storage
+  namespace: ctdl-xtra
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ctdl-xtra-efs
+  resources:
+    requests:
+      storage: 20Gi

--- a/infra/terraform/k8s-manifests/ctdl-xtra/ctdl-xtra/worker-deployment.yaml
+++ b/infra/terraform/k8s-manifests/ctdl-xtra/ctdl-xtra/worker-deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ctdl-xtra-worker
+  namespace: ctdl-xtra
+  labels:
+    app: ctdl-xtra-worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ctdl-xtra-worker
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: ctdl-xtra-worker
+        workload: ctdl-xtra
+    spec:
+      nodeSelector:
+        workload: ctdl-xtra
+      tolerations:
+        - key: workload
+          operator: Equal
+          value: ctdl-xtra
+          effect: NoSchedule
+      serviceAccountName: ctdl-xtra
+      containers:
+        - name: worker
+          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra-worker:release
+          imagePullPolicy: Always
+          command: ["pm2-runtime", "/app/dist/server/src/worker.js"]
+          envFrom:
+            - configMapRef:
+                name: ctdl-xtra-config
+            - secretRef:
+                name: ctdl-xtra-secrets
+          resources:
+            requests:
+              cpu: "1000m"
+              memory: "3Gi"
+            limits:
+              cpu: "3000m"
+              memory: "6Gi"
+          volumeMounts:
+            - name: extraction-storage
+              mountPath: /app/storage
+      volumes:
+        - name: extraction-storage
+          persistentVolumeClaim:
+            claimName: ctdl-xtra-storage

--- a/infra/terraform/k8s-manifests/ctdl-xtra/ctdl-xtra/worker-deployment.yaml
+++ b/infra/terraform/k8s-manifests/ctdl-xtra/ctdl-xtra/worker-deployment.yaml
@@ -41,10 +41,10 @@ spec:
           resources:
             requests:
               cpu: "1000m"
-              memory: "3Gi"
+              memory: "2Gi"
             limits:
               cpu: "3000m"
-              memory: "6Gi"
+              memory: "4Gi"
           volumeMounts:
             - name: extraction-storage
               mountPath: /app/storage

--- a/infra/terraform/k8s-manifests/ctdl-xtra/ctdl-xtra/worker-deployment.yaml
+++ b/infra/terraform/k8s-manifests/ctdl-xtra/ctdl-xtra/worker-deployment.yaml
@@ -32,7 +32,7 @@ spec:
         - name: worker
           image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra-worker:release
           imagePullPolicy: Always
-          command: ["pm2-runtime", "/app/dist/server/src/worker.js"]
+          args: ["pm2-runtime", "/app/dist/server/src/worker.js"]
           envFrom:
             - configMapRef:
                 name: ctdl-xtra-config

--- a/infra/terraform/k8s-manifests/ctdl-xtra/redis/configmap.yaml
+++ b/infra/terraform/k8s-manifests/ctdl-xtra/redis/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-config
+  namespace: ctdl-xtra
+data:
+  redis.conf: |
+    appendonly yes
+    save 60 1

--- a/infra/terraform/k8s-manifests/ctdl-xtra/redis/service.yaml
+++ b/infra/terraform/k8s-manifests/ctdl-xtra/redis/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: ctdl-xtra
+spec:
+  selector:
+    app: redis
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: 6379

--- a/infra/terraform/k8s-manifests/ctdl-xtra/redis/statefulset.yaml
+++ b/infra/terraform/k8s-manifests/ctdl-xtra/redis/statefulset.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis
+  namespace: ctdl-xtra
+spec:
+  serviceName: redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+        workload: ctdl-xtra
+    spec:
+      nodeSelector:
+        workload: ctdl-xtra
+      tolerations:
+        - key: workload
+          operator: Equal
+          value: ctdl-xtra
+          effect: NoSchedule
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
+          ports:
+            - containerPort: 6379
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "1Gi"
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: config
+              mountPath: /usr/local/etc/redis
+      volumes:
+        - name: config
+          configMap:
+            name: redis-config
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: gp3
+        resources:
+          requests:
+            storage: 20Gi

--- a/infra/terraform/k8s-manifests/ctdl-xtra/redis/statefulset.yaml
+++ b/infra/terraform/k8s-manifests/ctdl-xtra/redis/statefulset.yaml
@@ -34,7 +34,7 @@ spec:
               memory: "256Mi"
             limits:
               cpu: "500m"
-              memory: "1Gi"
+              memory: "2Gi"
           volumeMounts:
             - name: data
               mountPath: /data

--- a/infra/terraform/modules/ecr/main.tf
+++ b/infra/terraform/modules/ecr/main.tf
@@ -1,0 +1,50 @@
+resource "aws_ecr_repository" "this" {
+  for_each = var.repository_names
+
+  name                 = each.value
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = var.common_tags
+}
+
+resource "aws_ecr_lifecycle_policy" "this" {
+  for_each = aws_ecr_repository.this
+
+  repository = each.value.name
+  policy     = <<EOF
+{
+  "rules": [
+    {
+      "rulePriority": 1,
+      "description": "Keep last 30 tagged images",
+      "selection": {
+        "tagStatus": "tagged",
+        "tagPrefixList": ["release", "preview", "v"],
+        "countType": "imageCountMoreThan",
+        "countNumber": 30
+      },
+      "action": {
+        "type": "expire"
+      }
+    },
+    {
+      "rulePriority": 2,
+      "description": "Expire untagged images after 7 days",
+      "selection": {
+        "tagStatus": "untagged",
+        "countType": "sinceImagePushed",
+        "countUnit": "days",
+        "countNumber": 7
+      },
+      "action": {
+        "type": "expire"
+      }
+    }
+  ]
+}
+EOF
+}

--- a/infra/terraform/modules/ecr/outputs.tf
+++ b/infra/terraform/modules/ecr/outputs.tf
@@ -1,0 +1,4 @@
+output "repository_urls" {
+  description = "Repository URLs keyed by repository name."
+  value       = { for name, repo in aws_ecr_repository.this : name => repo.repository_url }
+}

--- a/infra/terraform/modules/ecr/variables.tf
+++ b/infra/terraform/modules/ecr/variables.tf
@@ -1,0 +1,10 @@
+variable "repository_names" {
+  description = "ECR repository names to create."
+  type        = set(string)
+}
+
+variable "common_tags" {
+  description = "Tags applied to all repositories."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/efs/main.tf
+++ b/infra/terraform/modules/efs/main.tf
@@ -1,0 +1,63 @@
+resource "aws_security_group" "efs" {
+  name        = "${var.name}-efs"
+  description = "Allow NFS access to ${var.name}"
+  vpc_id      = var.vpc_id
+
+  tags = merge(var.common_tags, {
+    Name = "${var.name}-efs"
+  })
+}
+
+resource "aws_security_group_rule" "nfs" {
+  for_each = var.allowed_security_group_ids
+
+  type                     = "ingress"
+  from_port                = 2049
+  to_port                  = 2049
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.efs.id
+  source_security_group_id = each.value
+  description              = "Allow NFS from EKS worker nodes"
+}
+
+resource "aws_efs_file_system" "this" {
+  creation_token   = var.name
+  encrypted        = true
+  performance_mode = "generalPurpose"
+  throughput_mode  = "elastic"
+
+  tags = merge(var.common_tags, {
+    Name = var.name
+  })
+}
+
+resource "aws_efs_mount_target" "this" {
+  for_each = var.subnet_ids
+
+  file_system_id  = aws_efs_file_system.this.id
+  subnet_id       = each.value
+  security_groups = [aws_security_group.efs.id]
+}
+
+resource "aws_efs_access_point" "storage" {
+  file_system_id = aws_efs_file_system.this.id
+
+  posix_user {
+    gid = 1000
+    uid = 1000
+  }
+
+  root_directory {
+    path = "/storage"
+
+    creation_info {
+      owner_gid   = 1000
+      owner_uid   = 1000
+      permissions = "0755"
+    }
+  }
+
+  tags = merge(var.common_tags, {
+    Name = "${var.name}-storage"
+  })
+}

--- a/infra/terraform/modules/efs/outputs.tf
+++ b/infra/terraform/modules/efs/outputs.tf
@@ -1,0 +1,9 @@
+output "file_system_id" {
+  description = "EFS file system ID."
+  value       = aws_efs_file_system.this.id
+}
+
+output "storage_access_point_id" {
+  description = "EFS access point ID for extraction storage."
+  value       = aws_efs_access_point.storage.id
+}

--- a/infra/terraform/modules/efs/variables.tf
+++ b/infra/terraform/modules/efs/variables.tf
@@ -1,0 +1,25 @@
+variable "name" {
+  description = "Name tag for the EFS file system."
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID where EFS mount targets are created."
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "Private subnet IDs for EFS mount targets."
+  type        = set(string)
+}
+
+variable "allowed_security_group_ids" {
+  description = "Security groups allowed to mount EFS."
+  type        = set(string)
+}
+
+variable "common_tags" {
+  description = "Tags applied to EFS resources."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/secrets/main.tf
+++ b/infra/terraform/modules/secrets/main.tf
@@ -1,0 +1,14 @@
+resource "aws_secretsmanager_secret" "this" {
+  name        = var.secret_name
+  description = var.description
+  tags        = var.tags
+}
+
+resource "aws_secretsmanager_secret_version" "this" {
+  secret_id     = aws_secretsmanager_secret.this.id
+  secret_string = jsonencode(var.secret_values)
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}

--- a/infra/terraform/modules/secrets/outputs.tf
+++ b/infra/terraform/modules/secrets/outputs.tf
@@ -1,0 +1,9 @@
+output "secret_arn" {
+  description = "Secrets Manager secret ARN."
+  value       = aws_secretsmanager_secret.this.arn
+}
+
+output "secret_name" {
+  description = "Secrets Manager secret name."
+  value       = aws_secretsmanager_secret.this.name
+}

--- a/infra/terraform/modules/secrets/variables.tf
+++ b/infra/terraform/modules/secrets/variables.tf
@@ -1,0 +1,22 @@
+variable "secret_name" {
+  description = "Secrets Manager secret name."
+  type        = string
+}
+
+variable "description" {
+  description = "Secrets Manager secret description."
+  type        = string
+  default     = null
+}
+
+variable "secret_values" {
+  description = "Initial JSON secret values. Values are ignored after creation."
+  type        = map(string)
+  sensitive   = true
+}
+
+variable "tags" {
+  description = "Tags applied to the secret."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Summary

- Add Terraform for CTDL xTRA EKS infrastructure on `cer-api-prod`.
- Add Kubernetes manifests for the `ctdl-xtra` namespace, web/worker workloads, Redis, EFS storage, ExternalSecret, migration job, and ingress.
- Add GitHub Actions workflows for image builds and Skooner token generation.
- Document the deployed infrastructure in `infra/terraform/README.md`.

## Notes

- Current deployment uses the `preview` image tags.
- The branch also includes existing app commits that were already present in this branch history relative to `main`.

## Testing

- Applied Terraform and Kubernetes resources during migration work.
- Built app and worker images through GitHub Actions.
- Verified ingress health endpoint returns `200`.
- Verified Skooner workflow YAML parses locally.
