### PR TITLE
Make lint/test non-blocking in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
@@ -40,6 +41,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
@@ -64,7 +66,6 @@ jobs:
   publish:
     name: Build & Publish
     runs-on: ubuntu-latest
-    needs: [lint, test]
     outputs:
       image_tag: ${{ steps.tag.outputs.value }}
     steps:


### PR DESCRIPTION
Adds `continue-on-error: true` to lint and test jobs and removes the `needs` dependency from publish, so images are built and pushed to ECR regardless of lint/test outcome.