### PR TITLE
Add base image with Chrome pre-baked to speed up release builds

### DIFF
--- a/.github/workflows/build-base.yml
+++ b/.github/workflows/build-base.yml
@@ -1,0 +1,48 @@
+name: Build Base Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - base.Dockerfile
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: us-east-1
+  ECR_REGISTRY: 996810415034.dkr.ecr.us-east-1.amazonaws.com
+  ECR_REPOSITORY: ctdl-xtra-staging/base
+
+jobs:
+  build:
+    name: Build & Push Base Image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - uses: aws-actions/amazon-ecr-login@v2
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build & push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: base.Dockerfile
+          push: true
+          tags: |
+            ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:latest
+            ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:sha-${{ github.sha }}
+          cache-from: type=gha,scope=base
+          cache-to: type=gha,mode=max,scope=base
+
+      - name: Summary
+        run: echo "### Built base image \`sha-${{ github.sha }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - uses: aws-actions/amazon-ecr-login@v2
+
       - uses: docker/setup-buildx-action@v3
 
       - name: Build API image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,42 +1,14 @@
-# From https://github.com/puppeteer/puppeteer/blob/main/docker/Dockerfile
-FROM node:20
-
-# Configure default locale (important for chrome-headless-shell).
-ENV LANG=en_US.UTF-8
+ARG BASE_IMAGE=996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra-staging/base:latest
+FROM ${BASE_IMAGE}
 
 ENV VITE_API_URL="$VITE_API_URL"
 
-# Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
-# Note: this installs the necessary libs to make the bundled version of Chrome that Puppeteer
-# installs, work.
-RUN apt-get update \
-  && apt-get install -y wget gnupg \
-  && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/googlechrome-linux-keyring.gpg \
-  && sh -c 'echo "deb [arch=amd64 signed-by=/usr/share/keyrings/googlechrome-linux-keyring.gpg] https://dl-ssl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-  && apt-get update \
-  && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-khmeros fonts-kacst fonts-freefont-ttf libxss1 dbus dbus-x11 \
-  --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* \
-  && groupadd -r pptruser && useradd -rm -g pptruser -G audio,video pptruser
-
-# Install pm2 for running the app
-RUN npm install pm2 -g
-
-# Install pnpm
-RUN npm install pnpm -g
-
-# Build the app
 COPY client/package.json client/pnpm-lock.yaml client/pnpm-workspace.yaml /build/app/client/
 COPY server/package.json server/pnpm-lock.yaml server/pnpm-workspace.yaml /build/app/server/
 RUN (cd /build/app/client && pnpm install) & \
   (cd /build/app/server && pnpm install) & \
   wait
 
-USER pptruser
-RUN /build/app/server/node_modules/.bin/rebrowser-puppeteer browsers install chrome
-RUN /build/app/server/node_modules/.bin/rebrowser-puppeteer browsers install chrome-headless-shell
-
-USER root
 COPY client/ /build/app/client
 COPY common/ /build/app/common
 COPY server/ /build/app/server

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -1,0 +1,20 @@
+FROM node:20
+
+ENV LANG=en_US.UTF-8
+
+RUN apt-get update \
+  && apt-get install -y wget gnupg \
+  && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/googlechrome-linux-keyring.gpg \
+  && sh -c 'echo "deb [arch=amd64 signed-by=/usr/share/keyrings/googlechrome-linux-keyring.gpg] https://dl-ssl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+  && apt-get update \
+  && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-khmeros fonts-kacst fonts-freefont-ttf libxss1 dbus dbus-x11 \
+  --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/* \
+  && groupadd -r pptruser && useradd -rm -g pptruser -G audio,video pptruser
+
+RUN npm install -g pm2 pnpm rebrowser-puppeteer@23.6.101
+
+USER pptruser
+RUN rebrowser-puppeteer browsers install chrome
+RUN rebrowser-puppeteer browsers install chrome-headless-shell
+USER root

--- a/worker.Dockerfile
+++ b/worker.Dockerfile
@@ -1,37 +1,9 @@
-# From https://github.com/puppeteer/puppeteer/blob/main/docker/Dockerfile
-FROM node:20
+ARG BASE_IMAGE=996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra-staging/base:latest
+FROM ${BASE_IMAGE}
 
-# Configure default locale (important for chrome-headless-shell).
-ENV LANG=en_US.UTF-8
-
-# Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
-# Note: this installs the necessary libs to make the bundled version of Chrome that Puppeteer
-# installs, work.
-RUN apt-get update \
-  && apt-get install -y wget gnupg \
-  && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/googlechrome-linux-keyring.gpg \
-  && sh -c 'echo "deb [arch=amd64 signed-by=/usr/share/keyrings/googlechrome-linux-keyring.gpg] https://dl-ssl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-  && apt-get update \
-  && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-khmeros fonts-kacst fonts-freefont-ttf libxss1 dbus dbus-x11 \
-  --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* \
-  && groupadd -r pptruser && useradd -rm -g pptruser -G audio,video pptruser
-
-# Install pm2 for running the app
-RUN npm install pm2 -g
-
-# Install pnpm
-RUN npm install pnpm -g
-
-# Build the app
 COPY server/package.json server/pnpm-lock.yaml server/pnpm-workspace.yaml /build/app/server/
 RUN cd /build/app/server && pnpm install
 
-USER pptruser
-RUN /build/app/server/node_modules/.bin/rebrowser-puppeteer browsers install chrome
-RUN /build/app/server/node_modules/.bin/rebrowser-puppeteer browsers install chrome-headless-shell
-
-USER root
 COPY server/ /build/app/server
 COPY common/ /build/app/common
 RUN cd /build/app/server && pnpm run build


### PR DESCRIPTION
## Summary

- Add `base.Dockerfile` containing: system Chrome (via apt), fonts, pm2, pnpm, and pre-downloaded Chrome/chrome-headless-shell binaries (rebrowser-puppeteer@23.6.101)
- Add `build-base.yml` workflow — triggers only when `base.Dockerfile` changes, pushes `ctdl-xtra-staging/base:latest`
- Slim down `Dockerfile` and `worker.Dockerfile` to `FROM ctdl-xtra-staging/base:latest` — removing the ~5 min apt + Chrome download from every release build
- Add ECR login to `ci.yml` build job so PR builds can pull the base image

## Note
On first merge, `build-base.yml` and `release.yml` will fire in parallel. The base image build takes ~7 min; `release.yml` will fail on this first run since the base image doesn't exist yet. Re-run `release.yml` manually after `build-base.yml` completes. All subsequent releases will be ~1–2 min.