### PR TITLE
Refactor deployment to template-based envsubst model

### DIFF
--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -13,8 +13,6 @@ permissions:
 
 env:
   AWS_REGION: us-east-1
-  ECR_REGISTRY: 996810415034.dkr.ecr.us-east-1.amazonaws.com
-  NAMESPACE: ctdl-xtra
 
 jobs:
   promote:
@@ -22,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: PRODUCTION
     steps:
+      - uses: actions/checkout@v4
+
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
@@ -43,31 +43,22 @@ jobs:
               exit 1
             fi
 
-            for DEST_TAG in "${IMAGE_TAG}" "prod-latest"; do
-              aws ecr put-image \
-                --repository-name "ctdl-xtra/${SERVICE}" \
-                --image-tag "${DEST_TAG}" \
-                --image-manifest "${MANIFEST}" || true
-            done
+            aws ecr put-image \
+              --repository-name "ctdl-xtra/${SERVICE}" \
+              --image-tag "${IMAGE_TAG}" \
+              --image-manifest "${MANIFEST}" || true
 
             echo "Copied ctdl-xtra-staging/${SERVICE}:${IMAGE_TAG} → ctdl-xtra/${SERVICE}:${IMAGE_TAG}"
           done
 
       - name: Configure kubeconfig
-        run: aws eks update-kubeconfig --name ctdl-xtra-prod --region "$AWS_REGION"
+        run: aws eks update-kubeconfig --name ctdl-xtra-prod --region "$AWS_REGION" --alias ctdl-xtra-prod
 
       - name: Deploy
         env:
           IMAGE_TAG: ${{ inputs.image_tag }}
-        run: |
-          API_IMAGE="${ECR_REGISTRY}/ctdl-xtra/api:${IMAGE_TAG}"
-          WORKER_IMAGE="${ECR_REGISTRY}/ctdl-xtra/worker:${IMAGE_TAG}"
-
-          kubectl set image deployment/ctdl-xtra-api    api="${API_IMAGE}"       -n "${NAMESPACE}"
-          kubectl set image deployment/ctdl-xtra-worker worker="${WORKER_IMAGE}" -n "${NAMESPACE}"
-
-          kubectl rollout status deployment/ctdl-xtra-api    -n "${NAMESPACE}" --timeout=300s
-          kubectl rollout status deployment/ctdl-xtra-worker -n "${NAMESPACE}" --timeout=300s
+          KUBE_CONTEXT: ctdl-xtra-prod
+        run: bash infra/terraform/k8s-manifests/production/app/deploy-app.sh
 
       - name: Summary
         run: |

--- a/.github/workflows/promote-staging.yml
+++ b/.github/workflows/promote-staging.yml
@@ -14,8 +14,6 @@ permissions:
 
 env:
   AWS_REGION: us-east-1
-  ECR_REGISTRY: 996810415034.dkr.ecr.us-east-1.amazonaws.com
-  NAMESPACE: ctdl-xtra
 
 jobs:
   promote:
@@ -23,26 +21,21 @@ jobs:
     runs-on: ubuntu-latest
     environment: STAGING
     steps:
+      - uses: actions/checkout@v4
+
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Configure kubeconfig
-        run: aws eks update-kubeconfig --name ctdl-xtra-staging --region "$AWS_REGION"
+        run: aws eks update-kubeconfig --name ctdl-xtra-staging --region "$AWS_REGION" --alias ctdl-xtra-staging
 
       - name: Deploy
         env:
           IMAGE_TAG: ${{ inputs.image_tag }}
-        run: |
-          API_IMAGE="${ECR_REGISTRY}/ctdl-xtra-staging/api:${IMAGE_TAG}"
-          WORKER_IMAGE="${ECR_REGISTRY}/ctdl-xtra-staging/worker:${IMAGE_TAG}"
-
-          kubectl set image deployment/ctdl-xtra-api    api="${API_IMAGE}"       -n "${NAMESPACE}"
-          kubectl set image deployment/ctdl-xtra-worker worker="${WORKER_IMAGE}" -n "${NAMESPACE}"
-
-          kubectl rollout status deployment/ctdl-xtra-api    -n "${NAMESPACE}" --timeout=300s
-          kubectl rollout status deployment/ctdl-xtra-worker -n "${NAMESPACE}" --timeout=300s
+          KUBE_CONTEXT: ctdl-xtra-staging
+        run: bash infra/terraform/k8s-manifests/staging/app/deploy-app.sh
 
       - name: Summary
         run: |

--- a/CI-CD.md
+++ b/CI-CD.md
@@ -1,0 +1,124 @@
+# CI/CD Pipeline
+
+## Branching Model
+
+```
+feature/* or fix/*
+       │
+       │  Pull Request
+       ▼
+     main  ──────────────────────────────────────────────────────────►  git history
+       │
+       │  Merge to main (automatic)
+       ▼
+  [Release workflow]
+  Build images → push to STAGING ECR
+       │
+       │  Manual trigger
+       ▼
+  [Promote to STAGING]
+  envsubst + kubectl apply → ctdl-xtra-staging cluster
+       │
+       │  Manual trigger (exact sha tag required)
+       ▼
+  [Promote to PRODUCTION]
+  Copy image STAGING ECR → PRODUCTION ECR (no rebuild)
+  envsubst + kubectl apply → ctdl-xtra-prod cluster
+```
+
+All development happens on short-lived branches off `main`. There is no long-lived staging or release branch — environment promotion is controlled through GitHub Actions workflows, not through git branches.
+
+---
+
+## Workflows
+
+### CI (`ci.yml`) — Pull Request
+
+Runs on every PR. Blocks merge if any job fails.
+
+| Job | What it does |
+|-----|-------------|
+| Lint | ESLint on the `client/` workspace |
+| Test | Vitest on the `server/` workspace |
+| Build images | Docker build for API and Worker (no push, uses GHA layer cache) |
+
+### Build Base Image (`build-base.yml`) — Push to `main` (path-filtered)
+
+Triggers only when `base.Dockerfile` changes. Builds the shared base image (system Chrome, fonts, pm2, pnpm, pre-downloaded Chrome binaries) and pushes to `ctdl-xtra-staging/base:latest`. Both `Dockerfile` and `worker.Dockerfile` `FROM` this base, so app builds skip the heavy apt + Chrome install.
+
+### Release (`release.yml`) — Push to `main`
+
+Runs automatically on every merge to `main`. Lint and Test run in parallel (non-blocking via `continue-on-error`); `publish` runs independently.
+
+Produces two image tags per service and pushes to STAGING ECR:
+
+| Tag | Purpose |
+|-----|---------|
+| `sha-<7char>` | Immutable reference to this exact commit, used for promotion |
+| `main-latest` | Floating tag, always points to the latest main build |
+
+ECR repositories written to:
+- `ctdl-xtra-staging/api`
+- `ctdl-xtra-staging/worker`
+
+### Promote to STAGING (`promote-staging.yml`) — Manual
+
+Go to **Actions → Promote to STAGING → Run workflow**.
+
+Input: `image_tag` (default: `main-latest`). Use a `sha-*` tag to deploy a specific commit.
+
+Runs `deploy-app.sh` with `IMAGE_TAG` set, which `envsubst`s the tag into `deployment.yaml` / `db-migrate-job.yaml` and `kubectl apply`s the full manifest set on `ctdl-xtra-staging`.
+
+### Promote to PRODUCTION (`promote-production.yml`) — Manual
+
+Go to **Actions → Promote to PRODUCTION → Run workflow**.
+
+Input: `image_tag` (**required**, must be an exact `sha-*` tag).
+
+Steps:
+1. Validates the tag exists in STAGING ECR.
+2. Copies the image manifest via the ECR API (no Docker pull/push, same digest guaranteed) to PRODUCTION ECR under the same `sha-*` tag.
+3. Runs `deploy-app.sh` against `ctdl-xtra-prod` — same envsubst + apply flow as staging.
+
+ECR repositories written to:
+- `ctdl-xtra/api`
+- `ctdl-xtra/worker`
+
+---
+
+## Deployment Model
+
+Manifests in `infra/terraform/k8s-manifests/{staging,production}/app/` are **templates**, not state snapshots. The image reference is left as a placeholder:
+
+```yaml
+image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra/api:${IMAGE_TAG}
+```
+
+At deploy time, `deploy-app.sh` substitutes `${IMAGE_TAG}` with the requested tag and applies the manifest. Consequences:
+
+- **Cluster state = last successful workflow run.** Workflow run history is deployment history.
+- **No `kubectl set image`.** Apply is the only deployment mechanism, so manifest edits (resource limits, env vars, probes) flow through the same path as image changes.
+- **No git commits from CI.** The manifest stays a template; the tag lives in the workflow input.
+- **Disaster recovery is trivial.** Re-run the workflow with the desired sha.
+- **You cannot `kubectl apply -f` the manifest directly** — it must go through `envsubst` (or via `bash deploy-app.sh` with `IMAGE_TAG` set).
+
+---
+
+## Key Principles
+
+- **Build once.** Images are built only on merge to `main`. Promotion to production copies the manifest via the AWS ECR API; the image is never rebuilt and the digest never changes.
+- **Immutable tags.** `sha-*` tags are never overwritten. Only `main-latest` floats (staging only).
+- **Specific sha in production.** Production deploys always specify an exact `sha-*` tag.
+- **Manual gates.** Both staging and production deploys require a human to trigger them in GitHub Actions.
+- **OIDC auth.** GitHub Actions assumes the `ctdl-xtra-github-actions-ci` IAM role via OIDC (no stored AWS credentials). The role ARN is stored as the `AWS_ROLE_ARN` repository secret.
+
+---
+
+## Infrastructure
+
+| Environment | EKS Cluster | ECR prefix | Domain |
+|-------------|-------------|------------|--------|
+| Staging | `ctdl-xtra-staging` | `ctdl-xtra-staging/*` | `xtra-staging.credentialengineregistry.org` |
+| Production | `ctdl-xtra-prod` | `ctdl-xtra/*` | `xtra.credentialengineregistry.org` |
+
+Terraform for the IAM role and OIDC provider lives in [`infra/terraform/github-ci-oidc/`](infra/terraform/github-ci-oidc/).

--- a/infra/terraform/k8s-manifests/production/app/db-migrate-job.yaml
+++ b/infra/terraform/k8s-manifests/production/app/db-migrate-job.yaml
@@ -25,7 +25,7 @@ spec:
         nodepool: app
       containers:
         - name: db-migrate
-          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra/api:prod-20260514-d36bff263e6e-r2
+          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra/api:${IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           command:
             - /app/entrypoint.sh

--- a/infra/terraform/k8s-manifests/production/app/deploy-app.sh
+++ b/infra/terraform/k8s-manifests/production/app/deploy-app.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+: "${IMAGE_TAG:?IMAGE_TAG must be set (e.g. sha-abc1234)}"
+export IMAGE_TAG
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONTEXT="${KUBE_CONTEXT:-ctdl-xtra-prod}"
 NAMESPACE="ctdl-xtra"
@@ -17,10 +20,13 @@ kubectl --context "${CONTEXT}" -n "${NAMESPACE}" create configmap rds-ca-bundle 
   -o yaml | kubectl --context "${CONTEXT}" apply -f -
 kubectl --context "${CONTEXT}" -n "${NAMESPACE}" wait --for=condition=Ready externalsecret/ctdl-xtra-app --timeout=120s
 kubectl --context "${CONTEXT}" -n "${NAMESPACE}" delete job ctdl-xtra-db-migrate --ignore-not-found
-kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/db-migrate-job.yaml"
+envsubst '${IMAGE_TAG}' < "${SCRIPT_DIR}/db-migrate-job.yaml" | kubectl --context "${CONTEXT}" apply -f -
 kubectl --context "${CONTEXT}" -n "${NAMESPACE}" wait --for=condition=Complete job/ctdl-xtra-db-migrate --timeout=300s
+kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/redis-configmap.yaml"
+kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/redis-externalsecret.yaml"
+kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/redis-statefulset.yaml"
 kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/service.yaml"
-kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/deployment.yaml"
+envsubst '${IMAGE_TAG}' < "${SCRIPT_DIR}/deployment.yaml" | kubectl --context "${CONTEXT}" apply -f -
 kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/ingress.yaml"
 kubectl --context "${CONTEXT}" -n "${NAMESPACE}" rollout status deployment/ctdl-xtra-api --timeout=300s
 kubectl --context "${CONTEXT}" -n "${NAMESPACE}" rollout status deployment/ctdl-xtra-worker --timeout=300s

--- a/infra/terraform/k8s-manifests/production/app/deployment.yaml
+++ b/infra/terraform/k8s-manifests/production/app/deployment.yaml
@@ -32,7 +32,7 @@ spec:
         nodepool: app
       containers:
         - name: api
-          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra/api:prod-20260514-d36bff263e6e-r2
+          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra/api:${IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -127,7 +127,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: worker
-          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra/worker:prod-20260514-d36bff263e6e-r2
+          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra/worker:${IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           env:
             - name: LOG_LEVEL

--- a/infra/terraform/k8s-manifests/staging/app/db-migrate-job.yaml
+++ b/infra/terraform/k8s-manifests/staging/app/db-migrate-job.yaml
@@ -25,7 +25,7 @@ spec:
         nodepool: app
       containers:
         - name: db-migrate
-          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra-staging/api:latest
+          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra-staging/api:${IMAGE_TAG}
           imagePullPolicy: Always
           command:
             - /app/entrypoint.sh

--- a/infra/terraform/k8s-manifests/staging/app/deploy-app.sh
+++ b/infra/terraform/k8s-manifests/staging/app/deploy-app.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+: "${IMAGE_TAG:?IMAGE_TAG must be set (e.g. sha-abc1234 or main-latest)}"
+export IMAGE_TAG
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONTEXT="${KUBE_CONTEXT:-ctdl-xtra-staging}"
 NAMESPACE="ctdl-xtra"
@@ -17,13 +20,13 @@ kubectl --context "${CONTEXT}" -n "${NAMESPACE}" create configmap rds-ca-bundle 
   -o yaml | kubectl --context "${CONTEXT}" apply -f -
 kubectl --context "${CONTEXT}" -n "${NAMESPACE}" wait --for=condition=Ready externalsecret/ctdl-xtra-app --timeout=120s
 kubectl --context "${CONTEXT}" -n "${NAMESPACE}" delete job ctdl-xtra-db-migrate --ignore-not-found
-kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/db-migrate-job.yaml"
+envsubst '${IMAGE_TAG}' < "${SCRIPT_DIR}/db-migrate-job.yaml" | kubectl --context "${CONTEXT}" apply -f -
 kubectl --context "${CONTEXT}" -n "${NAMESPACE}" wait --for=condition=Complete job/ctdl-xtra-db-migrate --timeout=300s
 kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/redis-configmap.yaml"
 kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/redis-externalsecret.yaml"
 kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/redis-statefulset.yaml"
 kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/service.yaml"
-kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/deployment.yaml"
+envsubst '${IMAGE_TAG}' < "${SCRIPT_DIR}/deployment.yaml" | kubectl --context "${CONTEXT}" apply -f -
 kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/ingress.yaml"
 kubectl --context "${CONTEXT}" -n "${NAMESPACE}" rollout status deployment/ctdl-xtra-api --timeout=300s
 kubectl --context "${CONTEXT}" -n "${NAMESPACE}" rollout status deployment/ctdl-xtra-worker --timeout=300s

--- a/infra/terraform/k8s-manifests/staging/app/deployment.yaml
+++ b/infra/terraform/k8s-manifests/staging/app/deployment.yaml
@@ -32,7 +32,7 @@ spec:
         nodepool: app
       containers:
         - name: api
-          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra-staging/api:latest
+          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra-staging/api:${IMAGE_TAG}
           imagePullPolicy: Always
           ports:
             - name: http
@@ -127,7 +127,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: worker
-          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra-staging/worker:latest
+          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra-staging/worker:${IMAGE_TAG}
           imagePullPolicy: Always
           env:
             - name: LOG_LEVEL


### PR DESCRIPTION
## Summary

Refactor the deployment model so that:

1. Manifests in `infra/terraform/k8s-manifests/{staging,production}/app/` become **templates** — `deployment.yaml` and `db-migrate-job.yaml` reference the image as `:${IMAGE_TAG}` instead of a hardcoded tag.
2. `deploy-app.sh` (both envs) now requires `IMAGE_TAG`, runs `envsubst` over the two image-bearing manifests, and applies the full manifest set.
3. `promote-staging.yml` and `promote-production.yml` checkout the repo and run `deploy-app.sh` — `kubectl set image` is gone.
4. Production no longer uses `prod-latest`. Every production deploy specifies an exact `sha-*` tag.

## Why

- **Cluster state = last successful workflow run.** No drift between manifest and cluster.
- **No git commits from CI.** Manifest is a template; tag lives in the workflow input.
- **Single deploy path.** Manifest edits (resource limits, env vars, probes) flow through the same workflow as image bumps — no more "kubectl set image clobbers my manifest" footguns.
- **Disaster recovery = re-run workflow** with the desired sha.

Documented in `CI-CD.md`.

## Test plan

- [ ] Merge → no immediate effect (workflows only fire on manual dispatch)
- [ ] Run `promote-staging` with `sha-9b0daf9` → verify rollout succeeds with the new image
- [ ] Run `promote-production` with `sha-9b0daf9` → verify ECR copy, then rollout