### PR TITLE
Grant layer upload perms on production ECR for crane copy

### DIFF
--- a/infra/terraform/github-ci-oidc/main.tf
+++ b/infra/terraform/github-ci-oidc/main.tf
@@ -80,8 +80,12 @@ resource "aws_iam_policy" "github_actions_ecr" {
         Sid    = "ProductionPromote"
         Effect = "Allow"
         Action = [
+          "ecr:BatchCheckLayerAvailability",
           "ecr:BatchGetImage",
           "ecr:GetDownloadUrlForLayer",
+          "ecr:InitiateLayerUpload",
+          "ecr:UploadLayerPart",
+          "ecr:CompleteLayerUpload",
           "ecr:PutImage",
           "ecr:DescribeRepositories",
           "ecr:ListImages",


### PR DESCRIPTION
crane copy needs BatchCheckLayerAvailability + InitiateLayerUpload + UploadLayerPart + CompleteLayerUpload to push blobs; the previous ProductionPromote policy only had PutImage (manifest write). Already applied to live IAM policy via terraform apply.