### PR TITLE
Switch prod app nodes to t3.large, cap autoscaler at 4

### DIFF
--- a/infra/terraform/envs/production/terraform.tfvars
+++ b/infra/terraform/envs/production/terraform.tfvars
@@ -51,8 +51,8 @@ system_node_max_size       = 4
 system_node_desired_size   = 2
 system_node_disk_size      = 30
 
-app_node_instance_types = ["m7i.large"]
+app_node_instance_types = ["t3.large"]
 app_node_min_size       = 2
-app_node_max_size       = 8
+app_node_max_size       = 4
 app_node_desired_size   = 2
 app_node_disk_size      = 50


### PR DESCRIPTION
Save ~$30/mo on prod compute. t3.large has the same 2 vCPU / 8 GiB as m7i.large but uses burstable CPU credits, well suited for the puppeteer workload that bursts during scraping and idles between jobs. Already applied to live infra via `terraform apply` — both new nodes are healthy and all 4 app pods migrated cleanly.