### PR TITLE
Add sandbox environment

### DIFF
--- a/.github/workflows/build-base.yml
+++ b/.github/workflows/build-base.yml
@@ -14,7 +14,7 @@ permissions:
 env:
   AWS_REGION: us-east-1
   ECR_REGISTRY: 996810415034.dkr.ecr.us-east-1.amazonaws.com
-  ECR_REPOSITORY: ctdl-xtra-base
+  ECR_REPOSITORY: ctdl-xtra-sandbox/base
 
 jobs:
   build:

--- a/.github/workflows/build-base.yml
+++ b/.github/workflows/build-base.yml
@@ -1,8 +1,10 @@
 name: Build Base Image
 
-# DISABLED: pushes to ctdl-xtra-staging/base which was decommissioned.
-# Re-enable the push trigger and repoint to the new base ECR once SANDBOX is built.
 on:
+  push:
+    branches: [main]
+    paths:
+      - base.Dockerfile
   workflow_dispatch:
 
 permissions:
@@ -12,7 +14,7 @@ permissions:
 env:
   AWS_REGION: us-east-1
   ECR_REGISTRY: 996810415034.dkr.ecr.us-east-1.amazonaws.com
-  ECR_REPOSITORY: ctdl-xtra-staging/base
+  ECR_REPOSITORY: ctdl-xtra-base
 
 jobs:
   build:

--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -1,8 +1,5 @@
 name: Promote to PRODUCTION
 
-# Source ECR is currently broken: staging was decommissioned and the
-# replacement SANDBOX env is not yet built. Re-point the crane copy step
-# once SANDBOX ECR repos exist.
 on:
   workflow_dispatch:
     inputs:
@@ -35,13 +32,13 @@ jobs:
 
       - uses: imjasonh/setup-crane@v0.4
 
-      - name: Copy images STAGING → PRODUCTION ECR
+      - name: Copy images SANDBOX → PRODUCTION ECR
         env:
           IMAGE_TAG: ${{ inputs.image_tag }}
         run: |
           set -euo pipefail
           for SERVICE in api worker; do
-            SRC="${ECR_REGISTRY}/ctdl-xtra-staging/${SERVICE}:${IMAGE_TAG}"
+            SRC="${ECR_REGISTRY}/ctdl-xtra-sandbox/${SERVICE}:${IMAGE_TAG}"
             DST="${ECR_REGISTRY}/ctdl-xtra/${SERVICE}:${IMAGE_TAG}"
             echo "Copying ${SRC} → ${DST}"
             crane copy "${SRC}" "${DST}"

--- a/.github/workflows/promote-sandbox.yml
+++ b/.github/workflows/promote-sandbox.yml
@@ -1,0 +1,55 @@
+name: Promote to SANDBOX
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Image tag to deploy (e.g. sha-abc1234 or main-latest)"
+        required: true
+        default: main-latest
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: us-east-1
+
+jobs:
+  promote:
+    name: Promote ${{ inputs.image_tag }} → SANDBOX
+    runs-on: ubuntu-latest
+    environment: SANDBOX
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Configure kubeconfig
+        run: aws eks update-kubeconfig --name ctdl-xtra-sandbox --region "$AWS_REGION" --alias ctdl-xtra-sandbox
+
+      - name: Look up EFS file system id
+        id: efs
+        run: |
+          set -euo pipefail
+          FS_ID=$(aws efs describe-file-systems \
+            --query "FileSystems[?Tags[?Key=='Name' && Value=='ctdl-xtra-sandbox-files']].FileSystemId | [0]" \
+            --output text)
+          if [ -z "$FS_ID" ] || [ "$FS_ID" = "None" ]; then
+            echo "Could not resolve EFS file system id for ctdl-xtra-sandbox-files" >&2
+            exit 1
+          fi
+          echo "id=$FS_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag }}
+          EFS_FS_ID: ${{ steps.efs.outputs.id }}
+          KUBE_CONTEXT: ctdl-xtra-sandbox
+        run: bash infra/terraform/k8s-manifests/sandbox/app/deploy-app.sh
+
+      - name: Summary
+        run: echo "### Deployed \`${{ inputs.image_tag }}\` to SANDBOX" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: Release
 
-# DISABLED: staging environment was decommissioned. Re-enable the push
-# trigger and update ECR_REGISTRY targets once SANDBOX is built.
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -92,8 +92,8 @@ jobs:
           file: Dockerfile
           push: true
           tags: |
-            ${{ env.ECR_REGISTRY }}/ctdl-xtra-staging/api:${{ steps.tag.outputs.value }}
-            ${{ env.ECR_REGISTRY }}/ctdl-xtra-staging/api:main-latest
+            ${{ env.ECR_REGISTRY }}/ctdl-xtra-sandbox/api:${{ steps.tag.outputs.value }}
+            ${{ env.ECR_REGISTRY }}/ctdl-xtra-sandbox/api:main-latest
           cache-from: type=gha,scope=api
           cache-to: type=gha,mode=max,scope=api
 
@@ -104,10 +104,10 @@ jobs:
           file: worker.Dockerfile
           push: true
           tags: |
-            ${{ env.ECR_REGISTRY }}/ctdl-xtra-staging/worker:${{ steps.tag.outputs.value }}
-            ${{ env.ECR_REGISTRY }}/ctdl-xtra-staging/worker:main-latest
+            ${{ env.ECR_REGISTRY }}/ctdl-xtra-sandbox/worker:${{ steps.tag.outputs.value }}
+            ${{ env.ECR_REGISTRY }}/ctdl-xtra-sandbox/worker:main-latest
           cache-from: type=gha,scope=worker
           cache-to: type=gha,mode=max,scope=worker
 
       - name: Summary
-        run: echo "### Published \`${{ steps.tag.outputs.value }}\` to STAGING ECR" >> "$GITHUB_STEP_SUMMARY"
+        run: echo "### Published \`${{ steps.tag.outputs.value }}\` to SANDBOX ECR" >> "$GITHUB_STEP_SUMMARY"

--- a/CI-CD.md
+++ b/CI-CD.md
@@ -1,10 +1,6 @@
 # CI/CD Pipeline
 
-> **Status:** the `staging` environment was decommissioned. Until SANDBOX is built, the `Release`, `Build Base Image`, and `Promote to PRODUCTION` workflows are disabled (manual-only via `workflow_dispatch`, with no working ECR targets). The `CI` workflow on PRs still runs.
->
-> The design target (per the xTRA Design Document) is `TEST → SANDBOX → PRODUCTION`.
-
-## Branching Model (target)
+## Branching Model
 
 ```
 feature/* or fix/*
@@ -16,12 +12,11 @@ feature/* or fix/*
        │  Merge to main (automatic)
        ▼
   [Release workflow]
-  Build images → push to TEST ECR     (not yet wired)
+  Build images → push to SANDBOX ECR
        │
        │  Manual trigger
        ▼
   [Promote to SANDBOX]
-  Copy image TEST ECR → SANDBOX ECR (no rebuild)
   envsubst + kubectl apply → ctdl-xtra-sandbox cluster
        │
        │  Manual trigger (exact sha tag required)
@@ -31,7 +26,9 @@ feature/* or fix/*
   envsubst + kubectl apply → ctdl-xtra-prod cluster
 ```
 
-All development happens on short-lived branches off `main`. There is no long-lived staging or release branch — environment promotion is controlled through GitHub Actions workflows, not through git branches.
+All development happens on short-lived branches off `main`. There is no long-lived branch — environment promotion is controlled through GitHub Actions workflows, not through git branches.
+
+Per the xTRA Design Document, a TEST tier will be added between merge and SANDBOX. Until that exists, builds land directly in SANDBOX.
 
 ---
 
@@ -47,44 +44,75 @@ Runs on every PR. Blocks merge if any job fails.
 | Test | Vitest on the `server/` workspace |
 | Build images | Docker build for API and Worker (no push, uses GHA layer cache) |
 
-### Build Base Image (`build-base.yml`) — Disabled
+### Build Base Image (`build-base.yml`) — Push to `main` (path-filtered)
 
-Built the shared base image (system Chrome, fonts, pm2, pnpm, pre-downloaded Chrome binaries). Pushed to `ctdl-xtra-staging/base:latest`, which no longer exists. The base will move to an env-neutral ECR repo when SANDBOX is built.
+Triggers only when `base.Dockerfile` changes. Builds the shared base image (system Chrome, fonts, pm2, pnpm, pre-downloaded Chrome binaries) and pushes to `ctdl-xtra-base:latest`. Both `Dockerfile` and `worker.Dockerfile` `FROM` this base, so app builds skip the heavy apt + Chrome install.
 
-### Release (`release.yml`) — Disabled
+The base image repo lives in an env-neutral ECR namespace (not under any environment prefix) so the same base is reused across SANDBOX, TEST, and PRODUCTION.
 
-Will resume building `sha-<7char>` images on every merge to `main` and pushing them to SANDBOX (or TEST, when that tier exists). Currently `workflow_dispatch` only.
+### Release (`release.yml`) — Push to `main`
 
-### Promote to PRODUCTION (`promote-production.yml`) — Disabled in practice
+Runs automatically on every merge to `main`. Lint and Test run in parallel (non-blocking via `continue-on-error`); `publish` runs independently.
 
-Manual only; copies an image from the pre-prod ECR to `ctdl-xtra/{api,worker}` using `crane copy` and deploys via `deploy-app.sh`. The source repo will be repointed to `ctdl-xtra-sandbox/*` once SANDBOX is built.
+Produces two image tags per service and pushes to SANDBOX ECR:
+
+| Tag | Purpose |
+|-----|---------|
+| `sha-<7char>` | Immutable reference to this exact commit, used for promotion |
+| `main-latest` | Floating tag, always points to the latest main build |
+
+ECR repositories written to:
+- `ctdl-xtra-sandbox/api`
+- `ctdl-xtra-sandbox/worker`
+
+### Promote to SANDBOX (`promote-sandbox.yml`) — Manual
+
+Go to **Actions → Promote to SANDBOX → Run workflow**.
+
+Input: `image_tag` (default: `main-latest`). Use a `sha-*` tag to deploy a specific commit.
+
+Looks up the sandbox EFS file system id, then runs `deploy-app.sh` with `IMAGE_TAG` and `EFS_FS_ID` set. `envsubst`s both into the manifests and `kubectl apply`s the full set on `ctdl-xtra-sandbox`.
+
+### Promote to PRODUCTION (`promote-production.yml`) — Manual
+
+Go to **Actions → Promote to PRODUCTION → Run workflow**.
+
+Input: `image_tag` (**required**, must be an exact `sha-*` tag).
+
+Steps:
+1. `crane copy` the image manifest+layers from SANDBOX ECR to PRODUCTION ECR under the same `sha-*` tag (no Docker pull/push, same digest guaranteed).
+2. Runs `deploy-app.sh` against `ctdl-xtra-prod` — envsubst + apply.
+
+ECR repositories written to:
+- `ctdl-xtra/api`
+- `ctdl-xtra/worker`
 
 ---
 
 ## Deployment Model
 
-Manifests in `infra/terraform/k8s-manifests/production/app/` are **templates**, not state snapshots. The image reference is left as a placeholder:
+Manifests in `infra/terraform/k8s-manifests/{sandbox,production}/app/` are **templates**, not state snapshots. The image reference is left as a placeholder:
 
 ```yaml
 image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra/api:${IMAGE_TAG}
 ```
 
-At deploy time, `deploy-app.sh` substitutes `${IMAGE_TAG}` with the requested tag and applies the manifest. Consequences:
+At deploy time, `deploy-app.sh` substitutes `${IMAGE_TAG}` with the requested tag and applies the manifest. Sandbox additionally templates `${EFS_FS_ID}` in `storage.yaml`. Consequences:
 
 - **Cluster state = last successful workflow run.** Workflow run history is deployment history.
 - **No `kubectl set image`.** Apply is the only deployment mechanism, so manifest edits (resource limits, env vars, probes) flow through the same path as image changes.
 - **No git commits from CI.** The manifest stays a template; the tag lives in the workflow input.
 - **Disaster recovery is trivial.** Re-run the workflow with the desired sha.
-- **You cannot `kubectl apply -f` the manifest directly** — it must go through `envsubst` (or via `bash deploy-app.sh` with `IMAGE_TAG` set).
+- **You cannot `kubectl apply -f` the manifest directly** — it must go through `envsubst` (or via `bash deploy-app.sh` with required env vars set).
 
 ---
 
 ## Key Principles
 
-- **Build once.** Images are built only on merge to `main`. Promotion copies via the AWS ECR API (`crane copy`); the image is never rebuilt and the digest never changes.
-- **Immutable tags.** `sha-*` tags are never overwritten.
+- **Build once.** Images are built only on merge to `main`. Promotion to production copies via `crane`; the image is never rebuilt and the digest never changes.
+- **Immutable tags.** `sha-*` tags are never overwritten. Only `main-latest` floats (sandbox only).
 - **Specific sha in production.** Production deploys always specify an exact `sha-*` tag.
-- **Manual gates.** Both pre-prod and production deploys require a human to trigger them in GitHub Actions.
+- **Manual gates.** Both sandbox and production deploys require a human to trigger them in GitHub Actions.
 - **OIDC auth.** GitHub Actions assumes the `ctdl-xtra-github-actions-ci` IAM role via OIDC (no stored AWS credentials). The role ARN is stored as the `AWS_ROLE_ARN` repository secret.
 
 ---
@@ -93,6 +121,7 @@ At deploy time, `deploy-app.sh` substitutes `${IMAGE_TAG}` with the requested ta
 
 | Environment | EKS Cluster | ECR prefix | Domain |
 |-------------|-------------|------------|--------|
+| Sandbox | `ctdl-xtra-sandbox` | `ctdl-xtra-sandbox/*` | `xtra-sandbox.credentialengineregistry.org` |
 | Production | `ctdl-xtra-prod` | `ctdl-xtra/*` | `xtra.credentialengineregistry.org` |
 
-Terraform for the IAM role and OIDC provider lives in [`infra/terraform/github-ci-oidc/`](infra/terraform/github-ci-oidc/).
+Terraform for the IAM role, OIDC provider, and shared `ctdl-xtra-base` ECR lives in [`infra/terraform/github-ci-oidc/`](infra/terraform/github-ci-oidc/).

--- a/CI-CD.md
+++ b/CI-CD.md
@@ -46,9 +46,9 @@ Runs on every PR. Blocks merge if any job fails.
 
 ### Build Base Image (`build-base.yml`) — Push to `main` (path-filtered)
 
-Triggers only when `base.Dockerfile` changes. Builds the shared base image (system Chrome, fonts, pm2, pnpm, pre-downloaded Chrome binaries) and pushes to `ctdl-xtra-base:latest`. Both `Dockerfile` and `worker.Dockerfile` `FROM` this base, so app builds skip the heavy apt + Chrome install.
+Triggers only when `base.Dockerfile` changes. Builds the shared base image (system Chrome, fonts, pm2, pnpm, pre-downloaded Chrome binaries) and pushes to `ctdl-xtra-sandbox/base:latest`. Both `Dockerfile` and `worker.Dockerfile` `FROM` this base, so app builds skip the heavy apt + Chrome install.
 
-The base image repo lives in an env-neutral ECR namespace (not under any environment prefix) so the same base is reused across SANDBOX, TEST, and PRODUCTION.
+The base image lives in the build-target env's own ECR namespace (currently sandbox). Production never pulls from it — base layers are baked into the api/worker image manifests at `docker build` time, so the promoted images are self-contained.
 
 ### Release (`release.yml`) — Push to `main`
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra-staging/base:latest
+ARG BASE_IMAGE=996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra-base:latest
 FROM ${BASE_IMAGE}
 
 ENV VITE_API_URL="$VITE_API_URL"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra-base:latest
+ARG BASE_IMAGE=996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra-sandbox/base:latest
 FROM ${BASE_IMAGE}
 
 ENV VITE_API_URL="$VITE_API_URL"

--- a/INFRASTRUCTURE-SUMMARY.md
+++ b/INFRASTRUCTURE-SUMMARY.md
@@ -2,38 +2,39 @@
 
 Quick reference for app developers — endpoints, names, and how to find/change things in each environment.
 
-> **Current state:** the only live environment is `PRODUCTION`. The previous `staging` env was decommissioned and will be replaced by a `SANDBOX` env (per the xTRA Design Document). Until SANDBOX is built, the release / promote workflows are disabled.
+> Per the xTRA Design Document, the target environment chain is `TEST → SANDBOX → PRODUCTION`. TEST is not yet built; until then, builds land directly in SANDBOX.
 
 ## Environments
 
-| | Production |
-|---|---|
-| **App URL** | `https://xtra.credentialengineregistry.org` |
-| **EKS cluster** | `ctdl-xtra-prod` |
-| **K8s namespace** | `ctdl-xtra` |
-| **AWS region** | `us-east-1` |
-| **AWS account** | `996810415034` |
+| | Sandbox | Production |
+|---|---|---|
+| **App URL** | `https://xtra-sandbox.credentialengineregistry.org` | `https://xtra.credentialengineregistry.org` |
+| **EKS cluster** | `ctdl-xtra-sandbox` | `ctdl-xtra-prod` |
+| **K8s namespace** | `ctdl-xtra` | `ctdl-xtra` |
+| **AWS region** | `us-east-1` | `us-east-1` |
+| **AWS account** | `996810415034` | `996810415034` |
 
 ## Container images (ECR)
 
-| | Production |
-|---|---|
-| API repo | `ctdl-xtra/api` |
-| Worker repo | `ctdl-xtra/worker` |
-| Base image | TBD — was `ctdl-xtra-staging/base`; will move to a env-neutral repo when SANDBOX is built |
-| Image tag pattern | `sha-<7char>` only |
+| | Sandbox | Production |
+|---|---|---|
+| API repo | `ctdl-xtra-sandbox/api` | `ctdl-xtra/api` |
+| Worker repo | `ctdl-xtra-sandbox/worker` | `ctdl-xtra/worker` |
+| Base image | `ctdl-xtra-base` (env-neutral, shared by API and Worker Dockerfiles) | same |
+| Image tag pattern | `sha-<7char>`, `main-latest` (floats) | `sha-<7char>` only |
 
-All images are at `996810415034.dkr.ecr.us-east-1.amazonaws.com/<repo>:<tag>`.
+All images are at `996810415034.dkr.ecr.us-east-1.amazonaws.com/<repo>:<tag>`. Promotion never rebuilds — the production image is the byte-for-byte same image as sandbox.
 
 ## Database (RDS PostgreSQL)
 
-| | Production |
-|---|---|
-| Endpoint | `ctdl-xtra-prod-postgres.cwdkv5tua6nq.us-east-1.rds.amazonaws.com:5432` |
-| DB name | `ctdl_xtra` |
-| Engine | PostgreSQL 17.5 |
-| HA | Multi-AZ |
-| Reachable from | inside cluster only (private subnets) |
+| | Sandbox | Production |
+|---|---|---|
+| Endpoint | TBD after first apply (see `terraform output rds_endpoint` in `envs/sandbox`) | `ctdl-xtra-prod-postgres.cwdkv5tua6nq.us-east-1.rds.amazonaws.com:5432` |
+| Instance class | `db.t4g.small` | `db.t4g.small` |
+| DB name | `ctdl_xtra` | `ctdl_xtra` |
+| Engine | PostgreSQL 17.5 | PostgreSQL 17.5 |
+| HA | Single-AZ | Multi-AZ |
+| Reachable from | inside cluster only (private subnets) | inside cluster only (private subnets) |
 
 `DATABASE_URL` (full connection string with credentials) is injected as an env var via the app secret — never hardcoded.
 
@@ -58,10 +59,10 @@ Runs **inside the cluster** as a StatefulSet (not AWS ElastiCache).
 
 Stored in **AWS Secrets Manager**, synced into the cluster by the External Secrets operator. Pods read them as plain env vars (`envFrom: secretRef`).
 
-| Purpose | Secret name (prod) |
-|---|---|
-| App env vars | `ctdl-xtra/prod/app` |
-| Redis password | `ctdl-xtra/prod/redis` |
+| Purpose | Secret name (sandbox) | Secret name (prod) |
+|---|---|---|
+| App env vars | `ctdl-xtra/sandbox/app` | `ctdl-xtra/prod/app` |
+| Redis password | `ctdl-xtra/sandbox/redis` | `ctdl-xtra/prod/redis` |
 
 To **add or change an app env var**, edit the app secret in Secrets Manager. Within ~5 min the External Secrets operator syncs it into the K8s `ctdl-xtra-app-env` Secret. Pods need a restart to see the change (`kubectl -n ctdl-xtra rollout restart deployment/ctdl-xtra-api deployment/ctdl-xtra-worker`).
 
@@ -78,20 +79,21 @@ Current keys in the app secret:
 
 ## Deployments
 
-In the `ctdl-xtra-prod` cluster's `ctdl-xtra` namespace:
+In each cluster's `ctdl-xtra` namespace:
 
-| Workload | Type | Prod replicas |
-|---|---|---|
-| `ctdl-xtra-api` | Deployment | 2 |
-| `ctdl-xtra-worker` | Deployment | 2 |
-| `redis` | StatefulSet | 1 |
-| `ctdl-xtra-db-migrate` | Job (one-shot per deploy) | — |
+| Workload | Type | Sandbox replicas | Prod replicas |
+|---|---|---|---|
+| `ctdl-xtra-api` | Deployment | 1 | 2 |
+| `ctdl-xtra-worker` | Deployment | 1 | 2 |
+| `redis` | StatefulSet | 1 | 1 |
+| `ctdl-xtra-db-migrate` | Job (one-shot per deploy) | — | — |
 
 The migrate Job runs `drizzle-kit migrate` before each rollout via the deploy script.
 
-
 ## Deploying
 
-> Currently paused. Release and promote workflows are disabled until SANDBOX is built. See [CI-CD.md](CI-CD.md) for context.
+You don't run `kubectl` to deploy — use the GitHub Actions workflows. See [CI-CD.md](CI-CD.md) for the full pipeline. TL;DR:
 
-The intended flow (per the xTRA Design Document) is `TEST → SANDBOX → PRODUCTION`. Builds happen on merge to `main`, all promotions are manual, and images are never rebuilt between tiers.
+- Merge to `main` → image auto-built and pushed to sandbox ECR
+- Run **Promote to SANDBOX** workflow → image deployed to sandbox cluster
+- Run **Promote to PRODUCTION** workflow with the same `sha-*` tag → same image copied to prod ECR and deployed

--- a/INFRASTRUCTURE-SUMMARY.md
+++ b/INFRASTRUCTURE-SUMMARY.md
@@ -20,7 +20,7 @@ Quick reference for app developers — endpoints, names, and how to find/change 
 |---|---|---|
 | API repo | `ctdl-xtra-sandbox/api` | `ctdl-xtra/api` |
 | Worker repo | `ctdl-xtra-sandbox/worker` | `ctdl-xtra/worker` |
-| Base image | `ctdl-xtra-base` (env-neutral, shared by API and Worker Dockerfiles) | same |
+| Base image | `ctdl-xtra-sandbox/base` (owned by sandbox; built once, consumed by Dockerfiles at build time) | N/A — base layers are embedded in the promoted api/worker images |
 | Image tag pattern | `sha-<7char>`, `main-latest` (floats) | `sha-<7char>` only |
 
 All images are at `996810415034.dkr.ecr.us-east-1.amazonaws.com/<repo>:<tag>`. Promotion never rebuilds — the production image is the byte-for-byte same image as sandbox.

--- a/infra/terraform/envs/sandbox/.terraform.lock.hcl
+++ b/infra/terraform/envs/sandbox/.terraform.lock.hcl
@@ -1,0 +1,46 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.50.0"
+  constraints = "~> 5.50.0"
+  hashes = [
+    "h1:LevuTzPS4S7t+Vh6Kpz77pBNDAwChaos91/6+CVnD4w=",
+    "zh:19be42f5a545d6712dee4bdb704b018d23bacf5d902ac3cb061eb1750dfe6a20",
+    "zh:1d880bdba95ce96efde37e5bcf457a57df2c1effa9b47bc67fa29c1a264ae53b",
+    "zh:1e9c78e324d7492be5e7744436ed71d66fe4eca3fb6af07a28efd0d1e3bf7640",
+    "zh:27ac672aa61b3795931561fdbe4a306ad1132af517d7711c14569429b2cc694f",
+    "zh:3b978423dead02f9a98d25de118adf264a2331acdc4550ea93bed01feabc12e7",
+    "zh:490d7eb4b922ba1b57e0ab8dec1a08df6517485febcab1e091fd6011281c3472",
+    "zh:64e7c84e18dac1af5778d6f516e01a46f9c91d710867c39fbc7efa3cd972dc62",
+    "zh:73867ac2956dcdd377121b3aa8fe2e1085e77fae9b61d018f56a863277ea4b6e",
+    "zh:7ed899d0d5c49f009b445d7816e4bf702d9c48205c24cf884cd2ae0247160455",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9b93784b3fb13d08cf95a4131c49b56bf7e1cd35daad6156b3658a89ce6fb58f",
+    "zh:b29d77eb75de474e46eb47e539c48916628d85599bcf14e5cc500b14a4578e75",
+    "zh:bbd9cec8ca705452e4a3d21d56474eacb8cc7b1b74b7f310fdea4bdcffebab32",
+    "zh:c352eb3169efa0e27a29b99a2630e8298710a084453c519caa39e5972ff6d1fc",
+    "zh:e32f4744b43be1708b309a734e0ac10b5c0f9f92e5849298cf1a90f2b906f6f3",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.6"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/infra/terraform/envs/sandbox/app-deps.tf
+++ b/infra/terraform/envs/sandbox/app-deps.tf
@@ -1,0 +1,280 @@
+locals {
+  app_secret_values = {
+    DATABASE_URL          = "postgresql://${var.db_username}:${random_password.db_password.result}@${aws_db_instance.app.address}:${aws_db_instance.app.port}/${var.db_name}?sslmode=require"
+    REDIS_URL             = "redis://:${random_password.redis_password.result}@redis.${var.app_namespace}.svc.cluster.local:6379"
+    ENCRYPTION_KEY        = random_password.encryption_key.result
+    COOKIE_KEY            = random_id.cookie_key.hex
+    EXTRACTION_FILES_PATH = "/data/extractions"
+    CLIENT_PATH           = "/app/public"
+    FRONTEND_URL          = "https://${var.app_domain_name}"
+    NODE_ENV              = "sandbox"
+    PORT                  = "3000"
+  }
+}
+
+# ---------------------------------------------------------------
+# Container Images
+# ---------------------------------------------------------------
+
+resource "aws_ecr_repository" "app" {
+  for_each = toset(["api", "worker"])
+
+  name                 = "${local.cluster_name}/${each.key}"
+  image_tag_mutability = "MUTABLE"
+  force_delete         = true
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${local.cluster_name}-${each.key}"
+  })
+}
+
+resource "aws_ecr_lifecycle_policy" "app" {
+  for_each = aws_ecr_repository.app
+
+  repository = each.value.name
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Keep the last 50 sandbox images"
+        selection = {
+          tagStatus     = "tagged"
+          tagPrefixList = ["sha-", "main-latest"]
+          countType     = "imageCountMoreThan"
+          countNumber   = 50
+        }
+        action = {
+          type = "expire"
+        }
+      },
+      {
+        rulePriority = 2
+        description  = "Expire untagged images after 7 days"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 7
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}
+
+# ---------------------------------------------------------------
+# Database
+# ---------------------------------------------------------------
+
+resource "random_password" "db_password" {
+  length  = 32
+  special = false
+}
+
+resource "aws_db_subnet_group" "app" {
+  name       = "${local.cluster_name}-db"
+  subnet_ids = module.vpc.private_subnet_ids
+
+  tags = merge(local.common_tags, {
+    Name = "${local.cluster_name}-db"
+  })
+}
+
+resource "aws_security_group" "rds" {
+  name        = "${local.cluster_name}-rds"
+  description = "Allow PostgreSQL access from the ${local.cluster_name} VPC"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    description = "PostgreSQL from private workloads"
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = [module.vpc.vpc_cidr_block]
+  }
+
+  egress {
+    description = "All outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${local.cluster_name}-rds"
+  })
+}
+
+resource "aws_db_parameter_group" "app" {
+  name   = "${local.cluster_name}-postgres${replace(var.db_engine_version, ".", "")}"
+  family = "postgres${split(".", var.db_engine_version)[0]}"
+
+  parameter {
+    name         = "rds.force_ssl"
+    value        = "1"
+    apply_method = "pending-reboot"
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${local.cluster_name}-postgres"
+  })
+}
+
+resource "aws_db_instance" "app" {
+  identifier = "${local.cluster_name}-postgres"
+
+  engine         = "postgres"
+  engine_version = var.db_engine_version
+  instance_class = var.db_instance_class
+
+  allocated_storage     = var.db_allocated_storage
+  max_allocated_storage = var.db_max_allocated_storage
+  storage_type          = "gp3"
+  storage_encrypted     = true
+
+  db_name  = var.db_name
+  username = var.db_username
+  password = random_password.db_password.result
+
+  db_subnet_group_name   = aws_db_subnet_group.app.name
+  vpc_security_group_ids = [aws_security_group.rds.id]
+  parameter_group_name   = aws_db_parameter_group.app.name
+  publicly_accessible    = false
+  multi_az               = var.db_multi_az
+
+  backup_retention_period = var.db_backup_retention_days
+  backup_window           = "07:00-08:00"
+  maintenance_window      = "sun:08:00-sun:09:00"
+  copy_tags_to_snapshot   = true
+
+  auto_minor_version_upgrade   = true
+  deletion_protection          = false
+  performance_insights_enabled = false
+  skip_final_snapshot          = true
+
+  tags = merge(local.common_tags, {
+    Name = "${local.cluster_name}-postgres"
+  })
+}
+
+# ---------------------------------------------------------------
+# Redis
+# ---------------------------------------------------------------
+
+resource "random_password" "redis_password" {
+  length  = 32
+  special = false
+}
+
+resource "aws_secretsmanager_secret" "redis" {
+  name                    = "ctdl-xtra/sandbox/redis"
+  description             = "Redis auth for ${local.cluster_name} in-cluster pod"
+  recovery_window_in_days = 0
+
+  tags = merge(local.common_tags, {
+    Name = "ctdl-xtra/sandbox/redis"
+  })
+}
+
+resource "aws_secretsmanager_secret_version" "redis" {
+  secret_id     = aws_secretsmanager_secret.redis.id
+  secret_string = jsonencode({ password = random_password.redis_password.result })
+}
+
+# ---------------------------------------------------------------
+# Shared Extraction Files
+# ---------------------------------------------------------------
+
+resource "aws_security_group" "efs" {
+  name        = "${local.cluster_name}-efs"
+  description = "Allow NFS access from the ${local.cluster_name} VPC"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    description = "NFS from private workloads"
+    from_port   = 2049
+    to_port     = 2049
+    protocol    = "tcp"
+    cidr_blocks = [module.vpc.vpc_cidr_block]
+  }
+
+  egress {
+    description = "All outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${local.cluster_name}-efs"
+  })
+}
+
+resource "aws_efs_file_system" "app" {
+  creation_token = "${local.cluster_name}-files"
+  encrypted      = true
+
+  lifecycle_policy {
+    transition_to_ia = "AFTER_30_DAYS"
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${local.cluster_name}-files"
+  })
+}
+
+resource "aws_efs_backup_policy" "app" {
+  file_system_id = aws_efs_file_system.app.id
+
+  backup_policy {
+    status = "ENABLED"
+  }
+}
+
+resource "aws_efs_mount_target" "app" {
+  for_each = zipmap(var.private_subnet_cidrs, module.vpc.private_subnet_ids)
+
+  file_system_id  = aws_efs_file_system.app.id
+  subnet_id       = each.value
+  security_groups = [aws_security_group.efs.id]
+}
+
+# ---------------------------------------------------------------
+# Runtime Secret
+# ---------------------------------------------------------------
+
+resource "random_password" "encryption_key" {
+  length  = 32
+  special = false
+}
+
+resource "random_id" "cookie_key" {
+  byte_length = 32
+}
+
+resource "aws_secretsmanager_secret" "app" {
+  name                    = var.app_secret_name
+  description             = "Runtime configuration for ${local.cluster_name}"
+  recovery_window_in_days = 0
+
+  tags = merge(local.common_tags, {
+    Name = var.app_secret_name
+  })
+}
+
+resource "aws_secretsmanager_secret_version" "app" {
+  secret_id     = aws_secretsmanager_secret.app.id
+  secret_string = jsonencode(local.app_secret_values)
+}

--- a/infra/terraform/envs/sandbox/app-deps.tf
+++ b/infra/terraform/envs/sandbox/app-deps.tf
@@ -17,7 +17,7 @@ locals {
 # ---------------------------------------------------------------
 
 resource "aws_ecr_repository" "app" {
-  for_each = toset(["api", "worker"])
+  for_each = toset(["api", "worker", "base"])
 
   name                 = "${local.cluster_name}/${each.key}"
   image_tag_mutability = "MUTABLE"

--- a/infra/terraform/envs/sandbox/backend.tf
+++ b/infra/terraform/envs/sandbox/backend.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.50.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+
+  backend "s3" {
+    bucket  = "terraform-state-o1r8"
+    key     = "ctdl-xtra/envs/sandbox/tfstate"
+    region  = "us-east-1"
+    encrypt = true
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+
+  default_tags {
+    tags = local.common_tags
+  }
+}

--- a/infra/terraform/envs/sandbox/main.tf
+++ b/infra/terraform/envs/sandbox/main.tf
@@ -1,0 +1,70 @@
+locals {
+  project_name = "ctdl-xtra"
+  env          = "sandbox"
+  cluster_name = "${local.project_name}-${local.env}"
+
+  common_tags = {
+    project     = local.project_name
+    environment = local.env
+    managed-by  = "terraform"
+  }
+}
+
+# ---------------------------------------------------------------
+# Networking
+# ---------------------------------------------------------------
+
+module "vpc" {
+  source = "../../modules/vpc"
+
+  name                   = local.cluster_name
+  vpc_cidr               = var.vpc_cidr
+  public_subnet_cidrs    = var.public_subnet_cidrs
+  private_subnet_cidrs   = var.private_subnet_cidrs
+  azs                    = var.azs
+  single_nat_gateway     = var.single_nat_gateway
+  nat_eip_allocation_ids = var.nat_eip_allocation_ids
+  enable_flow_logs       = var.enable_vpc_flow_logs
+  common_tags            = local.common_tags
+
+  public_subnet_tags = {
+    "kubernetes.io/cluster/${local.cluster_name}" = "shared"
+    "kubernetes.io/role/elb"                      = "1"
+  }
+
+  private_subnet_tags = {
+    "kubernetes.io/cluster/${local.cluster_name}" = "shared"
+    "kubernetes.io/role/internal-elb"             = "1"
+  }
+}
+
+# ---------------------------------------------------------------
+# EKS
+# ---------------------------------------------------------------
+
+module "eks" {
+  source = "../../modules/eks"
+
+  cluster_name                                = local.cluster_name
+  cluster_version                             = var.cluster_version
+  cluster_service_ipv4_cidr                   = var.cluster_service_ipv4_cidr
+  cluster_endpoint_private_access             = var.cluster_endpoint_private_access
+  cluster_endpoint_public_access              = var.cluster_endpoint_public_access
+  cluster_endpoint_public_access_cidrs        = var.cluster_endpoint_public_access_cidrs
+  authentication_mode                         = var.authentication_mode
+  bootstrap_cluster_creator_admin_permissions = var.bootstrap_cluster_creator_admin_permissions
+  cluster_admin_principal_arns                = var.cluster_admin_principal_arns
+  enable_cluster_secret_encryption            = var.enable_cluster_secret_encryption
+  private_subnet_ids                          = module.vpc.private_subnet_ids
+  route53_hosted_zone_id                      = var.route53_hosted_zone_id
+  app_namespace                               = var.app_namespace
+  additional_app_namespaces                   = var.additional_app_namespaces
+  app_service_account                         = var.app_service_account
+  application_irsa_role_name                  = "${local.cluster_name}-application-irsa-role"
+  application_irsa_policy_name                = "${local.cluster_name}-application-s3-policy"
+  application_s3_bucket_names                 = var.application_s3_bucket_names
+  external_secrets_secret_name_prefixes       = var.external_secrets_secret_name_prefixes
+  external_secrets_ssm_parameter_prefixes     = var.external_secrets_ssm_parameter_prefixes
+  enable_efs_csi_driver                       = var.enable_efs_csi_driver
+  common_tags                                 = local.common_tags
+}

--- a/infra/terraform/envs/sandbox/node-groups.tf
+++ b/infra/terraform/envs/sandbox/node-groups.tf
@@ -1,0 +1,80 @@
+resource "aws_eks_node_group" "system" {
+  cluster_name    = module.eks.cluster_id
+  node_group_name = "${local.cluster_name}-system"
+  node_role_arn   = module.eks.nodegroup_role_arn
+  subnet_ids      = module.vpc.private_subnet_ids
+
+  ami_type       = "AL2023_x86_64_STANDARD"
+  capacity_type  = "ON_DEMAND"
+  disk_size      = var.system_node_disk_size
+  instance_types = var.system_node_instance_types
+
+  labels = {
+    env      = local.env
+    nodepool = "system"
+  }
+
+  scaling_config {
+    desired_size = var.system_node_desired_size
+    max_size     = var.system_node_max_size
+    min_size     = var.system_node_min_size
+  }
+
+  update_config {
+    max_unavailable = 1
+  }
+
+  lifecycle {
+    ignore_changes = [
+      scaling_config[0].desired_size
+    ]
+  }
+
+  tags = merge(local.common_tags, {
+    "k8s.io/cluster-autoscaler/${local.cluster_name}" = "owned"
+    "k8s.io/cluster-autoscaler/enabled"               = "true"
+  })
+
+  depends_on = [module.vpc]
+}
+
+resource "aws_eks_node_group" "app" {
+  cluster_name    = module.eks.cluster_id
+  node_group_name = "${local.cluster_name}-app"
+  node_role_arn   = module.eks.nodegroup_role_arn
+  subnet_ids      = module.vpc.private_subnet_ids
+
+  ami_type       = "AL2023_x86_64_STANDARD"
+  capacity_type  = "ON_DEMAND"
+  disk_size      = var.app_node_disk_size
+  instance_types = var.app_node_instance_types
+
+  labels = {
+    env      = local.env
+    nodepool = "app"
+    workload = local.project_name
+  }
+
+  scaling_config {
+    desired_size = var.app_node_desired_size
+    max_size     = var.app_node_max_size
+    min_size     = var.app_node_min_size
+  }
+
+  update_config {
+    max_unavailable = 1
+  }
+
+  lifecycle {
+    ignore_changes = [
+      scaling_config[0].desired_size
+    ]
+  }
+
+  tags = merge(local.common_tags, {
+    "k8s.io/cluster-autoscaler/${local.cluster_name}" = "owned"
+    "k8s.io/cluster-autoscaler/enabled"               = "true"
+  })
+
+  depends_on = [module.vpc]
+}

--- a/infra/terraform/envs/sandbox/outputs.tf
+++ b/infra/terraform/envs/sandbox/outputs.tf
@@ -1,0 +1,99 @@
+output "cluster_name" {
+  description = "Sandbox EKS cluster name."
+  value       = module.eks.cluster_id
+}
+
+output "cluster_endpoint" {
+  description = "Sandbox EKS API endpoint."
+  value       = module.eks.cluster_endpoint
+}
+
+output "cluster_oidc_issuer_url" {
+  description = "Sandbox EKS OIDC issuer URL."
+  value       = module.eks.cluster_oidc_issuer_url
+}
+
+output "vpc_id" {
+  description = "Sandbox VPC ID."
+  value       = module.vpc.vpc_id
+}
+
+output "vpc_cidr_block" {
+  description = "Sandbox VPC CIDR block."
+  value       = module.vpc.vpc_cidr_block
+}
+
+output "private_subnet_ids" {
+  description = "Sandbox private subnet IDs."
+  value       = module.vpc.private_subnet_ids
+}
+
+output "public_subnet_ids" {
+  description = "Sandbox public subnet IDs."
+  value       = module.vpc.public_subnet_ids
+}
+
+output "system_node_group_name" {
+  description = "System managed node group name."
+  value       = aws_eks_node_group.system.node_group_name
+}
+
+output "app_node_group_name" {
+  description = "Application managed node group name."
+  value       = aws_eks_node_group.app.node_group_name
+}
+
+output "application_irsa_role_arn" {
+  description = "Application IRSA role ARN."
+  value       = module.eks.application_irsa_role_arn
+}
+
+output "cert_manager_irsa_role_arn" {
+  description = "cert-manager IRSA role ARN."
+  value       = module.eks.cert_manager_irsa_role_arn
+}
+
+output "external_secrets_irsa_role_arn" {
+  description = "External Secrets Operator IRSA role ARN."
+  value       = module.eks.external_secrets_irsa_role_arn
+}
+
+output "cluster_autoscaler_irsa_role_arn" {
+  description = "Cluster Autoscaler IRSA role ARN."
+  value       = module.eks.cluster_autoscaler_irsa_role_arn
+}
+
+output "ebs_csi_irsa_role_arn" {
+  description = "EBS CSI driver IRSA role ARN."
+  value       = module.eks.ebs_csi_irsa_role_arn
+}
+
+output "efs_csi_role_arn" {
+  description = "EFS CSI driver Pod Identity role ARN."
+  value       = module.eks.efs_csi_role_arn
+}
+
+output "api_ecr_repository_url" {
+  description = "API image ECR repository URL."
+  value       = aws_ecr_repository.app["api"].repository_url
+}
+
+output "worker_ecr_repository_url" {
+  description = "Worker image ECR repository URL."
+  value       = aws_ecr_repository.app["worker"].repository_url
+}
+
+output "app_secret_name" {
+  description = "Secrets Manager secret consumed by the xTRA app."
+  value       = aws_secretsmanager_secret.app.name
+}
+
+output "rds_endpoint" {
+  description = "PostgreSQL endpoint."
+  value       = aws_db_instance.app.endpoint
+}
+
+output "efs_file_system_id" {
+  description = "EFS file system ID for extraction files."
+  value       = aws_efs_file_system.app.id
+}

--- a/infra/terraform/envs/sandbox/terraform.tfvars
+++ b/infra/terraform/envs/sandbox/terraform.tfvars
@@ -1,0 +1,57 @@
+vpc_cidr             = "10.41.0.0/16"
+public_subnet_cidrs  = ["10.41.1.0/24", "10.41.2.0/24"]
+private_subnet_cidrs = ["10.41.11.0/24", "10.41.12.0/24"]
+azs                  = ["us-east-1a", "us-east-1b"]
+
+single_nat_gateway   = true
+enable_vpc_flow_logs = true
+
+cluster_version = "1.35"
+
+cluster_endpoint_private_access      = true
+cluster_endpoint_public_access       = true
+cluster_endpoint_public_access_cidrs = ["0.0.0.0/0"]
+
+authentication_mode                         = "API_AND_CONFIG_MAP"
+bootstrap_cluster_creator_admin_permissions = true
+cluster_admin_principal_arns                = ["arn:aws:iam::996810415034:role/ctdl-xtra-github-actions-ci"]
+
+route53_hosted_zone_id           = "Z1N75467P1FUL5"
+enable_cluster_secret_encryption = true
+enable_efs_csi_driver            = true
+
+app_namespace       = "ctdl-xtra"
+app_service_account = "ctdl-xtra"
+
+external_secrets_secret_name_prefixes = [
+  "ctdl-xtra/sandbox",
+  "ctdl-xtra-sandbox"
+]
+
+external_secrets_ssm_parameter_prefixes = [
+  "ctdl-xtra/sandbox"
+]
+
+app_domain_name = "xtra-sandbox.credentialengineregistry.org"
+app_secret_name = "ctdl-xtra/sandbox/app"
+
+db_name                  = "ctdl_xtra"
+db_username              = "ctdlxtra"
+db_engine_version        = "17.5"
+db_instance_class        = "db.t4g.small"
+db_allocated_storage     = 20
+db_max_allocated_storage = 100
+db_multi_az              = false
+db_backup_retention_days = 7
+
+system_node_instance_types = ["t3.medium"]
+system_node_min_size       = 1
+system_node_max_size       = 2
+system_node_desired_size   = 1
+system_node_disk_size      = 30
+
+app_node_instance_types = ["t3.medium"]
+app_node_min_size       = 1
+app_node_max_size       = 2
+app_node_desired_size   = 1
+app_node_disk_size      = 50

--- a/infra/terraform/envs/sandbox/variables.tf
+++ b/infra/terraform/envs/sandbox/variables.tf
@@ -1,0 +1,276 @@
+# ---------------------------------------------------------------------------
+# Networking
+# ---------------------------------------------------------------------------
+
+variable "vpc_cidr" {
+  description = "Sandbox VPC CIDR block."
+  type        = string
+}
+
+variable "public_subnet_cidrs" {
+  description = "Sandbox public subnet CIDR blocks."
+  type        = list(string)
+}
+
+variable "private_subnet_cidrs" {
+  description = "Sandbox private subnet CIDR blocks."
+  type        = list(string)
+}
+
+variable "azs" {
+  description = "Availability zones for the sandbox cluster."
+  type        = list(string)
+}
+
+variable "single_nat_gateway" {
+  description = "Use one shared NAT gateway instead of one NAT gateway per public subnet."
+  type        = bool
+  default     = true
+}
+
+variable "nat_eip_allocation_ids" {
+  description = "Existing Elastic IP allocation IDs to use for NAT gateways."
+  type        = list(string)
+  default     = []
+}
+
+variable "enable_vpc_flow_logs" {
+  description = "Enable VPC flow logs for sandbox network visibility."
+  type        = bool
+  default     = true
+}
+
+# ---------------------------------------------------------------------------
+# EKS
+# ---------------------------------------------------------------------------
+
+variable "cluster_version" {
+  description = "Kubernetes version for the sandbox EKS cluster."
+  type        = string
+}
+
+variable "cluster_service_ipv4_cidr" {
+  description = "Service IPv4 CIDR for the Kubernetes cluster."
+  type        = string
+  default     = null
+}
+
+variable "cluster_endpoint_private_access" {
+  description = "Whether the private EKS API endpoint is enabled."
+  type        = bool
+  default     = true
+}
+
+variable "cluster_endpoint_public_access" {
+  description = "Whether the public EKS API endpoint is enabled."
+  type        = bool
+  default     = true
+}
+
+variable "cluster_endpoint_public_access_cidrs" {
+  description = "CIDR ranges allowed to access the public EKS API endpoint."
+  type        = list(string)
+}
+
+variable "authentication_mode" {
+  description = "EKS authentication mode."
+  type        = string
+  default     = "API_AND_CONFIG_MAP"
+}
+
+variable "bootstrap_cluster_creator_admin_permissions" {
+  description = "Grant the cluster creator admin permissions at bootstrap."
+  type        = bool
+  default     = true
+}
+
+variable "cluster_admin_principal_arns" {
+  description = "Additional IAM principal ARNs to grant cluster admin access."
+  type        = list(string)
+  default     = []
+}
+
+variable "enable_cluster_secret_encryption" {
+  description = "Encrypt Kubernetes secrets using a customer-managed KMS key."
+  type        = bool
+  default     = true
+}
+
+variable "route53_hosted_zone_id" {
+  description = "Route53 hosted zone ID used by cert-manager DNS validation."
+  type        = string
+}
+
+variable "enable_efs_csi_driver" {
+  description = "Install the AWS EFS CSI driver add-on."
+  type        = bool
+  default     = false
+}
+
+# ---------------------------------------------------------------------------
+# IRSA
+# ---------------------------------------------------------------------------
+
+variable "app_namespace" {
+  description = "Primary Kubernetes namespace for the xTRA workload."
+  type        = string
+  default     = "ctdl-xtra"
+}
+
+variable "additional_app_namespaces" {
+  description = "Additional namespaces that may use the application IRSA role."
+  type        = list(string)
+  default     = []
+}
+
+variable "app_service_account" {
+  description = "Kubernetes service account name for application IRSA."
+  type        = string
+  default     = "ctdl-xtra"
+}
+
+variable "application_s3_bucket_names" {
+  description = "S3 buckets the xTRA service account can access."
+  type        = list(string)
+  default     = []
+}
+
+variable "external_secrets_secret_name_prefixes" {
+  description = "Secrets Manager name prefixes readable by External Secrets Operator."
+  type        = list(string)
+  default     = ["ctdl-xtra/sandbox", "ctdl-xtra-sandbox"]
+}
+
+variable "external_secrets_ssm_parameter_prefixes" {
+  description = "SSM Parameter Store prefixes readable by External Secrets Operator."
+  type        = list(string)
+  default     = ["ctdl-xtra/sandbox"]
+}
+
+# ---------------------------------------------------------------------------
+# Application dependencies
+# ---------------------------------------------------------------------------
+
+variable "app_domain_name" {
+  description = "Public hostname for the xTRA application."
+  type        = string
+  default     = "xtra-sandbox.credentialengineregistry.org"
+}
+
+variable "app_secret_name" {
+  description = "Secrets Manager JSON secret consumed by the xTRA workload."
+  type        = string
+  default     = "ctdl-xtra/sandbox/app"
+}
+
+variable "db_name" {
+  description = "PostgreSQL database name."
+  type        = string
+  default     = "ctdl_xtra"
+}
+
+variable "db_username" {
+  description = "PostgreSQL master username."
+  type        = string
+  default     = "ctdlxtra"
+}
+
+variable "db_engine_version" {
+  description = "PostgreSQL engine version."
+  type        = string
+  default     = "17.5"
+}
+
+variable "db_instance_class" {
+  description = "PostgreSQL instance class."
+  type        = string
+  default     = "db.t4g.small"
+}
+
+variable "db_allocated_storage" {
+  description = "Initial PostgreSQL storage in GiB."
+  type        = number
+  default     = 20
+}
+
+variable "db_max_allocated_storage" {
+  description = "Maximum PostgreSQL autoscaled storage in GiB."
+  type        = number
+  default     = 100
+}
+
+variable "db_multi_az" {
+  description = "Enable Multi-AZ standby for PostgreSQL."
+  type        = bool
+  default     = false
+}
+
+variable "db_backup_retention_days" {
+  description = "PostgreSQL backup retention in days."
+  type        = number
+  default     = 7
+}
+
+# ---------------------------------------------------------------------------
+# Node groups
+# ---------------------------------------------------------------------------
+
+variable "system_node_instance_types" {
+  description = "Instance types for untainted system nodes."
+  type        = list(string)
+  default     = ["t3.medium"]
+}
+
+variable "system_node_disk_size" {
+  description = "Disk size in GiB for system nodes."
+  type        = number
+  default     = 30
+}
+
+variable "system_node_min_size" {
+  description = "Minimum system node count."
+  type        = number
+  default     = 1
+}
+
+variable "system_node_max_size" {
+  description = "Maximum system node count."
+  type        = number
+  default     = 2
+}
+
+variable "system_node_desired_size" {
+  description = "Desired system node count."
+  type        = number
+  default     = 1
+}
+
+variable "app_node_instance_types" {
+  description = "Instance types for xTRA workload nodes."
+  type        = list(string)
+  default     = ["t3.medium"]
+}
+
+variable "app_node_disk_size" {
+  description = "Disk size in GiB for xTRA workload nodes."
+  type        = number
+  default     = 50
+}
+
+variable "app_node_min_size" {
+  description = "Minimum xTRA workload node count."
+  type        = number
+  default     = 1
+}
+
+variable "app_node_max_size" {
+  description = "Maximum xTRA workload node count."
+  type        = number
+  default     = 2
+}
+
+variable "app_node_desired_size" {
+  description = "Desired xTRA workload node count."
+  type        = number
+  default     = 1
+}

--- a/infra/terraform/github-ci-oidc/main.tf
+++ b/infra/terraform/github-ci-oidc/main.tf
@@ -8,8 +8,8 @@ locals {
 # ---------------------------------------------------------------
 
 resource "aws_iam_openid_connect_provider" "github" {
-  url             = "https://token.actions.githubusercontent.com"
-  client_id_list  = ["sts.amazonaws.com"]
+  url            = "https://token.actions.githubusercontent.com"
+  client_id_list = ["sts.amazonaws.com"]
   thumbprint_list = [
     "6938fd4d98bab03faadb97b34396831e3780aea1",
     "1c58a3a8518e8759bf075b76b750d4f2df264fcd",
@@ -42,7 +42,31 @@ resource "aws_iam_role" "github_actions_ci" {
 }
 
 # ---------------------------------------------------------------
-# ECR — push to STAGING repos, pull from STAGING to copy to PRODUCTION
+# Shared base image ECR repository (env-neutral)
+# ---------------------------------------------------------------
+
+resource "aws_ecr_repository" "base" {
+  name                 = "ctdl-xtra-base"
+  image_tag_mutability = "MUTABLE"
+  force_delete         = true
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    project    = "ctdl-xtra"
+    managed-by = "terraform"
+    Name       = "ctdl-xtra-base"
+  }
+}
+
+# ---------------------------------------------------------------
+# ECR — push to SANDBOX + base, copy SANDBOX → PRODUCTION
 # ---------------------------------------------------------------
 
 resource "aws_iam_policy" "github_actions_ecr" {
@@ -56,6 +80,26 @@ resource "aws_iam_policy" "github_actions_ecr" {
         Effect   = "Allow"
         Action   = "ecr:GetAuthorizationToken"
         Resource = "*"
+      },
+      {
+        Sid    = "SandboxReadWrite"
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "ecr:PutImage",
+          "ecr:InitiateLayerUpload",
+          "ecr:UploadLayerPart",
+          "ecr:CompleteLayerUpload",
+          "ecr:DescribeRepositories",
+          "ecr:ListImages",
+          "ecr:DescribeImages",
+        ]
+        Resource = [
+          "arn:aws:ecr:us-east-1:${local.aws_account_id}:repository/ctdl-xtra-sandbox/*",
+          aws_ecr_repository.base.arn,
+        ]
       },
       {
         Sid    = "ProductionPromote"
@@ -91,12 +135,20 @@ resource "aws_iam_policy" "github_actions_eks" {
     Version = "2012-10-17"
     Statement = [
       {
+        Sid    = "DescribeClusters"
         Effect = "Allow"
         Action = "eks:DescribeCluster"
         Resource = [
+          "arn:aws:eks:us-east-1:${local.aws_account_id}:cluster/ctdl-xtra-sandbox",
           "arn:aws:eks:us-east-1:${local.aws_account_id}:cluster/ctdl-xtra-prod",
         ]
-      }
+      },
+      {
+        Sid      = "DescribeEFS"
+        Effect   = "Allow"
+        Action   = "elasticfilesystem:DescribeFileSystems"
+        Resource = "*"
+      },
     ]
   })
 }

--- a/infra/terraform/github-ci-oidc/main.tf
+++ b/infra/terraform/github-ci-oidc/main.tf
@@ -42,31 +42,7 @@ resource "aws_iam_role" "github_actions_ci" {
 }
 
 # ---------------------------------------------------------------
-# Shared base image ECR repository (env-neutral)
-# ---------------------------------------------------------------
-
-resource "aws_ecr_repository" "base" {
-  name                 = "ctdl-xtra-base"
-  image_tag_mutability = "MUTABLE"
-  force_delete         = true
-
-  encryption_configuration {
-    encryption_type = "AES256"
-  }
-
-  image_scanning_configuration {
-    scan_on_push = true
-  }
-
-  tags = {
-    project    = "ctdl-xtra"
-    managed-by = "terraform"
-    Name       = "ctdl-xtra-base"
-  }
-}
-
-# ---------------------------------------------------------------
-# ECR — push to SANDBOX + base, copy SANDBOX → PRODUCTION
+# ECR — push to SANDBOX (including base), copy SANDBOX → PRODUCTION
 # ---------------------------------------------------------------
 
 resource "aws_iam_policy" "github_actions_ecr" {
@@ -98,7 +74,6 @@ resource "aws_iam_policy" "github_actions_ecr" {
         ]
         Resource = [
           "arn:aws:ecr:us-east-1:${local.aws_account_id}:repository/ctdl-xtra-sandbox/*",
-          aws_ecr_repository.base.arn,
         ]
       },
       {

--- a/infra/terraform/k8s-manifests/sandbox/addons/cluster-autoscaler.yaml
+++ b/infra/terraform/k8s-manifests/sandbox/addons/cluster-autoscaler.yaml
@@ -1,0 +1,128 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::996810415034:role/ctdl-xtra-sandbox-cluster-autoscaler-irsa-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-autoscaler
+rules:
+  - apiGroups: [""]
+    resources: ["events", "endpoints"]
+    verbs: ["create", "patch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["cluster-autoscaler-status", "cluster-autoscaler-priority-expander"]
+    verbs: ["delete", "get", "update", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/eviction"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["pods/status"]
+    verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    resourceNames: ["cluster-autoscaler"]
+    verbs: ["get", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["watch", "list", "get", "update"]
+  - apiGroups: [""]
+    resources: ["namespaces", "pods", "services", "replicationcontrollers", "persistentvolumeclaims", "persistentvolumes"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets", "daemonsets"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["watch", "list"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets", "replicasets", "daemonsets"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses", "csinodes", "csidrivers", "csistoragecapacities", "volumeattachments"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    resourceNames: ["cluster-autoscaler"]
+    verbs: ["get", "update"]
+  - apiGroups: ["resource.k8s.io"]
+    resources: ["resourceclaims", "resourceslices", "deviceclasses"]
+    verbs: ["watch", "list", "get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-autoscaler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-autoscaler
+subjects:
+  - kind: ServiceAccount
+    name: cluster-autoscaler
+    namespace: kube-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    app: cluster-autoscaler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cluster-autoscaler
+  template:
+    metadata:
+      labels:
+        app: cluster-autoscaler
+    spec:
+      serviceAccountName: cluster-autoscaler
+      priorityClassName: system-cluster-critical
+      nodeSelector:
+        nodepool: system
+      containers:
+        - name: cluster-autoscaler
+          image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.35.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - ./cluster-autoscaler
+            - --v=4
+            - --stderrthreshold=info
+            - --cloud-provider=aws
+            - --skip-nodes-with-local-storage=false
+            - --skip-nodes-with-system-pods=false
+            - --expander=least-waste
+            - --balance-similar-node-groups
+            - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/ctdl-xtra-sandbox
+          resources:
+            requests:
+              cpu: 100m
+              memory: 600Mi
+            limits:
+              cpu: 100m
+              memory: 600Mi
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /etc/ssl/certs/ca-certificates.crt
+              readOnly: true
+      volumes:
+        - name: ssl-certs
+          hostPath:
+            path: /etc/ssl/certs/ca-bundle.crt

--- a/infra/terraform/k8s-manifests/sandbox/addons/external-secrets-values.yaml
+++ b/infra/terraform/k8s-manifests/sandbox/addons/external-secrets-values.yaml
@@ -1,0 +1,18 @@
+installCRDs: true
+
+serviceAccount:
+  name: external-secrets
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::996810415034:role/ctdl-xtra-sandbox-external-secrets-irsa-role
+
+env:
+  AWS_REGION: us-east-1
+  AWS_DEFAULT_REGION: us-east-1
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi

--- a/infra/terraform/k8s-manifests/sandbox/addons/ingress-nginx-values.yaml
+++ b/infra/terraform/k8s-manifests/sandbox/addons/ingress-nginx-values.yaml
@@ -1,0 +1,8 @@
+controller:
+  replicaCount: 2
+  nodeSelector:
+    nodepool: system
+  service:
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-type: nlb
+      service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing

--- a/infra/terraform/k8s-manifests/sandbox/addons/install-foundation.sh
+++ b/infra/terraform/k8s-manifests/sandbox/addons/install-foundation.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+CONTEXT="${KUBE_CONTEXT:-ctdl-xtra-sandbox}"
+
+CERT_MANAGER_VERSION="v1.17.1"
+EXTERNAL_SECRETS_VERSION="2.4.1"
+INGRESS_NGINX_VERSION="4.12.1"
+METRICS_SERVER_VERSION="3.12.2"
+
+kubectl --context "${CONTEXT}" apply -f "${ROOT_DIR}/cluster/namespace.yaml"
+kubectl --context "${CONTEXT}" apply -f "${ROOT_DIR}/cluster/storageclass-gp3.yaml"
+
+helm repo add jetstack https://charts.jetstack.io --force-update
+helm repo add external-secrets https://charts.external-secrets.io --force-update
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx --force-update
+helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/ --force-update
+helm repo update
+
+helm upgrade --install cert-manager jetstack/cert-manager \
+  --kube-context "${CONTEXT}" \
+  --namespace cert-manager \
+  --create-namespace \
+  --version "${CERT_MANAGER_VERSION}" \
+  --set installCRDs=true \
+  --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"="arn:aws:iam::996810415034:role/ctdl-xtra-sandbox-cert-manager-irsa-role" \
+  --wait \
+  --timeout 5m
+
+kubectl --context "${CONTEXT}" apply -f "${ROOT_DIR}/cluster/cert-manager-cluster-issuer.yaml"
+
+helm upgrade --install external-secrets external-secrets/external-secrets \
+  --kube-context "${CONTEXT}" \
+  --namespace external-secrets \
+  --create-namespace \
+  --version "${EXTERNAL_SECRETS_VERSION}" \
+  --values "${SCRIPT_DIR}/external-secrets-values.yaml" \
+  --wait \
+  --timeout 5m
+
+kubectl --context "${CONTEXT}" apply -f "${ROOT_DIR}/cluster/cluster-secret-store.yaml"
+
+helm upgrade --install ingress-nginx ingress-nginx/ingress-nginx \
+  --kube-context "${CONTEXT}" \
+  --namespace ingress-nginx \
+  --create-namespace \
+  --version "${INGRESS_NGINX_VERSION}" \
+  --values "${SCRIPT_DIR}/ingress-nginx-values.yaml" \
+  --wait \
+  --timeout 10m
+
+helm upgrade --install metrics-server metrics-server/metrics-server \
+  --kube-context "${CONTEXT}" \
+  --namespace kube-system \
+  --version "${METRICS_SERVER_VERSION}" \
+  --values "${SCRIPT_DIR}/metrics-server-values.yaml" \
+  --wait \
+  --timeout 5m
+
+kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/cluster-autoscaler.yaml"
+kubectl --context "${CONTEXT}" -n kube-system rollout status deployment/cluster-autoscaler --timeout=180s

--- a/infra/terraform/k8s-manifests/sandbox/addons/metrics-server-values.yaml
+++ b/infra/terraform/k8s-manifests/sandbox/addons/metrics-server-values.yaml
@@ -1,0 +1,12 @@
+replicas: 2
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 200Mi
+  limits:
+    cpu: 200m
+    memory: 400Mi
+
+nodeSelector:
+  nodepool: system

--- a/infra/terraform/k8s-manifests/sandbox/app/db-migrate-job.yaml
+++ b/infra/terraform/k8s-manifests/sandbox/app/db-migrate-job.yaml
@@ -1,0 +1,58 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ctdl-xtra-db-migrate
+  namespace: ctdl-xtra
+  labels:
+    app.kubernetes.io/name: ctdl-xtra
+    app.kubernetes.io/component: db-migrate
+    app.kubernetes.io/part-of: ctdl-xtra
+    environment: sandbox
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ctdl-xtra
+        app.kubernetes.io/component: db-migrate
+        app.kubernetes.io/part-of: ctdl-xtra
+        environment: sandbox
+    spec:
+      restartPolicy: Never
+      serviceAccountName: ctdl-xtra
+      nodeSelector:
+        nodepool: app
+      containers:
+        - name: db-migrate
+          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra-sandbox/api:${IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
+          command:
+            - /app/entrypoint.sh
+          args:
+            - ./node_modules/.bin/drizzle-kit
+            - migrate
+          env:
+            - name: RUN_MIGRATIONS
+              value: "false"
+            - name: NODE_EXTRA_CA_CERTS
+              value: /etc/ssl/certs/rds-global-bundle.pem
+          envFrom:
+            - secretRef:
+                name: ctdl-xtra-app-env
+          volumeMounts:
+            - name: rds-ca-bundle
+              mountPath: /etc/ssl/certs/rds-global-bundle.pem
+              subPath: rds-global-bundle.pem
+              readOnly: true
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+      volumes:
+        - name: rds-ca-bundle
+          configMap:
+            name: rds-ca-bundle

--- a/infra/terraform/k8s-manifests/sandbox/app/deploy-app.sh
+++ b/infra/terraform/k8s-manifests/sandbox/app/deploy-app.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${IMAGE_TAG:?IMAGE_TAG must be set (e.g. sha-abc1234)}"
+: "${EFS_FS_ID:?EFS_FS_ID must be set (terraform output efs_file_system_id)}"
+export IMAGE_TAG EFS_FS_ID
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONTEXT="${KUBE_CONTEXT:-ctdl-xtra-sandbox}"
+NAMESPACE="ctdl-xtra"
+TMP_DIR="$(mktemp -d)"
+
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/externalsecret.yaml"
+envsubst '${EFS_FS_ID}' < "${SCRIPT_DIR}/storage.yaml" | kubectl --context "${CONTEXT}" apply -f -
+curl -fsSL "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" -o "${TMP_DIR}/rds-global-bundle.pem"
+kubectl --context "${CONTEXT}" -n "${NAMESPACE}" create configmap rds-ca-bundle \
+  --from-file="rds-global-bundle.pem=${TMP_DIR}/rds-global-bundle.pem" \
+  --dry-run=client \
+  -o yaml | kubectl --context "${CONTEXT}" apply -f -
+kubectl --context "${CONTEXT}" -n "${NAMESPACE}" wait --for=condition=Ready externalsecret/ctdl-xtra-app --timeout=120s
+kubectl --context "${CONTEXT}" -n "${NAMESPACE}" delete job ctdl-xtra-db-migrate --ignore-not-found
+envsubst '${IMAGE_TAG}' < "${SCRIPT_DIR}/db-migrate-job.yaml" | kubectl --context "${CONTEXT}" apply -f -
+kubectl --context "${CONTEXT}" -n "${NAMESPACE}" wait --for=condition=Complete job/ctdl-xtra-db-migrate --timeout=300s
+kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/redis-configmap.yaml"
+kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/redis-externalsecret.yaml"
+kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/redis-statefulset.yaml"
+kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/service.yaml"
+envsubst '${IMAGE_TAG}' < "${SCRIPT_DIR}/deployment.yaml" | kubectl --context "${CONTEXT}" apply -f -
+kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/ingress.yaml"
+kubectl --context "${CONTEXT}" -n "${NAMESPACE}" rollout status deployment/ctdl-xtra-api --timeout=300s
+kubectl --context "${CONTEXT}" -n "${NAMESPACE}" rollout status deployment/ctdl-xtra-worker --timeout=300s

--- a/infra/terraform/k8s-manifests/sandbox/app/deployment.yaml
+++ b/infra/terraform/k8s-manifests/sandbox/app/deployment.yaml
@@ -1,0 +1,160 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ctdl-xtra-api
+  namespace: ctdl-xtra
+  labels:
+    app.kubernetes.io/name: ctdl-xtra
+    app.kubernetes.io/component: api
+    app.kubernetes.io/part-of: ctdl-xtra
+    environment: sandbox
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ctdl-xtra
+      app.kubernetes.io/component: api
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ctdl-xtra
+        app.kubernetes.io/component: api
+        app.kubernetes.io/part-of: ctdl-xtra
+        environment: sandbox
+    spec:
+      serviceAccountName: ctdl-xtra
+      nodeSelector:
+        nodepool: app
+      containers:
+        - name: api
+          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra-sandbox/api:${IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 3000
+          env:
+            - name: RUN_MIGRATIONS
+              value: "false"
+            - name: LOG_LEVEL
+              value: info
+            - name: NODE_EXTRA_CA_CERTS
+              value: /etc/ssl/certs/rds-global-bundle.pem
+          envFrom:
+            - secretRef:
+                name: ctdl-xtra-app-env
+          readinessProbe:
+            httpGet:
+              path: /up
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /up
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /up
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 18
+          volumeMounts:
+            - name: extraction-files
+              mountPath: /data/extractions
+            - name: rds-ca-bundle
+              mountPath: /etc/ssl/certs/rds-global-bundle.pem
+              subPath: rds-global-bundle.pem
+              readOnly: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 384Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+      volumes:
+        - name: extraction-files
+          persistentVolumeClaim:
+            claimName: ctdl-xtra-files
+        - name: rds-ca-bundle
+          configMap:
+            name: rds-ca-bundle
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ctdl-xtra-worker
+  namespace: ctdl-xtra
+  labels:
+    app.kubernetes.io/name: ctdl-xtra
+    app.kubernetes.io/component: worker
+    app.kubernetes.io/part-of: ctdl-xtra
+    environment: sandbox
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ctdl-xtra
+      app.kubernetes.io/component: worker
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ctdl-xtra
+        app.kubernetes.io/component: worker
+        app.kubernetes.io/part-of: ctdl-xtra
+        environment: sandbox
+    spec:
+      serviceAccountName: ctdl-xtra
+      nodeSelector:
+        nodepool: app
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: worker
+          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra-sandbox/worker:${IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: LOG_LEVEL
+              value: info
+            - name: NODE_EXTRA_CA_CERTS
+              value: /etc/ssl/certs/rds-global-bundle.pem
+          envFrom:
+            - secretRef:
+                name: ctdl-xtra-app-env
+          volumeMounts:
+            - name: extraction-files
+              mountPath: /data/extractions
+            - name: rds-ca-bundle
+              mountPath: /etc/ssl/certs/rds-global-bundle.pem
+              subPath: rds-global-bundle.pem
+              readOnly: true
+          resources:
+            requests:
+              cpu: 200m
+              memory: 512Mi
+            limits:
+              cpu: "1500m"
+              memory: 1500Mi
+      volumes:
+        - name: extraction-files
+          persistentVolumeClaim:
+            claimName: ctdl-xtra-files
+        - name: rds-ca-bundle
+          configMap:
+            name: rds-ca-bundle

--- a/infra/terraform/k8s-manifests/sandbox/app/externalsecret.yaml
+++ b/infra/terraform/k8s-manifests/sandbox/app/externalsecret.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ctdl-xtra-app
+  namespace: ctdl-xtra
+  labels:
+    app.kubernetes.io/name: ctdl-xtra
+    app.kubernetes.io/part-of: ctdl-xtra
+    environment: sandbox
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: aws-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: ctdl-xtra-app-env
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: ctdl-xtra/sandbox/app

--- a/infra/terraform/k8s-manifests/sandbox/app/ingress.yaml
+++ b/infra/terraform/k8s-manifests/sandbox/app/ingress.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ctdl-xtra-api
+  namespace: ctdl-xtra
+  labels:
+    app.kubernetes.io/name: ctdl-xtra
+    app.kubernetes.io/component: api
+    app.kubernetes.io/part-of: ctdl-xtra
+    environment: sandbox
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - xtra-sandbox.credentialengineregistry.org
+      secretName: ctdl-xtra-tls
+  rules:
+    - host: xtra-sandbox.credentialengineregistry.org
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ctdl-xtra-api
+                port:
+                  name: http

--- a/infra/terraform/k8s-manifests/sandbox/app/redis-configmap.yaml
+++ b/infra/terraform/k8s-manifests/sandbox/app/redis-configmap.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-config
+  namespace: ctdl-xtra
+data:
+  redis.conf: |
+    bind 0.0.0.0
+    port 6379
+    protected-mode yes
+    tcp-keepalive 300
+    maxmemory 512mb
+    maxmemory-policy noeviction
+
+    # AOF persistence
+    appendonly yes
+    appendfsync everysec
+    auto-aof-rewrite-percentage 100
+    auto-aof-rewrite-min-size 64mb
+
+    # RDB snapshots
+    save 900 1
+    save 300 10
+    save 60 10000
+    dbfilename dump.rdb
+    dir /data
+
+    # Auth (injected via secret volume)
+    include /run/redis-auth/redis-password.conf

--- a/infra/terraform/k8s-manifests/sandbox/app/redis-externalsecret.yaml
+++ b/infra/terraform/k8s-manifests/sandbox/app/redis-externalsecret.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: redis-auth
+  namespace: ctdl-xtra
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: redis-auth
+    creationPolicy: Owner
+    template:
+      data:
+        password: "{{ .password }}"
+        redis-password.conf: "requirepass {{ .password }}"
+  data:
+    - secretKey: password
+      remoteRef:
+        key: ctdl-xtra/sandbox/redis
+        property: password

--- a/infra/terraform/k8s-manifests/sandbox/app/redis-statefulset.yaml
+++ b/infra/terraform/k8s-manifests/sandbox/app/redis-statefulset.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis
+  namespace: ctdl-xtra
+  labels:
+    app: redis
+spec:
+  serviceName: redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      nodeSelector:
+        workload: ctdl-xtra
+      containers:
+        - name: redis
+          image: redis:8.0-alpine
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -euo pipefail
+              PASS="$(cat /run/redis-auth/password)"
+              exec redis-server /usr/local/etc/redis/redis.conf --requirepass "$PASS"
+          ports:
+            - containerPort: 6379
+          volumeMounts:
+            - name: redis-data
+              mountPath: /data
+            - name: redis-config
+              mountPath: /usr/local/etc/redis
+            - name: redis-auth
+              mountPath: /run/redis-auth
+              readOnly: true
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - redis-cli -a "$(cat /run/redis-auth/password)" ping
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - redis-cli -a "$(cat /run/redis-auth/password)" ping
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      volumes:
+        - name: redis-config
+          configMap:
+            name: redis-config
+        - name: redis-auth
+          secret:
+            secretName: redis-auth
+  volumeClaimTemplates:
+    - metadata:
+        name: redis-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: gp3
+        resources:
+          requests:
+            storage: 10Gi
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: ctdl-xtra
+spec:
+  clusterIP: None
+  ports:
+    - port: 6379
+      targetPort: 6379
+  selector:
+    app: redis

--- a/infra/terraform/k8s-manifests/sandbox/app/service.yaml
+++ b/infra/terraform/k8s-manifests/sandbox/app/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ctdl-xtra-api
+  namespace: ctdl-xtra
+  labels:
+    app.kubernetes.io/name: ctdl-xtra
+    app.kubernetes.io/component: api
+    app.kubernetes.io/part-of: ctdl-xtra
+    environment: sandbox
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: ctdl-xtra
+    app.kubernetes.io/component: api
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/infra/terraform/k8s-manifests/sandbox/app/storage.yaml
+++ b/infra/terraform/k8s-manifests/sandbox/app/storage.yaml
@@ -1,0 +1,53 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ctdl-xtra-efs
+  labels:
+    app.kubernetes.io/name: ctdl-xtra
+    app.kubernetes.io/part-of: ctdl-xtra
+    environment: sandbox
+provisioner: efs.csi.aws.com
+reclaimPolicy: Retain
+volumeBindingMode: WaitForFirstConsumer
+mountOptions:
+  - tls
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: ctdl-xtra-files
+  labels:
+    app.kubernetes.io/name: ctdl-xtra
+    app.kubernetes.io/part-of: ctdl-xtra
+    environment: sandbox
+spec:
+  capacity:
+    storage: 50Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ctdl-xtra-efs
+  mountOptions:
+    - tls
+  csi:
+    driver: efs.csi.aws.com
+    volumeHandle: ${EFS_FS_ID}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ctdl-xtra-files
+  namespace: ctdl-xtra
+  labels:
+    app.kubernetes.io/name: ctdl-xtra
+    app.kubernetes.io/part-of: ctdl-xtra
+    environment: sandbox
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ctdl-xtra-efs
+  volumeName: ctdl-xtra-files
+  resources:
+    requests:
+      storage: 50Gi

--- a/infra/terraform/k8s-manifests/sandbox/cluster/cert-manager-cluster-issuer.yaml
+++ b/infra/terraform/k8s-manifests/sandbox/cluster/cert-manager-cluster-issuer.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: ariel@learningtapestry.com
+    privateKeySecretRef:
+      name: letsencrypt-prod-account-key
+    solvers:
+      - dns01:
+          route53:
+            region: us-east-1
+            hostedZoneID: Z1N75467P1FUL5

--- a/infra/terraform/k8s-manifests/sandbox/cluster/cluster-secret-store.yaml
+++ b/infra/terraform/k8s-manifests/sandbox/cluster/cluster-secret-store.yaml
@@ -1,0 +1,14 @@
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: aws-secret-manager
+spec:
+  provider:
+    aws:
+      service: SecretsManager
+      region: us-east-1
+      auth:
+        jwt:
+          serviceAccountRef:
+            name: external-secrets
+            namespace: external-secrets

--- a/infra/terraform/k8s-manifests/sandbox/cluster/namespace.yaml
+++ b/infra/terraform/k8s-manifests/sandbox/cluster/namespace.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ctdl-xtra
+  labels:
+    app.kubernetes.io/name: ctdl-xtra
+    app.kubernetes.io/part-of: ctdl-xtra
+    environment: sandbox
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ctdl-xtra
+  namespace: ctdl-xtra
+  labels:
+    app.kubernetes.io/name: ctdl-xtra
+    app.kubernetes.io/part-of: ctdl-xtra
+    environment: sandbox
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::996810415034:role/ctdl-xtra-sandbox-application-irsa-role

--- a/infra/terraform/k8s-manifests/sandbox/cluster/storageclass-gp3.yaml
+++ b/infra/terraform/k8s-manifests/sandbox/cluster/storageclass-gp3.yaml
@@ -1,0 +1,12 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gp3
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: ebs.csi.aws.com
+parameters:
+  type: gp3
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true

--- a/worker.Dockerfile
+++ b/worker.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra-base:latest
+ARG BASE_IMAGE=996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra-sandbox/base:latest
 FROM ${BASE_IMAGE}
 
 COPY server/package.json server/pnpm-lock.yaml server/pnpm-workspace.yaml /build/app/server/

--- a/worker.Dockerfile
+++ b/worker.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra-staging/base:latest
+ARG BASE_IMAGE=996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra-base:latest
 FROM ${BASE_IMAGE}
 
 COPY server/package.json server/pnpm-lock.yaml server/pnpm-workspace.yaml /build/app/server/


### PR DESCRIPTION
## Summary

Stands up the SANDBOX environment from scratch as the replacement for the decommissioned staging tier.

### Infrastructure (`infra/terraform/envs/sandbox/`)
- VPC `10.41.0.0/16`, single NAT gateway
- EKS cluster `ctdl-xtra-sandbox` (K8s 1.35)
- RDS `db.t4g.small` Single-AZ, deletion protection off, no final snapshot (sandbox is recreatable)
- EFS for shared extraction files
- 2 node groups, both 1× t3.medium (system + app), each min=1/max=2
- 3 ECR repos: `ctdl-xtra-sandbox/{api,worker,base}` — each env owns its container artifacts entirely; base lives alongside api/worker

### Shared CI plumbing (`infra/terraform/github-ci-oidc/`)
- CI role gets `ctdl-xtra-sandbox/*` push perms (wildcard covers api, worker, base) and `elasticfilesystem:DescribeFileSystems` for the sandbox promote workflow's auto-discovery

### Kubernetes (`infra/terraform/k8s-manifests/sandbox/`)
- Hostname `xtra-sandbox.credentialengineregistry.org`
- Right-sized for t3.medium: api/worker 1 replica each; trimmed requests/limits; smaller redis
- `storage.yaml` uses `${EFS_FS_ID}` substituted at deploy time

### CI/CD
- `release.yml` — re-enabled on push to main; pushes `sha-*` and `main-latest` to `ctdl-xtra-sandbox/{api,worker}`
- `build-base.yml` — re-enabled on `base.Dockerfile` change; pushes to `ctdl-xtra-sandbox/base:latest`
- `promote-production.yml` — `crane copy` source is now `ctdl-xtra-sandbox/*`
- `promote-sandbox.yml` (new) — manual deploy; auto-discovers EFS file system id and runs `deploy-app.sh`
- `Dockerfile` and `worker.Dockerfile` `FROM ctdl-xtra-sandbox/base:latest`

### Docs
- `INFRASTRUCTURE-SUMMARY.md` and `CI-CD.md` updated for sandbox+prod
- Notes the design-doc target of `TEST → SANDBOX → PRODUCTION` and that TEST is not yet built

## Apply plan (post-merge)

1. `terraform apply` `github-ci-oidc/` (0 add, 2 changed)
2. `terraform apply` `envs/sandbox/` (79 adds, ~15 min)
3. Trigger `Build Base Image` workflow manually to populate `ctdl-xtra-sandbox/base:latest`
4. Run `k8s-manifests/sandbox/addons/install-foundation.sh` (cert-manager, external-secrets, ingress-nginx, autoscaler, metrics-server)
5. Apply cluster manifests (namespace, storage class, cert issuer, secret store)
6. Trigger `Release` workflow to push the first sandbox image
7. Trigger `Promote to SANDBOX`
8. Add Route53 CNAME `xtra-sandbox.credentialengineregistry.org` → new ALB
9. Smoke test

Production untouched.

## Test plan

- [x] `terraform fmt && terraform validate` clean for both stacks
- [x] `terraform plan` clean: sandbox 79 to add; oidc 0 add + 2 changed
- [ ] After apply: end-to-end deploy via workflows succeeds
- [ ] App reachable at `https://xtra-sandbox.credentialengineregistry.org`