### PR TITLE
Add TEST environment and complete the promotion chain

### DIFF
--- a/.github/workflows/build-base.yml
+++ b/.github/workflows/build-base.yml
@@ -14,7 +14,7 @@ permissions:
 env:
   AWS_REGION: us-east-1
   ECR_REGISTRY: 996810415034.dkr.ecr.us-east-1.amazonaws.com
-  ECR_REPOSITORY: ctdl-xtra-sandbox/base
+  ECR_REPOSITORY: ctdl-xtra-test/base
 
 jobs:
   build:

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -1,0 +1,72 @@
+name: Deploy to TEST
+
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Image tag to deploy (defaults to main-latest)"
+        required: false
+        default: main-latest
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: us-east-1
+
+jobs:
+  deploy:
+    name: Deploy to TEST
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    environment: TEST
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Compute image tag
+        id: tag
+        run: |
+          if [ -n "${{ inputs.image_tag }}" ]; then
+            echo "value=${{ inputs.image_tag }}" >> "$GITHUB_OUTPUT"
+          else
+            SHA="${{ github.event.workflow_run.head_sha || github.sha }}"
+            echo "value=sha-${SHA:0:7}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Configure kubeconfig
+        run: aws eks update-kubeconfig --name ctdl-xtra-test --region "$AWS_REGION" --alias ctdl-xtra-test
+
+      - name: Look up EFS file system id
+        id: efs
+        run: |
+          set -euo pipefail
+          FS_ID=$(aws efs describe-file-systems \
+            --query "FileSystems[?Tags[?Key=='Name' && Value=='ctdl-xtra-test-files']].FileSystemId | [0]" \
+            --output text)
+          if [ -z "$FS_ID" ] || [ "$FS_ID" = "None" ]; then
+            echo "Could not resolve EFS file system id for ctdl-xtra-test-files" >&2
+            exit 1
+          fi
+          echo "id=$FS_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy
+        env:
+          IMAGE_TAG: ${{ steps.tag.outputs.value }}
+          EFS_FS_ID: ${{ steps.efs.outputs.id }}
+          KUBE_CONTEXT: ctdl-xtra-test
+        run: bash infra/terraform/k8s-manifests/test/app/deploy-app.sh
+
+      - name: Summary
+        run: echo "### Deployed \`${{ steps.tag.outputs.value }}\` to TEST" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/promote-sandbox.yml
+++ b/.github/workflows/promote-sandbox.yml
@@ -4,9 +4,8 @@ on:
   workflow_dispatch:
     inputs:
       image_tag:
-        description: "Image tag to deploy (e.g. sha-abc1234 or main-latest)"
+        description: "Exact image tag to promote from TEST → SANDBOX (e.g. sha-abc1234)"
         required: true
-        default: main-latest
 
 permissions:
   id-token: write
@@ -14,6 +13,7 @@ permissions:
 
 env:
   AWS_REGION: us-east-1
+  ECR_REGISTRY: 996810415034.dkr.ecr.us-east-1.amazonaws.com
 
 jobs:
   promote:
@@ -27,6 +27,22 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
+
+      - uses: aws-actions/amazon-ecr-login@v2
+
+      - uses: imjasonh/setup-crane@v0.4
+
+      - name: Copy images TEST → SANDBOX ECR
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag }}
+        run: |
+          set -euo pipefail
+          for SERVICE in api worker; do
+            SRC="${ECR_REGISTRY}/ctdl-xtra-test/${SERVICE}:${IMAGE_TAG}"
+            DST="${ECR_REGISTRY}/ctdl-xtra-sandbox/${SERVICE}:${IMAGE_TAG}"
+            echo "Copying ${SRC} → ${DST}"
+            crane copy "${SRC}" "${DST}"
+          done
 
       - name: Configure kubeconfig
         run: aws eks update-kubeconfig --name ctdl-xtra-sandbox --region "$AWS_REGION" --alias ctdl-xtra-sandbox
@@ -52,4 +68,4 @@ jobs:
         run: bash infra/terraform/k8s-manifests/sandbox/app/deploy-app.sh
 
       - name: Summary
-        run: echo "### Deployed \`${{ inputs.image_tag }}\` to SANDBOX" >> "$GITHUB_STEP_SUMMARY"
+        run: echo "### Promoted \`${{ inputs.image_tag }}\` TEST → SANDBOX" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,8 +92,8 @@ jobs:
           file: Dockerfile
           push: true
           tags: |
-            ${{ env.ECR_REGISTRY }}/ctdl-xtra-sandbox/api:${{ steps.tag.outputs.value }}
-            ${{ env.ECR_REGISTRY }}/ctdl-xtra-sandbox/api:main-latest
+            ${{ env.ECR_REGISTRY }}/ctdl-xtra-test/api:${{ steps.tag.outputs.value }}
+            ${{ env.ECR_REGISTRY }}/ctdl-xtra-test/api:main-latest
           cache-from: type=gha,scope=api
           cache-to: type=gha,mode=max,scope=api
 
@@ -104,10 +104,10 @@ jobs:
           file: worker.Dockerfile
           push: true
           tags: |
-            ${{ env.ECR_REGISTRY }}/ctdl-xtra-sandbox/worker:${{ steps.tag.outputs.value }}
-            ${{ env.ECR_REGISTRY }}/ctdl-xtra-sandbox/worker:main-latest
+            ${{ env.ECR_REGISTRY }}/ctdl-xtra-test/worker:${{ steps.tag.outputs.value }}
+            ${{ env.ECR_REGISTRY }}/ctdl-xtra-test/worker:main-latest
           cache-from: type=gha,scope=worker
           cache-to: type=gha,mode=max,scope=worker
 
       - name: Summary
-        run: echo "### Published \`${{ steps.tag.outputs.value }}\` to SANDBOX ECR" >> "$GITHUB_STEP_SUMMARY"
+        run: echo "### Published \`${{ steps.tag.outputs.value }}\` to TEST ECR" >> "$GITHUB_STEP_SUMMARY"

--- a/CI-CD.md
+++ b/CI-CD.md
@@ -12,11 +12,17 @@ feature/* or fix/*
        │  Merge to main (automatic)
        ▼
   [Release workflow]
-  Build images → push to SANDBOX ECR
+  Build images → push to TEST ECR
+       │
+       │  Automatic (workflow_run on Release success)
+       ▼
+  [Deploy to TEST]
+  envsubst + kubectl apply → ctdl-xtra-test cluster
        │
        │  Manual trigger
        ▼
   [Promote to SANDBOX]
+  Copy image TEST ECR → SANDBOX ECR (no rebuild)
   envsubst + kubectl apply → ctdl-xtra-sandbox cluster
        │
        │  Manual trigger (exact sha tag required)
@@ -28,7 +34,7 @@ feature/* or fix/*
 
 All development happens on short-lived branches off `main`. There is no long-lived branch — environment promotion is controlled through GitHub Actions workflows, not through git branches.
 
-Per the xTRA Design Document, a TEST tier will be added between merge and SANDBOX. Until that exists, builds land directly in SANDBOX.
+This mirrors the environment model in the xTRA Design Document: `DEVELOPMENT → TEST → SANDBOX → PRODUCTION`.
 
 ---
 
@@ -46,15 +52,15 @@ Runs on every PR. Blocks merge if any job fails.
 
 ### Build Base Image (`build-base.yml`) — Push to `main` (path-filtered)
 
-Triggers only when `base.Dockerfile` changes. Builds the shared base image (system Chrome, fonts, pm2, pnpm, pre-downloaded Chrome binaries) and pushes to `ctdl-xtra-sandbox/base:latest`. Both `Dockerfile` and `worker.Dockerfile` `FROM` this base, so app builds skip the heavy apt + Chrome install.
+Triggers only when `base.Dockerfile` changes. Builds the shared base image (system Chrome, fonts, pm2, pnpm, pre-downloaded Chrome binaries) and pushes to `ctdl-xtra-test/base:latest`. Both `Dockerfile` and `worker.Dockerfile` `FROM` this base, so app builds skip the heavy apt + Chrome install.
 
-The base image lives in the build-target env's own ECR namespace (currently sandbox). Production never pulls from it — base layers are baked into the api/worker image manifests at `docker build` time, so the promoted images are self-contained.
+The base image lives in TEST's ECR namespace because that's where builds happen. SANDBOX and PRODUCTION never pull from it — base layers are baked into the api/worker image manifests at `docker build` time, so promoted images are self-contained.
 
 ### Release (`release.yml`) — Push to `main`
 
 Runs automatically on every merge to `main`. Lint and Test run in parallel (non-blocking via `continue-on-error`); `publish` runs independently.
 
-Produces two image tags per service and pushes to SANDBOX ECR:
+Produces two image tags per service and pushes to TEST ECR:
 
 | Tag | Purpose |
 |-----|---------|
@@ -62,16 +68,24 @@ Produces two image tags per service and pushes to SANDBOX ECR:
 | `main-latest` | Floating tag, always points to the latest main build |
 
 ECR repositories written to:
-- `ctdl-xtra-sandbox/api`
-- `ctdl-xtra-sandbox/worker`
+- `ctdl-xtra-test/api`
+- `ctdl-xtra-test/worker`
+
+### Deploy to TEST (`deploy-test.yml`) — Automatic on Release success
+
+Triggered by `workflow_run` after `Release` completes successfully (also runnable manually via `workflow_dispatch`). Resolves the EFS file system id for `ctdl-xtra-test-files` and runs `deploy-app.sh` against the `ctdl-xtra-test` cluster. The deploy target is the same `sha-<7char>` tag the release just produced.
+
+This is the "automatic when possible" deployment the design doc specifies for TEST.
 
 ### Promote to SANDBOX (`promote-sandbox.yml`) — Manual
 
 Go to **Actions → Promote to SANDBOX → Run workflow**.
 
-Input: `image_tag` (default: `main-latest`). Use a `sha-*` tag to deploy a specific commit.
+Input: `image_tag` (**required**, must be an exact `sha-*` tag).
 
-Looks up the sandbox EFS file system id, then runs `deploy-app.sh` with `IMAGE_TAG` and `EFS_FS_ID` set. `envsubst`s both into the manifests and `kubectl apply`s the full set on `ctdl-xtra-sandbox`.
+Steps:
+1. `crane copy` the image manifest+layers from TEST ECR to SANDBOX ECR under the same `sha-*` tag.
+2. Runs `deploy-app.sh` against `ctdl-xtra-sandbox` — envsubst + apply.
 
 ### Promote to PRODUCTION (`promote-production.yml`) — Manual
 
@@ -80,7 +94,7 @@ Go to **Actions → Promote to PRODUCTION → Run workflow**.
 Input: `image_tag` (**required**, must be an exact `sha-*` tag).
 
 Steps:
-1. `crane copy` the image manifest+layers from SANDBOX ECR to PRODUCTION ECR under the same `sha-*` tag (no Docker pull/push, same digest guaranteed).
+1. `crane copy` the image manifest+layers from SANDBOX ECR to PRODUCTION ECR under the same `sha-*` tag.
 2. Runs `deploy-app.sh` against `ctdl-xtra-prod` — envsubst + apply.
 
 ECR repositories written to:
@@ -91,13 +105,13 @@ ECR repositories written to:
 
 ## Deployment Model
 
-Manifests in `infra/terraform/k8s-manifests/{sandbox,production}/app/` are **templates**, not state snapshots. The image reference is left as a placeholder:
+Manifests in `infra/terraform/k8s-manifests/{test,sandbox,production}/app/` are **templates**, not state snapshots. The image reference is left as a placeholder:
 
 ```yaml
 image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra/api:${IMAGE_TAG}
 ```
 
-At deploy time, `deploy-app.sh` substitutes `${IMAGE_TAG}` with the requested tag and applies the manifest. Sandbox additionally templates `${EFS_FS_ID}` in `storage.yaml`. Consequences:
+At deploy time, `deploy-app.sh` substitutes `${IMAGE_TAG}` with the requested tag and applies the manifest. TEST and SANDBOX additionally template `${EFS_FS_ID}` in `storage.yaml`. Consequences:
 
 - **Cluster state = last successful workflow run.** Workflow run history is deployment history.
 - **No `kubectl set image`.** Apply is the only deployment mechanism, so manifest edits (resource limits, env vars, probes) flow through the same path as image changes.
@@ -109,10 +123,10 @@ At deploy time, `deploy-app.sh` substitutes `${IMAGE_TAG}` with the requested ta
 
 ## Key Principles
 
-- **Build once.** Images are built only on merge to `main`. Promotion to production copies via `crane`; the image is never rebuilt and the digest never changes.
-- **Immutable tags.** `sha-*` tags are never overwritten. Only `main-latest` floats (sandbox only).
+- **Build once.** Images are built only on merge to `main`. Every promotion copies via `crane`; the image is never rebuilt and the digest never changes from TEST through PRODUCTION.
+- **Immutable tags.** `sha-*` tags are never overwritten. Only `main-latest` floats (TEST only).
 - **Specific sha in production.** Production deploys always specify an exact `sha-*` tag.
-- **Manual gates.** Both sandbox and production deploys require a human to trigger them in GitHub Actions.
+- **Manual gates above TEST.** TEST auto-deploys; SANDBOX and PRODUCTION require a human to trigger.
 - **OIDC auth.** GitHub Actions assumes the `ctdl-xtra-github-actions-ci` IAM role via OIDC (no stored AWS credentials). The role ARN is stored as the `AWS_ROLE_ARN` repository secret.
 
 ---
@@ -121,7 +135,8 @@ At deploy time, `deploy-app.sh` substitutes `${IMAGE_TAG}` with the requested ta
 
 | Environment | EKS Cluster | ECR prefix | Domain |
 |-------------|-------------|------------|--------|
+| Test | `ctdl-xtra-test` | `ctdl-xtra-test/*` | `xtra-test.credentialengineregistry.org` |
 | Sandbox | `ctdl-xtra-sandbox` | `ctdl-xtra-sandbox/*` | `xtra-sandbox.credentialengineregistry.org` |
 | Production | `ctdl-xtra-prod` | `ctdl-xtra/*` | `xtra.credentialengineregistry.org` |
 
-Terraform for the IAM role, OIDC provider, and shared `ctdl-xtra-base` ECR lives in [`infra/terraform/github-ci-oidc/`](infra/terraform/github-ci-oidc/).
+Terraform for the IAM role and OIDC provider lives in [`infra/terraform/github-ci-oidc/`](infra/terraform/github-ci-oidc/).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra-sandbox/base:latest
+ARG BASE_IMAGE=996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra-test/base:latest
 FROM ${BASE_IMAGE}
 
 ENV VITE_API_URL="$VITE_API_URL"

--- a/INFRASTRUCTURE-SUMMARY.md
+++ b/INFRASTRUCTURE-SUMMARY.md
@@ -2,39 +2,40 @@
 
 Quick reference for app developers — endpoints, names, and how to find/change things in each environment.
 
-> Per the xTRA Design Document, the target environment chain is `TEST → SANDBOX → PRODUCTION`. TEST is not yet built; until then, builds land directly in SANDBOX.
+The environment chain follows the xTRA Design Document: `DEVELOPMENT → TEST → SANDBOX → PRODUCTION`.
 
 ## Environments
 
-| | Sandbox | Production |
-|---|---|---|
-| **App URL** | `https://xtra-sandbox.credentialengineregistry.org` | `https://xtra.credentialengineregistry.org` |
-| **EKS cluster** | `ctdl-xtra-sandbox` | `ctdl-xtra-prod` |
-| **K8s namespace** | `ctdl-xtra` | `ctdl-xtra` |
-| **AWS region** | `us-east-1` | `us-east-1` |
-| **AWS account** | `996810415034` | `996810415034` |
+| | Test | Sandbox | Production |
+|---|---|---|---|
+| **App URL** | `https://xtra-test.credentialengineregistry.org` | `https://xtra-sandbox.credentialengineregistry.org` | `https://xtra.credentialengineregistry.org` |
+| **EKS cluster** | `ctdl-xtra-test` | `ctdl-xtra-sandbox` | `ctdl-xtra-prod` |
+| **K8s namespace** | `ctdl-xtra` | `ctdl-xtra` | `ctdl-xtra` |
+| **VPC CIDR** | `10.42.0.0/16` | `10.41.0.0/16` | `10.40.0.0/16` |
+| **AWS region** | `us-east-1` | `us-east-1` | `us-east-1` |
+| **AWS account** | `996810415034` | `996810415034` | `996810415034` |
 
 ## Container images (ECR)
 
-| | Sandbox | Production |
-|---|---|---|
-| API repo | `ctdl-xtra-sandbox/api` | `ctdl-xtra/api` |
-| Worker repo | `ctdl-xtra-sandbox/worker` | `ctdl-xtra/worker` |
-| Base image | `ctdl-xtra-sandbox/base` (owned by sandbox; built once, consumed by Dockerfiles at build time) | N/A — base layers are embedded in the promoted api/worker images |
-| Image tag pattern | `sha-<7char>`, `main-latest` (floats) | `sha-<7char>` only |
+| | Test | Sandbox | Production |
+|---|---|---|---|
+| API repo | `ctdl-xtra-test/api` | `ctdl-xtra-sandbox/api` | `ctdl-xtra/api` |
+| Worker repo | `ctdl-xtra-test/worker` | `ctdl-xtra-sandbox/worker` | `ctdl-xtra/worker` |
+| Base image | `ctdl-xtra-test/base` (owned by test; built once, consumed by Dockerfiles at build time) | N/A — base layers are embedded in the promoted api/worker images | N/A — same |
+| Image tag pattern | `sha-<7char>`, `main-latest` (floats) | `sha-<7char>` only (crane-copied from test) | `sha-<7char>` only (crane-copied from sandbox) |
 
-All images are at `996810415034.dkr.ecr.us-east-1.amazonaws.com/<repo>:<tag>`. Promotion never rebuilds — the production image is the byte-for-byte same image as sandbox.
+All images are at `996810415034.dkr.ecr.us-east-1.amazonaws.com/<repo>:<tag>`. Promotion never rebuilds — each tier is the byte-for-byte same image as the tier upstream.
 
 ## Database (RDS PostgreSQL)
 
-| | Sandbox | Production |
-|---|---|---|
-| Endpoint | TBD after first apply (see `terraform output rds_endpoint` in `envs/sandbox`) | `ctdl-xtra-prod-postgres.cwdkv5tua6nq.us-east-1.rds.amazonaws.com:5432` |
-| Instance class | `db.t4g.small` | `db.t4g.small` |
-| DB name | `ctdl_xtra` | `ctdl_xtra` |
-| Engine | PostgreSQL 17.5 | PostgreSQL 17.5 |
-| HA | Single-AZ | Multi-AZ |
-| Reachable from | inside cluster only (private subnets) | inside cluster only (private subnets) |
+| | Test | Sandbox | Production |
+|---|---|---|---|
+| Endpoint | `ctdl-xtra-test-postgres.cwdkv5tua6nq.us-east-1.rds.amazonaws.com:5432` | `ctdl-xtra-sandbox-postgres.cwdkv5tua6nq.us-east-1.rds.amazonaws.com:5432` | `ctdl-xtra-prod-postgres.cwdkv5tua6nq.us-east-1.rds.amazonaws.com:5432` |
+| Instance class | `db.t4g.small` | `db.t4g.small` | `db.t4g.small` |
+| DB name | `ctdl_xtra` | `ctdl_xtra` | `ctdl_xtra` |
+| Engine | PostgreSQL 17.5 | PostgreSQL 17.5 | PostgreSQL 17.5 |
+| HA | Single-AZ | Single-AZ | Multi-AZ |
+| Reachable from | inside cluster only (private subnets) | inside cluster only (private subnets) | inside cluster only (private subnets) |
 
 `DATABASE_URL` (full connection string with credentials) is injected as an env var via the app secret — never hardcoded.
 
@@ -59,10 +60,10 @@ Runs **inside the cluster** as a StatefulSet (not AWS ElastiCache).
 
 Stored in **AWS Secrets Manager**, synced into the cluster by the External Secrets operator. Pods read them as plain env vars (`envFrom: secretRef`).
 
-| Purpose | Secret name (sandbox) | Secret name (prod) |
-|---|---|---|
-| App env vars | `ctdl-xtra/sandbox/app` | `ctdl-xtra/prod/app` |
-| Redis password | `ctdl-xtra/sandbox/redis` | `ctdl-xtra/prod/redis` |
+| Purpose | Test | Sandbox | Prod |
+|---|---|---|---|
+| App env vars | `ctdl-xtra/test/app` | `ctdl-xtra/sandbox/app` | `ctdl-xtra/prod/app` |
+| Redis password | `ctdl-xtra/test/redis` | `ctdl-xtra/sandbox/redis` | `ctdl-xtra/prod/redis` |
 
 To **add or change an app env var**, edit the app secret in Secrets Manager. Within ~5 min the External Secrets operator syncs it into the K8s `ctdl-xtra-app-env` Secret. Pods need a restart to see the change (`kubectl -n ctdl-xtra rollout restart deployment/ctdl-xtra-api deployment/ctdl-xtra-worker`).
 
@@ -81,12 +82,12 @@ Current keys in the app secret:
 
 In each cluster's `ctdl-xtra` namespace:
 
-| Workload | Type | Sandbox replicas | Prod replicas |
-|---|---|---|---|
-| `ctdl-xtra-api` | Deployment | 1 | 2 |
-| `ctdl-xtra-worker` | Deployment | 1 | 2 |
-| `redis` | StatefulSet | 1 | 1 |
-| `ctdl-xtra-db-migrate` | Job (one-shot per deploy) | — | — |
+| Workload | Type | Test replicas | Sandbox replicas | Prod replicas |
+|---|---|---|---|---|
+| `ctdl-xtra-api` | Deployment | 1 | 1 | 2 |
+| `ctdl-xtra-worker` | Deployment | 1 | 1 | 2 |
+| `redis` | StatefulSet | 1 | 1 | 1 |
+| `ctdl-xtra-db-migrate` | Job (one-shot per deploy) | — | — | — |
 
 The migrate Job runs `drizzle-kit migrate` before each rollout via the deploy script.
 
@@ -94,6 +95,6 @@ The migrate Job runs `drizzle-kit migrate` before each rollout via the deploy sc
 
 You don't run `kubectl` to deploy — use the GitHub Actions workflows. See [CI-CD.md](CI-CD.md) for the full pipeline. TL;DR:
 
-- Merge to `main` → image auto-built and pushed to sandbox ECR
-- Run **Promote to SANDBOX** workflow → image deployed to sandbox cluster
-- Run **Promote to PRODUCTION** workflow with the same `sha-*` tag → same image copied to prod ECR and deployed
+- Merge to `main` → image built and pushed to test ECR → auto-deployed to test
+- Run **Promote to SANDBOX** with the `sha-*` tag → image crane-copied test→sandbox and deployed
+- Run **Promote to PRODUCTION** with the same `sha-*` tag → image crane-copied sandbox→prod and deployed

--- a/infra/terraform/envs/test/.terraform.lock.hcl
+++ b/infra/terraform/envs/test/.terraform.lock.hcl
@@ -1,0 +1,46 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.50.0"
+  constraints = "~> 5.50.0"
+  hashes = [
+    "h1:LevuTzPS4S7t+Vh6Kpz77pBNDAwChaos91/6+CVnD4w=",
+    "zh:19be42f5a545d6712dee4bdb704b018d23bacf5d902ac3cb061eb1750dfe6a20",
+    "zh:1d880bdba95ce96efde37e5bcf457a57df2c1effa9b47bc67fa29c1a264ae53b",
+    "zh:1e9c78e324d7492be5e7744436ed71d66fe4eca3fb6af07a28efd0d1e3bf7640",
+    "zh:27ac672aa61b3795931561fdbe4a306ad1132af517d7711c14569429b2cc694f",
+    "zh:3b978423dead02f9a98d25de118adf264a2331acdc4550ea93bed01feabc12e7",
+    "zh:490d7eb4b922ba1b57e0ab8dec1a08df6517485febcab1e091fd6011281c3472",
+    "zh:64e7c84e18dac1af5778d6f516e01a46f9c91d710867c39fbc7efa3cd972dc62",
+    "zh:73867ac2956dcdd377121b3aa8fe2e1085e77fae9b61d018f56a863277ea4b6e",
+    "zh:7ed899d0d5c49f009b445d7816e4bf702d9c48205c24cf884cd2ae0247160455",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9b93784b3fb13d08cf95a4131c49b56bf7e1cd35daad6156b3658a89ce6fb58f",
+    "zh:b29d77eb75de474e46eb47e539c48916628d85599bcf14e5cc500b14a4578e75",
+    "zh:bbd9cec8ca705452e4a3d21d56474eacb8cc7b1b74b7f310fdea4bdcffebab32",
+    "zh:c352eb3169efa0e27a29b99a2630e8298710a084453c519caa39e5972ff6d1fc",
+    "zh:e32f4744b43be1708b309a734e0ac10b5c0f9f92e5849298cf1a90f2b906f6f3",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.6"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/infra/terraform/envs/test/app-deps.tf
+++ b/infra/terraform/envs/test/app-deps.tf
@@ -7,7 +7,7 @@ locals {
     EXTRACTION_FILES_PATH = "/data/extractions"
     CLIENT_PATH           = "/app/public"
     FRONTEND_URL          = "https://${var.app_domain_name}"
-    NODE_ENV              = "sandbox"
+    NODE_ENV              = "test"
     PORT                  = "3000"
   }
 }
@@ -17,7 +17,7 @@ locals {
 # ---------------------------------------------------------------
 
 resource "aws_ecr_repository" "app" {
-  for_each = toset(["api", "worker"])
+  for_each = toset(["api", "worker", "base"])
 
   name                 = "${local.cluster_name}/${each.key}"
   image_tag_mutability = "MUTABLE"
@@ -44,7 +44,7 @@ resource "aws_ecr_lifecycle_policy" "app" {
     rules = [
       {
         rulePriority = 1
-        description  = "Keep the last 50 sandbox images"
+        description  = "Keep the last 50 test images"
         selection = {
           tagStatus     = "tagged"
           tagPrefixList = ["sha-", "main-latest"]
@@ -178,12 +178,12 @@ resource "random_password" "redis_password" {
 }
 
 resource "aws_secretsmanager_secret" "redis" {
-  name                    = "ctdl-xtra/sandbox/redis"
+  name                    = "ctdl-xtra/test/redis"
   description             = "Redis auth for ${local.cluster_name} in-cluster pod"
   recovery_window_in_days = 0
 
   tags = merge(local.common_tags, {
-    Name = "ctdl-xtra/sandbox/redis"
+    Name = "ctdl-xtra/test/redis"
   })
 }
 

--- a/infra/terraform/envs/test/backend.tf
+++ b/infra/terraform/envs/test/backend.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.50.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+
+  backend "s3" {
+    bucket  = "terraform-state-o1r8"
+    key     = "ctdl-xtra/envs/test/tfstate"
+    region  = "us-east-1"
+    encrypt = true
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+
+  default_tags {
+    tags = local.common_tags
+  }
+}

--- a/infra/terraform/envs/test/main.tf
+++ b/infra/terraform/envs/test/main.tf
@@ -1,0 +1,70 @@
+locals {
+  project_name = "ctdl-xtra"
+  env          = "test"
+  cluster_name = "${local.project_name}-${local.env}"
+
+  common_tags = {
+    project     = local.project_name
+    environment = local.env
+    managed-by  = "terraform"
+  }
+}
+
+# ---------------------------------------------------------------
+# Networking
+# ---------------------------------------------------------------
+
+module "vpc" {
+  source = "../../modules/vpc"
+
+  name                   = local.cluster_name
+  vpc_cidr               = var.vpc_cidr
+  public_subnet_cidrs    = var.public_subnet_cidrs
+  private_subnet_cidrs   = var.private_subnet_cidrs
+  azs                    = var.azs
+  single_nat_gateway     = var.single_nat_gateway
+  nat_eip_allocation_ids = var.nat_eip_allocation_ids
+  enable_flow_logs       = var.enable_vpc_flow_logs
+  common_tags            = local.common_tags
+
+  public_subnet_tags = {
+    "kubernetes.io/cluster/${local.cluster_name}" = "shared"
+    "kubernetes.io/role/elb"                      = "1"
+  }
+
+  private_subnet_tags = {
+    "kubernetes.io/cluster/${local.cluster_name}" = "shared"
+    "kubernetes.io/role/internal-elb"             = "1"
+  }
+}
+
+# ---------------------------------------------------------------
+# EKS
+# ---------------------------------------------------------------
+
+module "eks" {
+  source = "../../modules/eks"
+
+  cluster_name                                = local.cluster_name
+  cluster_version                             = var.cluster_version
+  cluster_service_ipv4_cidr                   = var.cluster_service_ipv4_cidr
+  cluster_endpoint_private_access             = var.cluster_endpoint_private_access
+  cluster_endpoint_public_access              = var.cluster_endpoint_public_access
+  cluster_endpoint_public_access_cidrs        = var.cluster_endpoint_public_access_cidrs
+  authentication_mode                         = var.authentication_mode
+  bootstrap_cluster_creator_admin_permissions = var.bootstrap_cluster_creator_admin_permissions
+  cluster_admin_principal_arns                = var.cluster_admin_principal_arns
+  enable_cluster_secret_encryption            = var.enable_cluster_secret_encryption
+  private_subnet_ids                          = module.vpc.private_subnet_ids
+  route53_hosted_zone_id                      = var.route53_hosted_zone_id
+  app_namespace                               = var.app_namespace
+  additional_app_namespaces                   = var.additional_app_namespaces
+  app_service_account                         = var.app_service_account
+  application_irsa_role_name                  = "${local.cluster_name}-application-irsa-role"
+  application_irsa_policy_name                = "${local.cluster_name}-application-s3-policy"
+  application_s3_bucket_names                 = var.application_s3_bucket_names
+  external_secrets_secret_name_prefixes       = var.external_secrets_secret_name_prefixes
+  external_secrets_ssm_parameter_prefixes     = var.external_secrets_ssm_parameter_prefixes
+  enable_efs_csi_driver                       = var.enable_efs_csi_driver
+  common_tags                                 = local.common_tags
+}

--- a/infra/terraform/envs/test/node-groups.tf
+++ b/infra/terraform/envs/test/node-groups.tf
@@ -1,0 +1,80 @@
+resource "aws_eks_node_group" "system" {
+  cluster_name    = module.eks.cluster_id
+  node_group_name = "${local.cluster_name}-system"
+  node_role_arn   = module.eks.nodegroup_role_arn
+  subnet_ids      = module.vpc.private_subnet_ids
+
+  ami_type       = "AL2023_x86_64_STANDARD"
+  capacity_type  = "ON_DEMAND"
+  disk_size      = var.system_node_disk_size
+  instance_types = var.system_node_instance_types
+
+  labels = {
+    env      = local.env
+    nodepool = "system"
+  }
+
+  scaling_config {
+    desired_size = var.system_node_desired_size
+    max_size     = var.system_node_max_size
+    min_size     = var.system_node_min_size
+  }
+
+  update_config {
+    max_unavailable = 1
+  }
+
+  lifecycle {
+    ignore_changes = [
+      scaling_config[0].desired_size
+    ]
+  }
+
+  tags = merge(local.common_tags, {
+    "k8s.io/cluster-autoscaler/${local.cluster_name}" = "owned"
+    "k8s.io/cluster-autoscaler/enabled"               = "true"
+  })
+
+  depends_on = [module.vpc]
+}
+
+resource "aws_eks_node_group" "app" {
+  cluster_name    = module.eks.cluster_id
+  node_group_name = "${local.cluster_name}-app"
+  node_role_arn   = module.eks.nodegroup_role_arn
+  subnet_ids      = module.vpc.private_subnet_ids
+
+  ami_type       = "AL2023_x86_64_STANDARD"
+  capacity_type  = "ON_DEMAND"
+  disk_size      = var.app_node_disk_size
+  instance_types = var.app_node_instance_types
+
+  labels = {
+    env      = local.env
+    nodepool = "app"
+    workload = local.project_name
+  }
+
+  scaling_config {
+    desired_size = var.app_node_desired_size
+    max_size     = var.app_node_max_size
+    min_size     = var.app_node_min_size
+  }
+
+  update_config {
+    max_unavailable = 1
+  }
+
+  lifecycle {
+    ignore_changes = [
+      scaling_config[0].desired_size
+    ]
+  }
+
+  tags = merge(local.common_tags, {
+    "k8s.io/cluster-autoscaler/${local.cluster_name}" = "owned"
+    "k8s.io/cluster-autoscaler/enabled"               = "true"
+  })
+
+  depends_on = [module.vpc]
+}

--- a/infra/terraform/envs/test/outputs.tf
+++ b/infra/terraform/envs/test/outputs.tf
@@ -1,0 +1,99 @@
+output "cluster_name" {
+  description = "Test EKS cluster name."
+  value       = module.eks.cluster_id
+}
+
+output "cluster_endpoint" {
+  description = "Test EKS API endpoint."
+  value       = module.eks.cluster_endpoint
+}
+
+output "cluster_oidc_issuer_url" {
+  description = "Test EKS OIDC issuer URL."
+  value       = module.eks.cluster_oidc_issuer_url
+}
+
+output "vpc_id" {
+  description = "Test VPC ID."
+  value       = module.vpc.vpc_id
+}
+
+output "vpc_cidr_block" {
+  description = "Test VPC CIDR block."
+  value       = module.vpc.vpc_cidr_block
+}
+
+output "private_subnet_ids" {
+  description = "Test private subnet IDs."
+  value       = module.vpc.private_subnet_ids
+}
+
+output "public_subnet_ids" {
+  description = "Test public subnet IDs."
+  value       = module.vpc.public_subnet_ids
+}
+
+output "system_node_group_name" {
+  description = "System managed node group name."
+  value       = aws_eks_node_group.system.node_group_name
+}
+
+output "app_node_group_name" {
+  description = "Application managed node group name."
+  value       = aws_eks_node_group.app.node_group_name
+}
+
+output "application_irsa_role_arn" {
+  description = "Application IRSA role ARN."
+  value       = module.eks.application_irsa_role_arn
+}
+
+output "cert_manager_irsa_role_arn" {
+  description = "cert-manager IRSA role ARN."
+  value       = module.eks.cert_manager_irsa_role_arn
+}
+
+output "external_secrets_irsa_role_arn" {
+  description = "External Secrets Operator IRSA role ARN."
+  value       = module.eks.external_secrets_irsa_role_arn
+}
+
+output "cluster_autoscaler_irsa_role_arn" {
+  description = "Cluster Autoscaler IRSA role ARN."
+  value       = module.eks.cluster_autoscaler_irsa_role_arn
+}
+
+output "ebs_csi_irsa_role_arn" {
+  description = "EBS CSI driver IRSA role ARN."
+  value       = module.eks.ebs_csi_irsa_role_arn
+}
+
+output "efs_csi_role_arn" {
+  description = "EFS CSI driver Pod Identity role ARN."
+  value       = module.eks.efs_csi_role_arn
+}
+
+output "api_ecr_repository_url" {
+  description = "API image ECR repository URL."
+  value       = aws_ecr_repository.app["api"].repository_url
+}
+
+output "worker_ecr_repository_url" {
+  description = "Worker image ECR repository URL."
+  value       = aws_ecr_repository.app["worker"].repository_url
+}
+
+output "app_secret_name" {
+  description = "Secrets Manager secret consumed by the xTRA app."
+  value       = aws_secretsmanager_secret.app.name
+}
+
+output "rds_endpoint" {
+  description = "PostgreSQL endpoint."
+  value       = aws_db_instance.app.endpoint
+}
+
+output "efs_file_system_id" {
+  description = "EFS file system ID for extraction files."
+  value       = aws_efs_file_system.app.id
+}

--- a/infra/terraform/envs/test/terraform.tfvars
+++ b/infra/terraform/envs/test/terraform.tfvars
@@ -1,0 +1,57 @@
+vpc_cidr             = "10.42.0.0/16"
+public_subnet_cidrs  = ["10.42.1.0/24", "10.42.2.0/24"]
+private_subnet_cidrs = ["10.42.11.0/24", "10.42.12.0/24"]
+azs                  = ["us-east-1a", "us-east-1b"]
+
+single_nat_gateway   = true
+enable_vpc_flow_logs = true
+
+cluster_version = "1.35"
+
+cluster_endpoint_private_access      = true
+cluster_endpoint_public_access       = true
+cluster_endpoint_public_access_cidrs = ["0.0.0.0/0"]
+
+authentication_mode                         = "API_AND_CONFIG_MAP"
+bootstrap_cluster_creator_admin_permissions = true
+cluster_admin_principal_arns                = ["arn:aws:iam::996810415034:role/ctdl-xtra-github-actions-ci"]
+
+route53_hosted_zone_id           = "Z1N75467P1FUL5"
+enable_cluster_secret_encryption = true
+enable_efs_csi_driver            = true
+
+app_namespace       = "ctdl-xtra"
+app_service_account = "ctdl-xtra"
+
+external_secrets_secret_name_prefixes = [
+  "ctdl-xtra/test",
+  "ctdl-xtra-test"
+]
+
+external_secrets_ssm_parameter_prefixes = [
+  "ctdl-xtra/test"
+]
+
+app_domain_name = "xtra-test.credentialengineregistry.org"
+app_secret_name = "ctdl-xtra/test/app"
+
+db_name                  = "ctdl_xtra"
+db_username              = "ctdlxtra"
+db_engine_version        = "17.5"
+db_instance_class        = "db.t4g.small"
+db_allocated_storage     = 20
+db_max_allocated_storage = 100
+db_multi_az              = false
+db_backup_retention_days = 7
+
+system_node_instance_types = ["t3.medium"]
+system_node_min_size       = 1
+system_node_max_size       = 2
+system_node_desired_size   = 1
+system_node_disk_size      = 30
+
+app_node_instance_types = ["t3.medium"]
+app_node_min_size       = 1
+app_node_max_size       = 2
+app_node_desired_size   = 1
+app_node_disk_size      = 50

--- a/infra/terraform/envs/test/variables.tf
+++ b/infra/terraform/envs/test/variables.tf
@@ -1,0 +1,276 @@
+# ---------------------------------------------------------------------------
+# Networking
+# ---------------------------------------------------------------------------
+
+variable "vpc_cidr" {
+  description = "Test VPC CIDR block."
+  type        = string
+}
+
+variable "public_subnet_cidrs" {
+  description = "Test public subnet CIDR blocks."
+  type        = list(string)
+}
+
+variable "private_subnet_cidrs" {
+  description = "Test private subnet CIDR blocks."
+  type        = list(string)
+}
+
+variable "azs" {
+  description = "Availability zones for the test cluster."
+  type        = list(string)
+}
+
+variable "single_nat_gateway" {
+  description = "Use one shared NAT gateway instead of one NAT gateway per public subnet."
+  type        = bool
+  default     = true
+}
+
+variable "nat_eip_allocation_ids" {
+  description = "Existing Elastic IP allocation IDs to use for NAT gateways."
+  type        = list(string)
+  default     = []
+}
+
+variable "enable_vpc_flow_logs" {
+  description = "Enable VPC flow logs for test network visibility."
+  type        = bool
+  default     = true
+}
+
+# ---------------------------------------------------------------------------
+# EKS
+# ---------------------------------------------------------------------------
+
+variable "cluster_version" {
+  description = "Kubernetes version for the test EKS cluster."
+  type        = string
+}
+
+variable "cluster_service_ipv4_cidr" {
+  description = "Service IPv4 CIDR for the Kubernetes cluster."
+  type        = string
+  default     = null
+}
+
+variable "cluster_endpoint_private_access" {
+  description = "Whether the private EKS API endpoint is enabled."
+  type        = bool
+  default     = true
+}
+
+variable "cluster_endpoint_public_access" {
+  description = "Whether the public EKS API endpoint is enabled."
+  type        = bool
+  default     = true
+}
+
+variable "cluster_endpoint_public_access_cidrs" {
+  description = "CIDR ranges allowed to access the public EKS API endpoint."
+  type        = list(string)
+}
+
+variable "authentication_mode" {
+  description = "EKS authentication mode."
+  type        = string
+  default     = "API_AND_CONFIG_MAP"
+}
+
+variable "bootstrap_cluster_creator_admin_permissions" {
+  description = "Grant the cluster creator admin permissions at bootstrap."
+  type        = bool
+  default     = true
+}
+
+variable "cluster_admin_principal_arns" {
+  description = "Additional IAM principal ARNs to grant cluster admin access."
+  type        = list(string)
+  default     = []
+}
+
+variable "enable_cluster_secret_encryption" {
+  description = "Encrypt Kubernetes secrets using a customer-managed KMS key."
+  type        = bool
+  default     = true
+}
+
+variable "route53_hosted_zone_id" {
+  description = "Route53 hosted zone ID used by cert-manager DNS validation."
+  type        = string
+}
+
+variable "enable_efs_csi_driver" {
+  description = "Install the AWS EFS CSI driver add-on."
+  type        = bool
+  default     = false
+}
+
+# ---------------------------------------------------------------------------
+# IRSA
+# ---------------------------------------------------------------------------
+
+variable "app_namespace" {
+  description = "Primary Kubernetes namespace for the xTRA workload."
+  type        = string
+  default     = "ctdl-xtra"
+}
+
+variable "additional_app_namespaces" {
+  description = "Additional namespaces that may use the application IRSA role."
+  type        = list(string)
+  default     = []
+}
+
+variable "app_service_account" {
+  description = "Kubernetes service account name for application IRSA."
+  type        = string
+  default     = "ctdl-xtra"
+}
+
+variable "application_s3_bucket_names" {
+  description = "S3 buckets the xTRA service account can access."
+  type        = list(string)
+  default     = []
+}
+
+variable "external_secrets_secret_name_prefixes" {
+  description = "Secrets Manager name prefixes readable by External Secrets Operator."
+  type        = list(string)
+  default     = ["ctdl-xtra/test", "ctdl-xtra-test"]
+}
+
+variable "external_secrets_ssm_parameter_prefixes" {
+  description = "SSM Parameter Store prefixes readable by External Secrets Operator."
+  type        = list(string)
+  default     = ["ctdl-xtra/test"]
+}
+
+# ---------------------------------------------------------------------------
+# Application dependencies
+# ---------------------------------------------------------------------------
+
+variable "app_domain_name" {
+  description = "Public hostname for the xTRA application."
+  type        = string
+  default     = "xtra-test.credentialengineregistry.org"
+}
+
+variable "app_secret_name" {
+  description = "Secrets Manager JSON secret consumed by the xTRA workload."
+  type        = string
+  default     = "ctdl-xtra/test/app"
+}
+
+variable "db_name" {
+  description = "PostgreSQL database name."
+  type        = string
+  default     = "ctdl_xtra"
+}
+
+variable "db_username" {
+  description = "PostgreSQL master username."
+  type        = string
+  default     = "ctdlxtra"
+}
+
+variable "db_engine_version" {
+  description = "PostgreSQL engine version."
+  type        = string
+  default     = "17.5"
+}
+
+variable "db_instance_class" {
+  description = "PostgreSQL instance class."
+  type        = string
+  default     = "db.t4g.small"
+}
+
+variable "db_allocated_storage" {
+  description = "Initial PostgreSQL storage in GiB."
+  type        = number
+  default     = 20
+}
+
+variable "db_max_allocated_storage" {
+  description = "Maximum PostgreSQL autoscaled storage in GiB."
+  type        = number
+  default     = 100
+}
+
+variable "db_multi_az" {
+  description = "Enable Multi-AZ standby for PostgreSQL."
+  type        = bool
+  default     = false
+}
+
+variable "db_backup_retention_days" {
+  description = "PostgreSQL backup retention in days."
+  type        = number
+  default     = 7
+}
+
+# ---------------------------------------------------------------------------
+# Node groups
+# ---------------------------------------------------------------------------
+
+variable "system_node_instance_types" {
+  description = "Instance types for untainted system nodes."
+  type        = list(string)
+  default     = ["t3.medium"]
+}
+
+variable "system_node_disk_size" {
+  description = "Disk size in GiB for system nodes."
+  type        = number
+  default     = 30
+}
+
+variable "system_node_min_size" {
+  description = "Minimum system node count."
+  type        = number
+  default     = 1
+}
+
+variable "system_node_max_size" {
+  description = "Maximum system node count."
+  type        = number
+  default     = 2
+}
+
+variable "system_node_desired_size" {
+  description = "Desired system node count."
+  type        = number
+  default     = 1
+}
+
+variable "app_node_instance_types" {
+  description = "Instance types for xTRA workload nodes."
+  type        = list(string)
+  default     = ["t3.medium"]
+}
+
+variable "app_node_disk_size" {
+  description = "Disk size in GiB for xTRA workload nodes."
+  type        = number
+  default     = 50
+}
+
+variable "app_node_min_size" {
+  description = "Minimum xTRA workload node count."
+  type        = number
+  default     = 1
+}
+
+variable "app_node_max_size" {
+  description = "Maximum xTRA workload node count."
+  type        = number
+  default     = 2
+}
+
+variable "app_node_desired_size" {
+  description = "Desired xTRA workload node count."
+  type        = number
+  default     = 1
+}

--- a/infra/terraform/github-ci-oidc/main.tf
+++ b/infra/terraform/github-ci-oidc/main.tf
@@ -42,7 +42,7 @@ resource "aws_iam_role" "github_actions_ci" {
 }
 
 # ---------------------------------------------------------------
-# ECR — push to SANDBOX (including base), copy SANDBOX → PRODUCTION
+# ECR — push to TEST (incl. base), promote TEST→SANDBOX→PRODUCTION
 # ---------------------------------------------------------------
 
 resource "aws_iam_policy" "github_actions_ecr" {
@@ -58,7 +58,7 @@ resource "aws_iam_policy" "github_actions_ecr" {
         Resource = "*"
       },
       {
-        Sid    = "SandboxReadWrite"
+        Sid    = "TestReadWrite"
         Effect = "Allow"
         Action = [
           "ecr:BatchCheckLayerAvailability",
@@ -68,6 +68,25 @@ resource "aws_iam_policy" "github_actions_ecr" {
           "ecr:InitiateLayerUpload",
           "ecr:UploadLayerPart",
           "ecr:CompleteLayerUpload",
+          "ecr:DescribeRepositories",
+          "ecr:ListImages",
+          "ecr:DescribeImages",
+        ]
+        Resource = [
+          "arn:aws:ecr:us-east-1:${local.aws_account_id}:repository/ctdl-xtra-test/*",
+        ]
+      },
+      {
+        Sid    = "SandboxPromote"
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:BatchGetImage",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:InitiateLayerUpload",
+          "ecr:UploadLayerPart",
+          "ecr:CompleteLayerUpload",
+          "ecr:PutImage",
           "ecr:DescribeRepositories",
           "ecr:ListImages",
           "ecr:DescribeImages",
@@ -114,6 +133,7 @@ resource "aws_iam_policy" "github_actions_eks" {
         Effect = "Allow"
         Action = "eks:DescribeCluster"
         Resource = [
+          "arn:aws:eks:us-east-1:${local.aws_account_id}:cluster/ctdl-xtra-test",
           "arn:aws:eks:us-east-1:${local.aws_account_id}:cluster/ctdl-xtra-sandbox",
           "arn:aws:eks:us-east-1:${local.aws_account_id}:cluster/ctdl-xtra-prod",
         ]

--- a/infra/terraform/k8s-manifests/test/addons/cluster-autoscaler.yaml
+++ b/infra/terraform/k8s-manifests/test/addons/cluster-autoscaler.yaml
@@ -1,0 +1,128 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::996810415034:role/ctdl-xtra-test-cluster-autoscaler-irsa-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-autoscaler
+rules:
+  - apiGroups: [""]
+    resources: ["events", "endpoints"]
+    verbs: ["create", "patch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["cluster-autoscaler-status", "cluster-autoscaler-priority-expander"]
+    verbs: ["delete", "get", "update", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/eviction"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["pods/status"]
+    verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    resourceNames: ["cluster-autoscaler"]
+    verbs: ["get", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["watch", "list", "get", "update"]
+  - apiGroups: [""]
+    resources: ["namespaces", "pods", "services", "replicationcontrollers", "persistentvolumeclaims", "persistentvolumes"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets", "daemonsets"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["watch", "list"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets", "replicasets", "daemonsets"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses", "csinodes", "csidrivers", "csistoragecapacities", "volumeattachments"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    resourceNames: ["cluster-autoscaler"]
+    verbs: ["get", "update"]
+  - apiGroups: ["resource.k8s.io"]
+    resources: ["resourceclaims", "resourceslices", "deviceclasses"]
+    verbs: ["watch", "list", "get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-autoscaler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-autoscaler
+subjects:
+  - kind: ServiceAccount
+    name: cluster-autoscaler
+    namespace: kube-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    app: cluster-autoscaler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cluster-autoscaler
+  template:
+    metadata:
+      labels:
+        app: cluster-autoscaler
+    spec:
+      serviceAccountName: cluster-autoscaler
+      priorityClassName: system-cluster-critical
+      nodeSelector:
+        nodepool: system
+      containers:
+        - name: cluster-autoscaler
+          image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.35.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - ./cluster-autoscaler
+            - --v=4
+            - --stderrthreshold=info
+            - --cloud-provider=aws
+            - --skip-nodes-with-local-storage=false
+            - --skip-nodes-with-system-pods=false
+            - --expander=least-waste
+            - --balance-similar-node-groups
+            - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/ctdl-xtra-test
+          resources:
+            requests:
+              cpu: 100m
+              memory: 600Mi
+            limits:
+              cpu: 100m
+              memory: 600Mi
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /etc/ssl/certs/ca-certificates.crt
+              readOnly: true
+      volumes:
+        - name: ssl-certs
+          hostPath:
+            path: /etc/ssl/certs/ca-bundle.crt

--- a/infra/terraform/k8s-manifests/test/addons/external-secrets-values.yaml
+++ b/infra/terraform/k8s-manifests/test/addons/external-secrets-values.yaml
@@ -1,0 +1,18 @@
+installCRDs: true
+
+serviceAccount:
+  name: external-secrets
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::996810415034:role/ctdl-xtra-test-external-secrets-irsa-role
+
+env:
+  AWS_REGION: us-east-1
+  AWS_DEFAULT_REGION: us-east-1
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi

--- a/infra/terraform/k8s-manifests/test/addons/ingress-nginx-values.yaml
+++ b/infra/terraform/k8s-manifests/test/addons/ingress-nginx-values.yaml
@@ -1,0 +1,8 @@
+controller:
+  replicaCount: 2
+  nodeSelector:
+    nodepool: system
+  service:
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-type: nlb
+      service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing

--- a/infra/terraform/k8s-manifests/test/addons/install-foundation.sh
+++ b/infra/terraform/k8s-manifests/test/addons/install-foundation.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+CONTEXT="${KUBE_CONTEXT:-ctdl-xtra-test}"
+
+CERT_MANAGER_VERSION="v1.17.1"
+EXTERNAL_SECRETS_VERSION="2.4.1"
+INGRESS_NGINX_VERSION="4.12.1"
+METRICS_SERVER_VERSION="3.12.2"
+
+kubectl --context "${CONTEXT}" apply -f "${ROOT_DIR}/cluster/namespace.yaml"
+kubectl --context "${CONTEXT}" apply -f "${ROOT_DIR}/cluster/storageclass-gp3.yaml"
+
+helm repo add jetstack https://charts.jetstack.io --force-update
+helm repo add external-secrets https://charts.external-secrets.io --force-update
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx --force-update
+helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/ --force-update
+helm repo update
+
+helm upgrade --install cert-manager jetstack/cert-manager \
+  --kube-context "${CONTEXT}" \
+  --namespace cert-manager \
+  --create-namespace \
+  --version "${CERT_MANAGER_VERSION}" \
+  --set installCRDs=true \
+  --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"="arn:aws:iam::996810415034:role/ctdl-xtra-test-cert-manager-irsa-role" \
+  --wait \
+  --timeout 5m
+
+kubectl --context "${CONTEXT}" apply -f "${ROOT_DIR}/cluster/cert-manager-cluster-issuer.yaml"
+
+helm upgrade --install external-secrets external-secrets/external-secrets \
+  --kube-context "${CONTEXT}" \
+  --namespace external-secrets \
+  --create-namespace \
+  --version "${EXTERNAL_SECRETS_VERSION}" \
+  --values "${SCRIPT_DIR}/external-secrets-values.yaml" \
+  --wait \
+  --timeout 5m
+
+kubectl --context "${CONTEXT}" apply -f "${ROOT_DIR}/cluster/cluster-secret-store.yaml"
+
+helm upgrade --install ingress-nginx ingress-nginx/ingress-nginx \
+  --kube-context "${CONTEXT}" \
+  --namespace ingress-nginx \
+  --create-namespace \
+  --version "${INGRESS_NGINX_VERSION}" \
+  --values "${SCRIPT_DIR}/ingress-nginx-values.yaml" \
+  --wait \
+  --timeout 10m
+
+helm upgrade --install metrics-server metrics-server/metrics-server \
+  --kube-context "${CONTEXT}" \
+  --namespace kube-system \
+  --version "${METRICS_SERVER_VERSION}" \
+  --values "${SCRIPT_DIR}/metrics-server-values.yaml" \
+  --wait \
+  --timeout 5m
+
+kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/cluster-autoscaler.yaml"
+kubectl --context "${CONTEXT}" -n kube-system rollout status deployment/cluster-autoscaler --timeout=180s

--- a/infra/terraform/k8s-manifests/test/addons/metrics-server-values.yaml
+++ b/infra/terraform/k8s-manifests/test/addons/metrics-server-values.yaml
@@ -1,0 +1,12 @@
+replicas: 2
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 200Mi
+  limits:
+    cpu: 200m
+    memory: 400Mi
+
+nodeSelector:
+  nodepool: system

--- a/infra/terraform/k8s-manifests/test/app/db-migrate-job.yaml
+++ b/infra/terraform/k8s-manifests/test/app/db-migrate-job.yaml
@@ -1,0 +1,58 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ctdl-xtra-db-migrate
+  namespace: ctdl-xtra
+  labels:
+    app.kubernetes.io/name: ctdl-xtra
+    app.kubernetes.io/component: db-migrate
+    app.kubernetes.io/part-of: ctdl-xtra
+    environment: test
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ctdl-xtra
+        app.kubernetes.io/component: db-migrate
+        app.kubernetes.io/part-of: ctdl-xtra
+        environment: test
+    spec:
+      restartPolicy: Never
+      serviceAccountName: ctdl-xtra
+      nodeSelector:
+        nodepool: app
+      containers:
+        - name: db-migrate
+          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra-test/api:${IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
+          command:
+            - /app/entrypoint.sh
+          args:
+            - ./node_modules/.bin/drizzle-kit
+            - migrate
+          env:
+            - name: RUN_MIGRATIONS
+              value: "false"
+            - name: NODE_EXTRA_CA_CERTS
+              value: /etc/ssl/certs/rds-global-bundle.pem
+          envFrom:
+            - secretRef:
+                name: ctdl-xtra-app-env
+          volumeMounts:
+            - name: rds-ca-bundle
+              mountPath: /etc/ssl/certs/rds-global-bundle.pem
+              subPath: rds-global-bundle.pem
+              readOnly: true
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+      volumes:
+        - name: rds-ca-bundle
+          configMap:
+            name: rds-ca-bundle

--- a/infra/terraform/k8s-manifests/test/app/deploy-app.sh
+++ b/infra/terraform/k8s-manifests/test/app/deploy-app.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${IMAGE_TAG:?IMAGE_TAG must be set (e.g. sha-abc1234)}"
+: "${EFS_FS_ID:?EFS_FS_ID must be set (terraform output efs_file_system_id)}"
+export IMAGE_TAG EFS_FS_ID
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONTEXT="${KUBE_CONTEXT:-ctdl-xtra-test}"
+NAMESPACE="ctdl-xtra"
+TMP_DIR="$(mktemp -d)"
+
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/externalsecret.yaml"
+envsubst '${EFS_FS_ID}' < "${SCRIPT_DIR}/storage.yaml" | kubectl --context "${CONTEXT}" apply -f -
+curl -fsSL "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" -o "${TMP_DIR}/rds-global-bundle.pem"
+kubectl --context "${CONTEXT}" -n "${NAMESPACE}" create configmap rds-ca-bundle \
+  --from-file="rds-global-bundle.pem=${TMP_DIR}/rds-global-bundle.pem" \
+  --dry-run=client \
+  -o yaml | kubectl --context "${CONTEXT}" apply -f -
+kubectl --context "${CONTEXT}" -n "${NAMESPACE}" wait --for=condition=Ready externalsecret/ctdl-xtra-app --timeout=120s
+kubectl --context "${CONTEXT}" -n "${NAMESPACE}" delete job ctdl-xtra-db-migrate --ignore-not-found
+envsubst '${IMAGE_TAG}' < "${SCRIPT_DIR}/db-migrate-job.yaml" | kubectl --context "${CONTEXT}" apply -f -
+kubectl --context "${CONTEXT}" -n "${NAMESPACE}" wait --for=condition=Complete job/ctdl-xtra-db-migrate --timeout=300s
+kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/redis-configmap.yaml"
+kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/redis-externalsecret.yaml"
+kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/redis-statefulset.yaml"
+kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/service.yaml"
+envsubst '${IMAGE_TAG}' < "${SCRIPT_DIR}/deployment.yaml" | kubectl --context "${CONTEXT}" apply -f -
+kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/ingress.yaml"
+kubectl --context "${CONTEXT}" -n "${NAMESPACE}" rollout status deployment/ctdl-xtra-api --timeout=300s
+kubectl --context "${CONTEXT}" -n "${NAMESPACE}" rollout status deployment/ctdl-xtra-worker --timeout=300s

--- a/infra/terraform/k8s-manifests/test/app/deployment.yaml
+++ b/infra/terraform/k8s-manifests/test/app/deployment.yaml
@@ -1,0 +1,160 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ctdl-xtra-api
+  namespace: ctdl-xtra
+  labels:
+    app.kubernetes.io/name: ctdl-xtra
+    app.kubernetes.io/component: api
+    app.kubernetes.io/part-of: ctdl-xtra
+    environment: test
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ctdl-xtra
+      app.kubernetes.io/component: api
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ctdl-xtra
+        app.kubernetes.io/component: api
+        app.kubernetes.io/part-of: ctdl-xtra
+        environment: test
+    spec:
+      serviceAccountName: ctdl-xtra
+      nodeSelector:
+        nodepool: app
+      containers:
+        - name: api
+          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra-test/api:${IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 3000
+          env:
+            - name: RUN_MIGRATIONS
+              value: "false"
+            - name: LOG_LEVEL
+              value: info
+            - name: NODE_EXTRA_CA_CERTS
+              value: /etc/ssl/certs/rds-global-bundle.pem
+          envFrom:
+            - secretRef:
+                name: ctdl-xtra-app-env
+          readinessProbe:
+            httpGet:
+              path: /up
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /up
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /up
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 18
+          volumeMounts:
+            - name: extraction-files
+              mountPath: /data/extractions
+            - name: rds-ca-bundle
+              mountPath: /etc/ssl/certs/rds-global-bundle.pem
+              subPath: rds-global-bundle.pem
+              readOnly: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 384Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+      volumes:
+        - name: extraction-files
+          persistentVolumeClaim:
+            claimName: ctdl-xtra-files
+        - name: rds-ca-bundle
+          configMap:
+            name: rds-ca-bundle
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ctdl-xtra-worker
+  namespace: ctdl-xtra
+  labels:
+    app.kubernetes.io/name: ctdl-xtra
+    app.kubernetes.io/component: worker
+    app.kubernetes.io/part-of: ctdl-xtra
+    environment: test
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ctdl-xtra
+      app.kubernetes.io/component: worker
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ctdl-xtra
+        app.kubernetes.io/component: worker
+        app.kubernetes.io/part-of: ctdl-xtra
+        environment: test
+    spec:
+      serviceAccountName: ctdl-xtra
+      nodeSelector:
+        nodepool: app
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: worker
+          image: 996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra-test/worker:${IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: LOG_LEVEL
+              value: info
+            - name: NODE_EXTRA_CA_CERTS
+              value: /etc/ssl/certs/rds-global-bundle.pem
+          envFrom:
+            - secretRef:
+                name: ctdl-xtra-app-env
+          volumeMounts:
+            - name: extraction-files
+              mountPath: /data/extractions
+            - name: rds-ca-bundle
+              mountPath: /etc/ssl/certs/rds-global-bundle.pem
+              subPath: rds-global-bundle.pem
+              readOnly: true
+          resources:
+            requests:
+              cpu: 200m
+              memory: 512Mi
+            limits:
+              cpu: "1500m"
+              memory: 1500Mi
+      volumes:
+        - name: extraction-files
+          persistentVolumeClaim:
+            claimName: ctdl-xtra-files
+        - name: rds-ca-bundle
+          configMap:
+            name: rds-ca-bundle

--- a/infra/terraform/k8s-manifests/test/app/externalsecret.yaml
+++ b/infra/terraform/k8s-manifests/test/app/externalsecret.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ctdl-xtra-app
+  namespace: ctdl-xtra
+  labels:
+    app.kubernetes.io/name: ctdl-xtra
+    app.kubernetes.io/part-of: ctdl-xtra
+    environment: test
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: aws-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: ctdl-xtra-app-env
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: ctdl-xtra/test/app

--- a/infra/terraform/k8s-manifests/test/app/ingress.yaml
+++ b/infra/terraform/k8s-manifests/test/app/ingress.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ctdl-xtra-api
+  namespace: ctdl-xtra
+  labels:
+    app.kubernetes.io/name: ctdl-xtra
+    app.kubernetes.io/component: api
+    app.kubernetes.io/part-of: ctdl-xtra
+    environment: test
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - xtra-test.credentialengineregistry.org
+      secretName: ctdl-xtra-tls
+  rules:
+    - host: xtra-test.credentialengineregistry.org
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ctdl-xtra-api
+                port:
+                  name: http

--- a/infra/terraform/k8s-manifests/test/app/redis-configmap.yaml
+++ b/infra/terraform/k8s-manifests/test/app/redis-configmap.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-config
+  namespace: ctdl-xtra
+data:
+  redis.conf: |
+    bind 0.0.0.0
+    port 6379
+    protected-mode yes
+    tcp-keepalive 300
+    maxmemory 512mb
+    maxmemory-policy noeviction
+
+    # AOF persistence
+    appendonly yes
+    appendfsync everysec
+    auto-aof-rewrite-percentage 100
+    auto-aof-rewrite-min-size 64mb
+
+    # RDB snapshots
+    save 900 1
+    save 300 10
+    save 60 10000
+    dbfilename dump.rdb
+    dir /data
+
+    # Auth (injected via secret volume)
+    include /run/redis-auth/redis-password.conf

--- a/infra/terraform/k8s-manifests/test/app/redis-externalsecret.yaml
+++ b/infra/terraform/k8s-manifests/test/app/redis-externalsecret.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: redis-auth
+  namespace: ctdl-xtra
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: redis-auth
+    creationPolicy: Owner
+    template:
+      data:
+        password: "{{ .password }}"
+        redis-password.conf: "requirepass {{ .password }}"
+  data:
+    - secretKey: password
+      remoteRef:
+        key: ctdl-xtra/test/redis
+        property: password

--- a/infra/terraform/k8s-manifests/test/app/redis-statefulset.yaml
+++ b/infra/terraform/k8s-manifests/test/app/redis-statefulset.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis
+  namespace: ctdl-xtra
+  labels:
+    app: redis
+spec:
+  serviceName: redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      nodeSelector:
+        workload: ctdl-xtra
+      containers:
+        - name: redis
+          image: redis:8.0-alpine
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -euo pipefail
+              PASS="$(cat /run/redis-auth/password)"
+              exec redis-server /usr/local/etc/redis/redis.conf --requirepass "$PASS"
+          ports:
+            - containerPort: 6379
+          volumeMounts:
+            - name: redis-data
+              mountPath: /data
+            - name: redis-config
+              mountPath: /usr/local/etc/redis
+            - name: redis-auth
+              mountPath: /run/redis-auth
+              readOnly: true
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - redis-cli -a "$(cat /run/redis-auth/password)" ping
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - redis-cli -a "$(cat /run/redis-auth/password)" ping
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      volumes:
+        - name: redis-config
+          configMap:
+            name: redis-config
+        - name: redis-auth
+          secret:
+            secretName: redis-auth
+  volumeClaimTemplates:
+    - metadata:
+        name: redis-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: gp3
+        resources:
+          requests:
+            storage: 10Gi
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: ctdl-xtra
+spec:
+  clusterIP: None
+  ports:
+    - port: 6379
+      targetPort: 6379
+  selector:
+    app: redis

--- a/infra/terraform/k8s-manifests/test/app/service.yaml
+++ b/infra/terraform/k8s-manifests/test/app/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ctdl-xtra-api
+  namespace: ctdl-xtra
+  labels:
+    app.kubernetes.io/name: ctdl-xtra
+    app.kubernetes.io/component: api
+    app.kubernetes.io/part-of: ctdl-xtra
+    environment: test
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: ctdl-xtra
+    app.kubernetes.io/component: api
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/infra/terraform/k8s-manifests/test/app/storage.yaml
+++ b/infra/terraform/k8s-manifests/test/app/storage.yaml
@@ -1,0 +1,53 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ctdl-xtra-efs
+  labels:
+    app.kubernetes.io/name: ctdl-xtra
+    app.kubernetes.io/part-of: ctdl-xtra
+    environment: test
+provisioner: efs.csi.aws.com
+reclaimPolicy: Retain
+volumeBindingMode: WaitForFirstConsumer
+mountOptions:
+  - tls
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: ctdl-xtra-files
+  labels:
+    app.kubernetes.io/name: ctdl-xtra
+    app.kubernetes.io/part-of: ctdl-xtra
+    environment: test
+spec:
+  capacity:
+    storage: 50Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ctdl-xtra-efs
+  mountOptions:
+    - tls
+  csi:
+    driver: efs.csi.aws.com
+    volumeHandle: ${EFS_FS_ID}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ctdl-xtra-files
+  namespace: ctdl-xtra
+  labels:
+    app.kubernetes.io/name: ctdl-xtra
+    app.kubernetes.io/part-of: ctdl-xtra
+    environment: test
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ctdl-xtra-efs
+  volumeName: ctdl-xtra-files
+  resources:
+    requests:
+      storage: 50Gi

--- a/infra/terraform/k8s-manifests/test/cluster/cert-manager-cluster-issuer.yaml
+++ b/infra/terraform/k8s-manifests/test/cluster/cert-manager-cluster-issuer.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: ariel@learningtapestry.com
+    privateKeySecretRef:
+      name: letsencrypt-prod-account-key
+    solvers:
+      - dns01:
+          route53:
+            region: us-east-1
+            hostedZoneID: Z1N75467P1FUL5

--- a/infra/terraform/k8s-manifests/test/cluster/cluster-secret-store.yaml
+++ b/infra/terraform/k8s-manifests/test/cluster/cluster-secret-store.yaml
@@ -1,0 +1,14 @@
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: aws-secret-manager
+spec:
+  provider:
+    aws:
+      service: SecretsManager
+      region: us-east-1
+      auth:
+        jwt:
+          serviceAccountRef:
+            name: external-secrets
+            namespace: external-secrets

--- a/infra/terraform/k8s-manifests/test/cluster/namespace.yaml
+++ b/infra/terraform/k8s-manifests/test/cluster/namespace.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ctdl-xtra
+  labels:
+    app.kubernetes.io/name: ctdl-xtra
+    app.kubernetes.io/part-of: ctdl-xtra
+    environment: test
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ctdl-xtra
+  namespace: ctdl-xtra
+  labels:
+    app.kubernetes.io/name: ctdl-xtra
+    app.kubernetes.io/part-of: ctdl-xtra
+    environment: test
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::996810415034:role/ctdl-xtra-test-application-irsa-role

--- a/infra/terraform/k8s-manifests/test/cluster/storageclass-gp3.yaml
+++ b/infra/terraform/k8s-manifests/test/cluster/storageclass-gp3.yaml
@@ -1,0 +1,12 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gp3
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: ebs.csi.aws.com
+parameters:
+  type: gp3
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true

--- a/worker.Dockerfile
+++ b/worker.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra-sandbox/base:latest
+ARG BASE_IMAGE=996810415034.dkr.ecr.us-east-1.amazonaws.com/ctdl-xtra-test/base:latest
 FROM ${BASE_IMAGE}
 
 COPY server/package.json server/pnpm-lock.yaml server/pnpm-workspace.yaml /build/app/server/


### PR DESCRIPTION
## Summary

Brings the pipeline to the full `DEV → TEST → SANDBOX → PRODUCTION` model from the xTRA Design Document. Each tier is isolated; TEST is now the build target, and SANDBOX and PROD receive promoted images via `crane copy`.

### Infrastructure
- **`infra/terraform/envs/test/`** (new): VPC `10.42.0.0/16`, EKS `ctdl-xtra-test`, RDS `db.t4g.small` Single-AZ, EFS, 1× t3.medium system + 1× t3.medium app, ECR repos `ctdl-xtra-test/{api,worker,base}`
- **`infra/terraform/envs/sandbox/`**: drops the `base` ECR (builds happen in test now). 2 resources destroyed (repo + lifecycle policy). No impact on running sandbox pods — the images they're running embed the base layers.
- **`github-ci-oidc/`**: adds `TestReadWrite` policy for `ctdl-xtra-test/*`, tightens `SandboxPromote` (formerly `SandboxReadWrite`) since sandbox is promote-only now, adds the `ctdl-xtra-test` cluster to `eks:DescribeCluster`

### Manifests
- **`k8s-manifests/test/`**: clone of sandbox set, host `xtra-test.credentialengineregistry.org`, IRSA + secret keys retargeted

### CI/CD
- `release.yml` — pushes to `ctdl-xtra-test/{api,worker}` (was sandbox)
- **`deploy-test.yml`** (new) — triggered by `workflow_run` on Release success; auto-deploys the just-built image to `ctdl-xtra-test`. This is the "automatic when possible" deployment the design doc specifies for TEST.
- `promote-sandbox.yml` — now `crane copy`s test → sandbox before deploying
- `promote-production.yml` — unchanged (still crane-copies sandbox → prod)
- `build-base.yml` — pushes to `ctdl-xtra-test/base`
- `Dockerfile` + `worker.Dockerfile` — `FROM ctdl-xtra-test/base:latest`

### Docs
`INFRASTRUCTURE-SUMMARY.md` and `CI-CD.md` updated for the 3-env model.

## Apply plan (post-merge)

1. `terraform apply` `github-ci-oidc/` (0 add + 2 changed)
2. `terraform apply` `envs/test/` (79 adds, ~15 min)
3. `terraform apply` `envs/sandbox/` (0 add + 2 destroy: drops the unused base repo)
4. Trigger `Build Base Image` to populate `ctdl-xtra-test/base:latest`
5. Run `k8s-manifests/test/addons/install-foundation.sh`
6. Trigger `Release` → pushes images to test ECR → `Deploy to TEST` auto-fires → app reachable at `xtra-test.credentialengineregistry.org`
7. Add Route53 CNAME `xtra-test.*` → new ALB
8. Smoke test

Production untouched. Sandbox keeps running its current images (the next promote-sandbox will pull from test).

## Test plan

- [x] `terraform fmt && terraform validate` clean for all three stacks
- [x] `terraform plan` clean: test 79 add, sandbox 2 destroy, oidc 2 change
- [ ] After apply: end-to-end deploy via workflows succeeds
- [ ] App reachable at `https://xtra-test.credentialengineregistry.org`
- [ ] Promote test → sandbox works
- [ ] Promote sandbox → prod still works (no source URI changed for that step)