### PR TITLE
Deploy Skooner dashboards to test, sandbox, production

### DIFF
--- a/.github/workflows/skooner-token.yml
+++ b/.github/workflows/skooner-token.yml
@@ -3,6 +3,15 @@ name: Generate Skooner token
 on:
   workflow_dispatch:
     inputs:
+      environment:
+        description: "Target environment / cluster"
+        type: choice
+        required: true
+        default: test
+        options:
+          - test
+          - sandbox
+          - prod
       duration:
         description: "Token duration"
         type: choice
@@ -32,7 +41,6 @@ permissions:
 
 env:
   AWS_REGION: us-east-1
-  EKS_CLUSTER: cer-api-prod
   SA_NAMESPACE: kube-system
   SA_NAME: skooner-sa
   APP_NAMESPACE: ctdl-xtra
@@ -44,6 +52,31 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Resolve target cluster + hostname
+        id: target
+        env:
+          ENVIRONMENT: ${{ inputs.environment }}
+        run: |
+          set -euo pipefail
+          case "${ENVIRONMENT}" in
+            test)
+              echo "cluster=ctdl-xtra-test" >> "$GITHUB_OUTPUT"
+              echo "hostname=status.xtra-test.credentialengineregistry.org" >> "$GITHUB_OUTPUT"
+              ;;
+            sandbox)
+              echo "cluster=ctdl-xtra-sandbox" >> "$GITHUB_OUTPUT"
+              echo "hostname=status.xtra-sandbox.credentialengineregistry.org" >> "$GITHUB_OUTPUT"
+              ;;
+            prod)
+              echo "cluster=ctdl-xtra-prod" >> "$GITHUB_OUTPUT"
+              echo "hostname=status.xtra.credentialengineregistry.org" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Unknown environment: ${ENVIRONMENT}" >&2
+              exit 1
+              ;;
+          esac
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -58,7 +91,7 @@ jobs:
 
       - name: Update kubeconfig
         run: |
-          aws eks update-kubeconfig --name "${{ env.EKS_CLUSTER }}" --region "${{ env.AWS_REGION }}"
+          aws eks update-kubeconfig --name "${{ steps.target.outputs.cluster }}" --region "${{ env.AWS_REGION }}"
 
       - name: Mask sensitive inputs
         if: ${{ inputs.whitelist_source_range != '' }}
@@ -75,6 +108,9 @@ jobs:
           SA="${SA_NAME}"
           APP_NS="${APP_NAMESPACE}"
           echo "Validating role: ${ROLE}"
+          # Use `apply --dry-run=server` so validation is idempotent when the
+          # binding already exists (server-side `create` dry-run rejects
+          # existing resources, breaking re-runs).
           if [ "${ROLE}" = "cluster-admin" ]; then
             kubectl create clusterrolebinding "${SA}" \
               --clusterrole="cluster-admin" \
@@ -112,25 +148,31 @@ jobs:
             echo "binding_kind=ClusterRoleBinding" >> "$GITHUB_OUTPUT"
             echo "binding_namespace=cluster-wide" >> "$GITHUB_OUTPUT"
           elif [ "${ROLE}" = "developer" ]; then
+            # Cluster-wide read-only via view
             kubectl create clusterrolebinding "${SA}-developer-view" \
               --clusterrole="view" \
               --serviceaccount="${NS}:${SA}" \
               --dry-run=client -o yaml > /tmp/rbac-view.yaml
             kubectl apply -f /tmp/rbac-view.yaml
+            # Namespaced edit in the app namespace
             kubectl -n "${APP_NS}" create rolebinding "${SA}-developer-edit" \
               --clusterrole="edit" \
               --serviceaccount="${NS}:${SA}" \
               --dry-run=client -o yaml > /tmp/rbac-edit.yaml
             kubectl -n "${APP_NS}" apply -f /tmp/rbac-edit.yaml
+            # Ensure no lingering admin CRB remains
             kubectl delete clusterrolebinding "${SA}" --ignore-not-found
             echo "binding_kind=developer" >> "$GITHUB_OUTPUT"
             echo "binding_namespace=cluster-wide,${APP_NS}" >> "$GITHUB_OUTPUT"
           else
+            # view: revoke any elevated bindings, including the cluster-admin
+            # CRB baked into skooner.yaml. Re-applying the foundation script
+            # restores cluster-admin (the install-time default).
             kubectl delete clusterrolebinding "${SA}" --ignore-not-found
             kubectl delete clusterrolebinding "${SA}-developer-view" --ignore-not-found
             kubectl -n "${APP_NS}" delete rolebinding "${SA}-developer-edit" --ignore-not-found
             echo "binding_kind=view-only" >> "$GITHUB_OUTPUT"
-            echo "binding_namespace=${NS}" >> "$GITHUB_OUTPUT"
+            echo "binding_namespace=-" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Update Skooner Ingress whitelist (optional)
@@ -161,6 +203,9 @@ jobs:
           REPO: ${{ github.repository }}
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           ACTOR: ${{ github.actor }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          CLUSTER: ${{ steps.target.outputs.cluster }}
+          HOSTNAME: ${{ steps.target.outputs.hostname }}
           DURATION: ${{ inputs.duration }}
           ROLE: ${{ inputs.role }}
           WHITELIST_CONFIGURED: ${{ inputs.whitelist_source_range != '' }}
@@ -178,6 +223,9 @@ jobs:
             --arg repo "$REPO" \
             --arg run "$RUN_URL" \
             --arg actor "$ACTOR" \
+            --arg env "$ENVIRONMENT" \
+            --arg cluster "$CLUSTER" \
+            --arg url "https://${HOSTNAME}/#!workload" \
             --arg duration "$DURATION" \
             --arg role "$ROLE" \
             --arg ns "$BINDING_NS" \
@@ -187,9 +235,10 @@ jobs:
             {
               text: "Skooner token generated",
               blocks: [
-                { "type": "header", "text": { "type": "plain_text", "text": "Skooner token" } },
+                { "type": "header", "text": { "type": "plain_text", "text": "Skooner token (\($env))" } },
                 { "type": "section", "fields": [
                     {"type":"mrkdwn", "text": "*Requested by:*\n\($actor)"},
+                    {"type":"mrkdwn", "text": "*Cluster:*\n\($cluster)"},
                     {"type":"mrkdwn", "text": "*Duration:*\n\($duration)"},
                     {"type":"mrkdwn", "text": "*Role:*\n\($role)"},
                     {"type":"mrkdwn", "text": "*Namespace:*\n\($ns)"}
@@ -203,7 +252,7 @@ jobs:
                 { "type": "context", "elements": [
                     {"type":"mrkdwn", "text": "<\($run)|View run>"},
                     {"type":"mrkdwn", "text": $repo},
-                    {"type":"mrkdwn", "text": "<https://status.cer-api.credentialengineregistry.org/#!workload|Open Skooner>"}
+                    {"type":"mrkdwn", "text": "<\($url)|Open Skooner>"}
                   ]
                 }
               ]

--- a/INFRASTRUCTURE-SUMMARY.md
+++ b/INFRASTRUCTURE-SUMMARY.md
@@ -91,6 +91,26 @@ In each cluster's `ctdl-xtra` namespace:
 
 The migrate Job runs `drizzle-kit migrate` before each rollout via the deploy script.
 
+## Skooner dashboards
+
+Web UI for cluster inspection. One Skooner deployment per cluster, exposed via ingress with TLS issued by cert-manager.
+
+| | Test | Sandbox | Production |
+|---|---|---|---|
+| URL | `https://status.xtra-test.credentialengineregistry.org` | `https://status.xtra-sandbox.credentialengineregistry.org` | `https://status.xtra.credentialengineregistry.org` |
+| Image | `ghcr.io/skooner-k8s/skooner:stable` | same | same |
+| ServiceAccount | `skooner-sa` in `kube-system` | same | same |
+| Default RBAC at install time | `skooner-sa` ClusterRoleBinding → `cluster-admin` | same | same |
+
+**Logging in**: paste a short-lived ServiceAccount token. Tokens are issued by the `Generate Skooner token` workflow (manual, `workflow_dispatch`). Inputs:
+
+- `environment` — `test` / `sandbox` / `prod` (picks the cluster)
+- `duration` — `30m` / `2h` / `6h`
+- `role` — `view` (revokes all bindings), `developer` (cluster-wide view + edit on `ctdl-xtra` namespace), `cluster-admin`
+- `whitelist_source_range` — optional NGINX `whitelist-source-range` annotation (CIDR or comma-separated CIDRs)
+
+The token is delivered via Slack (the `SLACK_WEBHOOK_URL` repo secret). Choosing `view` revokes the baked-in `cluster-admin` binding; re-running `install-foundation.sh` restores it.
+
 ## Deploying
 
 You don't run `kubectl` to deploy — use the GitHub Actions workflows. See [CI-CD.md](CI-CD.md) for the full pipeline. TL;DR:

--- a/infra/terraform/k8s-manifests/production/addons/install-foundation.sh
+++ b/infra/terraform/k8s-manifests/production/addons/install-foundation.sh
@@ -61,3 +61,6 @@ helm upgrade --install metrics-server metrics-server/metrics-server \
 
 kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/cluster-autoscaler.yaml"
 kubectl --context "${CONTEXT}" -n kube-system rollout status deployment/cluster-autoscaler --timeout=180s
+
+kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/skooner.yaml"
+kubectl --context "${CONTEXT}" -n kube-system rollout status deployment/skooner --timeout=180s

--- a/infra/terraform/k8s-manifests/production/addons/skooner.yaml
+++ b/infra/terraform/k8s-manifests/production/addons/skooner.yaml
@@ -1,0 +1,104 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: skooner-sa
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: skooner-sa
+subjects:
+  - kind: ServiceAccount
+    name: skooner-sa
+    namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: skooner
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: skooner
+  template:
+    metadata:
+      labels:
+        k8s-app: skooner
+    spec:
+      serviceAccountName: skooner-sa
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: skooner
+          image: ghcr.io/skooner-k8s/skooner:stable
+          ports:
+            - containerPort: 4654
+          livenessProbe:
+            httpGet:
+              scheme: HTTP
+              path: /
+              port: 4654
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: skooner
+  namespace: kube-system
+spec:
+  ports:
+    - port: 80
+      targetPort: 4654
+  selector:
+    k8s-app: skooner
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: skooner-certificate
+  namespace: kube-system
+spec:
+  secretName: skooner-tls
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  dnsNames:
+    - status.xtra.credentialengineregistry.org
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: skooner-ingress
+  namespace: kube-system
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - status.xtra.credentialengineregistry.org
+      secretName: skooner-tls
+  rules:
+    - host: status.xtra.credentialengineregistry.org
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: skooner
+                port:
+                  number: 80

--- a/infra/terraform/k8s-manifests/sandbox/addons/install-foundation.sh
+++ b/infra/terraform/k8s-manifests/sandbox/addons/install-foundation.sh
@@ -61,3 +61,6 @@ helm upgrade --install metrics-server metrics-server/metrics-server \
 
 kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/cluster-autoscaler.yaml"
 kubectl --context "${CONTEXT}" -n kube-system rollout status deployment/cluster-autoscaler --timeout=180s
+
+kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/skooner.yaml"
+kubectl --context "${CONTEXT}" -n kube-system rollout status deployment/skooner --timeout=180s

--- a/infra/terraform/k8s-manifests/sandbox/addons/skooner.yaml
+++ b/infra/terraform/k8s-manifests/sandbox/addons/skooner.yaml
@@ -1,0 +1,104 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: skooner-sa
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: skooner-sa
+subjects:
+  - kind: ServiceAccount
+    name: skooner-sa
+    namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: skooner
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: skooner
+  template:
+    metadata:
+      labels:
+        k8s-app: skooner
+    spec:
+      serviceAccountName: skooner-sa
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: skooner
+          image: ghcr.io/skooner-k8s/skooner:stable
+          ports:
+            - containerPort: 4654
+          livenessProbe:
+            httpGet:
+              scheme: HTTP
+              path: /
+              port: 4654
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: skooner
+  namespace: kube-system
+spec:
+  ports:
+    - port: 80
+      targetPort: 4654
+  selector:
+    k8s-app: skooner
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: skooner-certificate
+  namespace: kube-system
+spec:
+  secretName: skooner-tls
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  dnsNames:
+    - status.xtra-sandbox.credentialengineregistry.org
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: skooner-ingress
+  namespace: kube-system
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - status.xtra-sandbox.credentialengineregistry.org
+      secretName: skooner-tls
+  rules:
+    - host: status.xtra-sandbox.credentialengineregistry.org
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: skooner
+                port:
+                  number: 80

--- a/infra/terraform/k8s-manifests/test/addons/install-foundation.sh
+++ b/infra/terraform/k8s-manifests/test/addons/install-foundation.sh
@@ -61,3 +61,6 @@ helm upgrade --install metrics-server metrics-server/metrics-server \
 
 kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/cluster-autoscaler.yaml"
 kubectl --context "${CONTEXT}" -n kube-system rollout status deployment/cluster-autoscaler --timeout=180s
+
+kubectl --context "${CONTEXT}" apply -f "${SCRIPT_DIR}/skooner.yaml"
+kubectl --context "${CONTEXT}" -n kube-system rollout status deployment/skooner --timeout=180s

--- a/infra/terraform/k8s-manifests/test/addons/skooner.yaml
+++ b/infra/terraform/k8s-manifests/test/addons/skooner.yaml
@@ -1,0 +1,104 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: skooner-sa
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: skooner-sa
+subjects:
+  - kind: ServiceAccount
+    name: skooner-sa
+    namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: skooner
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: skooner
+  template:
+    metadata:
+      labels:
+        k8s-app: skooner
+    spec:
+      serviceAccountName: skooner-sa
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: skooner
+          image: ghcr.io/skooner-k8s/skooner:stable
+          ports:
+            - containerPort: 4654
+          livenessProbe:
+            httpGet:
+              scheme: HTTP
+              path: /
+              port: 4654
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: skooner
+  namespace: kube-system
+spec:
+  ports:
+    - port: 80
+      targetPort: 4654
+  selector:
+    k8s-app: skooner
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: skooner-certificate
+  namespace: kube-system
+spec:
+  secretName: skooner-tls
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  dnsNames:
+    - status.xtra-test.credentialengineregistry.org
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: skooner-ingress
+  namespace: kube-system
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - status.xtra-test.credentialengineregistry.org
+      secretName: skooner-tls
+  rules:
+    - host: status.xtra-test.credentialengineregistry.org
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: skooner
+                port:
+                  number: 80


### PR DESCRIPTION
## Summary

Adds Skooner (K8s dashboard) to all three clusters and rewrites the broken `skooner-token.yml` workflow to target them, we tightened the OIDC IAM policy.

### Manifests (`k8s-manifests/{test,sandbox,production}/addons/skooner.yaml`)

Config:
- ServiceAccount `skooner-sa` in `kube-system`
- `skooner-sa` ClusterRoleBinding → `cluster-admin` (the install-time default; the token workflow tightens/relaxes at token issuance)
- Skooner Deployment (1 replica, `ghcr.io/skooner-k8s/skooner:stable`, small resource footprint)
- Service + Certificate + Ingress
- Hostname per env: `status.xtra-test.*`, `status.xtra-sandbox.*`, `status.xtra.*`

### Workflow (`.github/workflows/skooner-token.yml`)

Added an `environment` input dropdown (test / sandbox / prod) so a single workflow targets all three clusters. The cluster name and Skooner URL are resolved from the input via a small case statement step.

| `role` input | Effect on bindings |
|---|---|
| `view` | Revokes everything including the baked `cluster-admin` CRB → no access until next `install-foundation.sh` |
| `developer` | Cluster-wide `view` + namespaced `edit` on `ctdl-xtra` |
| `cluster-admin` | Re-creates the `skooner-sa` CRB → `cluster-admin` |

### Foundation installer

Added Skooner apply + rollout-wait to each env's `install-foundation.sh` so re-runs are idempotent.

### Docs

`INFRASTRUCTURE-SUMMARY.md`: new Skooner dashboards section with URLs and the token issuance flow.

## Apply plan (post-merge)

1. Run `install-foundation.sh` in each env to apply the new Skooner manifests
2. Add three Route53 CNAMEs pointing at each cluster's ingress-nginx ALB
3. Wait for cert-manager to issue Let's Encrypt certs
4. Smoke test each URL
5. Test the workflow with `environment=test` `role=view`
