### PR TITLE
fix(skooner-token): empty whitelist input clears the annotation

### DIFF
--- a/.github/workflows/skooner-token.yml
+++ b/.github/workflows/skooner-token.yml
@@ -175,14 +175,22 @@ jobs:
             echo "binding_namespace=-" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Update Skooner Ingress whitelist (optional)
-        if: ${{ inputs.whitelist_source_range != '' }}
+      - name: Update Skooner Ingress whitelist
+        id: whitelist
         env:
           WHITELIST: ${{ inputs.whitelist_source_range }}
         run: |
-          echo "Setting whitelist-source-range"
-          kubectl -n kube-system annotate ingress skooner-ingress \
-            nginx.ingress.kubernetes.io/whitelist-source-range="${WHITELIST}" --overwrite
+          if [ -z "${WHITELIST}" ]; then
+            echo "Clearing whitelist-source-range"
+            kubectl -n kube-system annotate ingress skooner-ingress \
+              nginx.ingress.kubernetes.io/whitelist-source-range- --overwrite
+            echo "state=cleared" >> "$GITHUB_OUTPUT"
+          else
+            echo "Setting whitelist-source-range"
+            kubectl -n kube-system annotate ingress skooner-ingress \
+              nginx.ingress.kubernetes.io/whitelist-source-range="${WHITELIST}" --overwrite
+            echo "state=configured" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Create Skooner token
         id: tok
@@ -208,7 +216,7 @@ jobs:
           HOSTNAME: ${{ steps.target.outputs.hostname }}
           DURATION: ${{ inputs.duration }}
           ROLE: ${{ inputs.role }}
-          WHITELIST_CONFIGURED: ${{ inputs.whitelist_source_range != '' }}
+          WHITELIST_STATE: ${{ steps.whitelist.outputs.state }}
           BINDING_KIND: ${{ steps.rbac.outputs.binding_kind }}
           BINDING_NS: ${{ steps.rbac.outputs.binding_namespace }}
           SA_NAME: ${{ env.SA_NAME }}
@@ -229,7 +237,7 @@ jobs:
             --arg duration "$DURATION" \
             --arg role "$ROLE" \
             --arg ns "$BINDING_NS" \
-            --arg whitelist_configured "$WHITELIST_CONFIGURED" \
+            --arg whitelist_state "$WHITELIST_STATE" \
             --arg token "$TOKEN" \
             '
             {
@@ -245,7 +253,7 @@ jobs:
                   ]
                 },
                 { "type": "section", "fields": [
-                    {"type":"mrkdwn", "text": "*Whitelist:*\n\(if $whitelist_configured == "true" then "configured" else "unchanged" end)"}
+                    {"type":"mrkdwn", "text": "*Whitelist:*\n\($whitelist_state)"}
                   ]
                 },
                 { "type": "section", "text": { "type": "mrkdwn", "text": "*Token:*\n```\($token)```" } },


### PR DESCRIPTION
## Why

The Skooner token workflow takes an optional `whitelist_source_range` input that stamps an nginx `whitelist-source-range` annotation on the `skooner-ingress`. Previously the step was guarded by `if: inputs.whitelist_source_range != ''`, so an empty input was a no-op — whatever a previous run had set remained in place.

This produced silent drift. A real example surfaced on prod today: a past run had set `whitelist-source-range: 153.67.181.222`. On the prod cluster, the ingress-nginx controller svc was `externalTrafficPolicy: Cluster`, so nginx never saw the real client IP (it saw a kube node IP after SNAT). Every request — from any IP, including the one in the allowlist — was rejected with 403 by nginx's `access forbidden by rule`. Skooner was effectively unreachable, with no obvious cause, and the workflow's "unchanged" Slack note hid the fact that the stale allowlist was still in force.

## What changes

- Drop the `if:` guard on the whitelist step so it always runs.
- Empty input → `kubectl annotate ... whitelist-source-range-` (remove the annotation).
- Non-empty input → existing `--overwrite` set, unchanged.
- Slack notification now reports `state=configured` or `state=cleared`.

## Out of scope (already done live)

- Switched prod `ingress-nginx-controller` svc to `externalTrafficPolicy: Local` so nginx sees real client IPs (sandbox already had this). The whitelist feature will now actually work on prod going forward.
- Cleared the stale `153.67.181.222` annotation on prod so the dashboard is reachable in the meantime.

## Test plan

- [ ] Dispatch on test with `whitelist_source_range` blank → Slack shows `Whitelist: cleared`, annotation absent on the ingress.
- [ ] Dispatch on test with `whitelist_source_range=1.2.3.4/32` → Slack shows `Whitelist: configured`, annotation present.
- [ ] Re-dispatch on test with blank input → annotation removed again (proves drift is reset on every run).
- [ ] Dispatch on prod with your own IP/32 → page loads only from that IP, 403 elsewhere.